### PR TITLE
Feature - add xUnit test logging for .NET Core apps

### DIFF
--- a/docs/preview/logging.md
+++ b/docs/preview/logging.md
@@ -32,6 +32,31 @@ public class TestClass
 }
 ```
 
+### xUnit Test Logging in .NET Core
+
+During integration testing of hosts, one could find the need to add the log messages to the xUnit output for defect localization.
+The `Arcus.Testing.Logging` library provides an extension to add this in a more dev-friendly way.
+
+```csharp
+public class TestClass
+{
+    private readonly ILogger _outputWriter;
+
+    public TestClass(ITestOutputHelper outputWriter)
+    {
+        _outputWriter = outputWriter;
+    }
+
+    [Fact]
+    public void TestMethod()
+    {
+        IHost host = new HostBuilder()
+            .ConfigureLogging(loggingBuilder => loggingBuilder.AddXunitTestLogging(_outputWriter))
+            .Build();
+    }
+}
+```
+
 ## In-memory Test Logging
 
 The `Arcus.Testing.Logging` library provides a `InMemoryLogger` and `InMemoryLogger<T>` which are [Microsoft Logging](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/logging/?view=aspnetcore-3.1) `ILogger` and `ILogger<T>` implementations respectively.

--- a/src/Arcus.Testing.Logging/Arcus.Testing.Logging.csproj
+++ b/src/Arcus.Testing.Logging/Arcus.Testing.Logging.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>

--- a/src/Arcus.Testing.Logging/CustomLoggerProvider.cs
+++ b/src/Arcus.Testing.Logging/CustomLoggerProvider.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using GuardNet;
+using Microsoft.Extensions.Logging;
+
+namespace Arcus.Testing.Logging
+{
+    /// <summary>
+    /// Custom <see cref="ILoggerProvider"/> that creates a custom <see cref="ILogger"/> provider.
+    /// </summary>
+    public class CustomLoggerProvider : ILoggerProvider
+    {
+        private readonly ILogger _logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CustomLoggerProvider"/> class.
+        /// </summary>
+        /// <param name="logger">The logger instance to return on <see cref="CreateLogger"/>.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="logger"/> is <c>null</c>.</exception>
+        public CustomLoggerProvider(ILogger logger)
+        {
+            Guard.NotNull(logger, nameof(logger), "Requires an logger instance to be returned when this provider creates the logger");
+            _logger = logger;
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="T:Microsoft.Extensions.Logging.ILogger" /> instance.
+        /// </summary>
+        /// <param name="categoryName">The category name for messages produced by the logger.</param>
+        /// <returns></returns>
+        public ILogger CreateLogger(string categoryName)
+        {
+            return _logger;
+        }
+
+        /// <summary>
+        /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.</
+        /// summary>
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/src/Arcus.Testing.Logging/Extensions/ILoggerBuilderExtensions.cs
+++ b/src/Arcus.Testing.Logging/Extensions/ILoggerBuilderExtensions.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using Arcus.Testing.Logging;
+using GuardNet;
+using Xunit.Abstractions;
+
+// ReSharper disable once CheckNamespace
+namespace Microsoft.Extensions.Logging
+{
+    /// <summary>
+    /// Extensions on the <see cref="ILoggingBuilder"/> related to logging.
+    /// </summary>
+    // ReSharper disable once InconsistentNaming
+    public static class ILoggerBuilderExtensions
+    {
+        /// <summary>
+        /// Adds an the logging messages from the given xUnit <paramref name="outputWriter"/> as a provider to the <paramref name="builder"/>.
+        /// </summary>
+        /// <param name="builder">The logging builder to add the xUnit logging test messages to.</param>
+        /// <param name="outputWriter">The xUnit test logger used across the test suite.</param>
+        /// <exception cref="ArgumentNullException">Thrown when either the <paramref name="builder"/> or the <paramref name="outputWriter"/> is <c>null</c>.</exception>
+        public static ILoggingBuilder AddXunitTestLogging(this ILoggingBuilder builder, ITestOutputHelper outputWriter)
+        {
+            Guard.NotNull(builder, nameof(builder), "Requires a logging builder to add the xUnit logging to");
+            Guard.NotNull(outputWriter, nameof(outputWriter), "Requires a xUnit test logger to add as a provider to the logging builder");
+
+            var logger = new XunitTestLogger(outputWriter);
+            var provider = new CustomLoggerProvider(logger);
+
+            return builder.AddProvider(provider);
+        }
+    }
+}

--- a/src/Arcus.Testing.Tests.Unit/Arcus.Testing.Tests.Unit.csproj
+++ b/src/Arcus.Testing.Tests.Unit/Arcus.Testing.Tests.Unit.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Bogus" Version="29.0.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
+    <PackageReference Include="Moq" Version="4.14.5" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>

--- a/src/Arcus.Testing.Tests.Unit/Logging/CustomLoggerProviderTests.cs
+++ b/src/Arcus.Testing.Tests.Unit/Logging/CustomLoggerProviderTests.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using Arcus.Testing.Logging;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace Arcus.Testing.Tests.Unit.Logging
+{
+    [Trait(name: "Category", value: "Unit")]
+    public class CustomLoggerProviderTests
+    {
+        [Fact]
+        public void AddCustomLoggerProvider_WithInMemoryLogger_CollectsLogMessages()
+        {
+            // Arrange
+            var spyLogger = new InMemoryLogger();
+            var provider = new CustomLoggerProvider(spyLogger);
+
+            var builder = new HostBuilder();
+
+            // Act
+            builder.ConfigureLogging(logging => logging.AddProvider(provider));
+
+            // Assert
+            IHost host = builder.Build();
+            var logger = host.Services.GetRequiredService<ILogger<CustomLoggerProviderTests>>();
+
+            string expected = "This informational message should be logged";
+            logger.LogInformation(expected);
+
+            string actual = Assert.Single(spyLogger.Messages);
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void CreateProvider_WithoutLogger_Throws()
+        {
+            Assert.ThrowsAny<ArgumentException>(() => new CustomLoggerProvider(logger: null));
+        }
+    }
+}

--- a/src/Arcus.Testing.Tests.Unit/Logging/ILoggerBuilderExtensionsTests.cs
+++ b/src/Arcus.Testing.Tests.Unit/Logging/ILoggerBuilderExtensionsTests.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Arcus.Testing.Tests.Unit.Logging
+{
+    // ReSharper disable once InconsistentNaming
+    [Trait(name: "Category", value: "Unit")]
+    public class ILoggerBuilderExtensionsTests
+    {
+        [Fact]
+        public void AddXunitTestLogging_WithInfoMessage_LogsInfoMessage()
+        {
+            // Arrange
+            var spyLogger = new Mock<ITestOutputHelper>();
+            var builder = new HostBuilder();
+
+            // Act
+            builder.ConfigureLogging(logging => logging.AddXunitTestLogging(spyLogger.Object));
+
+            // Assert
+            IHost host = builder.Build();
+            var logger = host.Services.GetRequiredService<ILogger<ILoggerBuilderExtensionsTests>>();
+
+            string exptected = "This informational message should be logged";
+            logger.LogInformation(exptected);
+
+            spyLogger.Verify(l => l.WriteLine(It.Is<string>(msg => msg.EndsWith(exptected))));
+        }
+
+        [Fact]
+        public void AddXunitTestLogging_WithoutBuilder_Throws()
+        {
+            Assert.ThrowsAny<ArgumentException>(
+                () => ((ILoggingBuilder) null).AddXunitTestLogging(Mock.Of<ITestOutputHelper>()));
+        }
+
+        [Fact]
+        public void AddXunitTestLogging_WithoutXunitTestLogger_Throws()
+        {
+            // Arrange
+            var builder = new HostBuilder();
+            
+            // Act
+            builder.ConfigureLogging(logging => logging.AddXunitTestLogging(outputWriter: null));
+
+            // Assert
+            Assert.ThrowsAny<ArgumentException>(() => builder.Build());
+        }
+    }
+}

--- a/src/Arcus.Testing.Tests.Unit/Logging/SpyLoggerTests.cs
+++ b/src/Arcus.Testing.Tests.Unit/Logging/SpyLoggerTests.cs
@@ -6,7 +6,7 @@ using Bogus;
 using Microsoft.Extensions.Logging;
 using Xunit;
 
-namespace Arcus.Testing.Tests.Unit
+namespace Arcus.Testing.Tests.Unit.Logging
 {
     [Trait(name: "Category", value: "Unit")]
     public class InMemoryLoggerTests


### PR DESCRIPTION
Provides a test infrastructure so that we can write diagnostic test messages to the xUnit test output from .NET Core apps.

Relates to #25 