### PR TITLE
Docs - add missing 'using's to the feature docs

### DIFF
--- a/docs/features/logging.md
+++ b/docs/features/logging.md
@@ -13,13 +13,17 @@ inside the [xUnit](https://xunit.net/) test framework.
 Log messages written to the `ILogger` instance will be written to the xUnit test output.
 
 ```csharp
+using Arcus.Testing.Logging;
+using Microsoft.Extensions.Logging;
+using Xunit.Abstractions;
+
 public class TestClass
 {
-	private readonly ILogger _testLogger;
+    private readonly ILogger _testLogger;
 
-	public TestClass(ITestOutputHelper outputWriter)
-	{
-		_testLogger = new XunitTestLogger(outputWriter);
-	}
+    public TestClass(ITestOutputHelper outputWriter)
+    {
+        _testLogger = new XunitTestLogger(outputWriter);
+    }
 }
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,7 +20,7 @@ For more granular packages we recommend reading the documentation.
 
 # Features
 
-- [xUnit Logging](logging)
+- [xUnit Logging](features/logging)
 
 # License
 This is licensed under The MIT License (MIT). Which means that you can use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the web application. But you always need to state that Codit is the original author of this web application.

--- a/docs/preview/features/logging.md
+++ b/docs/preview/features/logging.md
@@ -21,6 +21,10 @@ inside the [xUnit](https://xunit.net/) test framework.
 Log messages written to the `ILogger` instance will be written to the xUnit test output.
 
 ```csharp
+using Arcus.Testing.Logging;
+using Microsoft.Extensions.Logging;
+using Xunit.Abstractions;
+
 public class TestClass
 {
     private readonly ILogger _testLogger;
@@ -38,6 +42,11 @@ During integration testing of hosts, one could find the need to add the log mess
 The `Arcus.Testing.Logging` library provides an extension to add this in a more dev-friendly way.
 
 ```csharp
+using Arcus.Testing.Logging;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Hosting;
+using Xunit.Abstractions;
+
 public class TestClass
 {
     private readonly ILogger _outputWriter;
@@ -63,6 +72,9 @@ The `Arcus.Testing.Logging` library provides a `InMemoryLogger` and `InMemoryLog
 These types help in tracking logged messages and their metadata information like the level on which the message was logged or the related exception.
 
 ```csharp
+using Arcus.Testing.Logging;
+using Microsoft.Extensions.Logging;
+
 ILogger logger = new InMemoryLogger();
 
 logger.LogInformation("This is a informational message");
@@ -83,6 +95,9 @@ string message = entry.Message;
 Or, alternatively you can use the generic variant:
 
 ```csharp
+using Arcus.Testing.Logging;
+using Microsoft.Extensions.Logging;
+
 ILogger<MyType> logger = new InMemoryLogger<MyType>();
 
 logger.LogInformation("This is a informational message");

--- a/docs/preview/index.md
+++ b/docs/preview/index.md
@@ -20,7 +20,7 @@ For more granular packages we recommend reading the documentation.
 
 # Features
 
-- [xUnit Logging and Logging Testing](logging)
+- [xUnit Logging and Logging Testing](features/logging)
 
 # License
 This is licensed under The MIT License (MIT). Which means that you can use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the web application. But you always need to state that Codit is the original author of this web application.

--- a/docs/v0.1/features/logging.md
+++ b/docs/v0.1/features/logging.md
@@ -13,13 +13,17 @@ inside the [xUnit](https://xunit.net/) test framework.
 Log messages written to the `ILogger` instance will be written to the xUnit test output.
 
 ```csharp
+using Arcus.Testing.Logging;
+using Microsoft.Extensions.Logging;
+using Xunit.Abstractions;
+
 public class TestClass
 {
-	private readonly ILogger _testLogger;
+    private readonly ILogger _testLogger;
 
-	public TestClass(ITestOutputHelper outputWriter)
-	{
-		_testLogger = new XunitTestLogger(outputWriter);
-	}
+    public TestClass(ITestOutputHelper outputWriter)
+    {
+        _testLogger = new XunitTestLogger(outputWriter);
+    }
 }
 ```

--- a/docs/v0.1/index.md
+++ b/docs/v0.1/index.md
@@ -20,7 +20,7 @@ For more granular packages we recommend reading the documentation.
 
 # Features
 
-- [xUnit Logging](logging)
+- [xUnit Logging](features/logging)
 
 # License
 This is licensed under The MIT License (MIT). Which means that you can use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the web application. But you always need to state that Codit is the original author of this web application.


### PR DESCRIPTION
Add missing `using` statements to the feature docs.

Relates to https://github.com/arcus-azure/arcus/issues/107