### PR TITLE
Feature - add in-memory secret provider for the Arcus secret store

### DIFF
--- a/docs/preview/features/inmemory-secret-provider.md
+++ b/docs/preview/features/inmemory-secret-provider.md
@@ -1,0 +1,96 @@
+---
+title: Security
+layout: default
+---
+
+# Security
+
+## Installation
+
+The following functionality is available when installing this package:
+
+```shell
+PM> Install-Package -Name Arcus.Testing.Security.Providers.InMemory
+```
+
+## In-memory secret provider
+
+As an addition to the [Arcus Security]() package, we have added an in-memory `ISecretProvider` implementation. 
+This secret provider created so you can test you secret store configuration with non-secret values in a easy manner, without implementing your own `ISecretProvider`.
+
+After installing the package, the `.AddInMemory` extension should be available to you:
+
+```csharp
+using Microsoft.Extensions.Hosting;
+
+public void Program
+{
+    public static void Main(string[] args)
+    {
+        Host.CreateDefaultBuilder()
+            .ConfigureSecretStore((config, stores) =>
+            {
+                // Adding a in-memory secret provider to the secret store, without any additional secrets.
+                // This is mainly used to have at least a single secret provider registration which is required for the secret store to be set up.
+                stores.AddInMemory();
+
+                // Adding a in-memory secret provider to the secret store, with a single secret name/value pair.
+                stores.AddInMemory("MySecret", "P@ssw0rd");
+
+                // Adding a in-memory secret provider to the secret store, with several secret name/value pairs.
+                stores.AddInMemory(new Dictionary<string, string>
+                {
+                    ["MySecret-1"] = "P@ssw0rd",
+                    ["MySecret-2"] = "qwerty"
+                });
+            })
+            .Build()
+            .Run();
+    }
+}
+```
+
+The secret store will behave the same, so this in-memory secret provider will be a part when you inject the `ISecretProvider` in your application:
+
+```csharp
+using Arcus.Security.Core;
+
+[ApiController]
+public class MyController : ControllerBase
+{
+    public MyController(ISecretProvider secretProvider)
+    {
+        secretProvider.GetRawSecretAsync("MySecret");
+    }
+}
+```
+
+### Customization
+
+The in-memory secret provider also has some several extra options to customize the usage.
+
+```csharp
+using Microsoft.Extenions.Hosting;
+
+public void Program
+{
+    public static void Main(string[] args)
+    {
+        Host.CreateDefaultBuilder()
+            .ConfigureSecretStore((config, stores) =>
+            {
+                // Adding a in-memory secret provider to the secret store, with caching configuration.
+                // This means that the secret provider will be registered as a cached variant and can be retrieved as such (via `ISecretStore.GetCachedProvider`).
+                // For more information on caching secrets: https://security.arcus-azure.net/features/secrets/general
+                stores.AddInMemory("MySecret", "P@ssw0rd", new CacheConfiguration(TimeSpan.FromSeconds(5));
+
+                // Adding a in-memory secret provider to the secret store, with a dedicated name.
+                // This means that the secret provider can be retrieved with the `ISecretStore.GetProvider("your-name")`.
+                // For more information on retrieving a specific secret provider: https://security.arcus-azure.net/features/secret-store/named-secret-providers
+                stores.AddInMemory(new Dictionary<string, string> { ["MySecret"] = "P@ssw0rd" }, secretProviderName: "InMemory");
+            })
+            .Build()
+            .Run();
+    }
+}
+```

--- a/docs/preview/index.md
+++ b/docs/preview/index.md
@@ -20,6 +20,7 @@ For more granular packages we recommend reading the documentation.
 
 # Features
 
+- [In-memory test secret provider the Arcus secret store](features/inmemory-secret-provider)
 - [xUnit Logging and Logging Testing](features/logging)
 
 # License

--- a/src/Arcus.Testing.Security.Providers.InMemory/Arcus.Testing.Security.Providers.InMemory.csproj
+++ b/src/Arcus.Testing.Security.Providers.InMemory/Arcus.Testing.Security.Providers.InMemory.csproj
@@ -1,26 +1,26 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <Authors>Arcus</Authors>
     <Company>Arcus</Company>
-    <Description>Provides logging capabilities during Arcus testing</Description>
+    <Description>Provides security capabilities during Arcus testing</Description>
     <Copyright>Copyright (c) Arcus</Copyright>
     <PackageLicenseUrl>https://github.com/arcus-azure/arcus.testing/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/arcus-azure/arcus.testing</PackageProjectUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/arcus-azure/arcus/master/media/arcus.png</PackageIconUrl>
     <RepositoryUrl>https://github.com/arcus-azure/arcus.testing</RepositoryUrl>
     <RepositoryType>Git</RepositoryType>
-    <PackageTags>Azure;Testing</PackageTags>
-    <PackageId>Arcus.Testing.Logging</PackageId>
+    <PackageTags>Azure;Testing;Security</PackageTags>
+    <PackageId>Arcus.Testing.Security</PackageId>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Arcus.Security.Core" Version="1.5.0" />
     <PackageReference Include="Guard.Net" Version="1.2.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.8" />
-    <PackageReference Include="xunit.abstractions" Version="2.0.1" />
   </ItemGroup>
 
 </Project>

--- a/src/Arcus.Testing.Security.Providers.InMemory/Extensions/SecretStoreBuilderExtensions.cs
+++ b/src/Arcus.Testing.Security.Providers.InMemory/Extensions/SecretStoreBuilderExtensions.cs
@@ -1,0 +1,232 @@
+﻿using System;
+using System.Collections.Generic;
+using Arcus.Security.Core.Caching.Configuration;
+using Arcus.Testing.Security.Providers.InMemory;
+using GuardNet;
+
+// ReSharper disable once CheckNamespace
+namespace Microsoft.Extensions.Hosting
+{
+    /// <summary>
+    /// Extensions on the <see cref="SecretStoreBuilder"/> class to add test-related options.
+    /// </summary>
+    public static class SecretStoreBuilderExtensions
+    {
+        /// <summary>
+        /// Adds the <see cref="InMemorySecretProvider"/> to the secret store without any in-memory stored secrets.
+        /// </summary>
+        /// <param name="builder">The secret store builder to add the secret provider.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="builder"/> is <c>null</c>.</exception>
+        public static SecretStoreBuilder AddInMemory(this SecretStoreBuilder builder)
+        {
+            Guard.NotNull(builder, nameof(builder), "Requires a secret store builder to add the in-memory secret provider to the secret store");
+
+            builder.AddInMemory(secretProviderName: null);
+            return builder;
+        }
+        
+        /// <summary>
+        /// Adds the <see cref="InMemoryCachedSecretProvider"/> to the secret store without any in-memory stored secrets.
+        /// </summary>
+        /// <param name="builder">The secret store builder to add the secret provider.</param>
+        /// <param name="cacheConfiguration">The <see cref="ICacheConfiguration" /> which defines how the cache works.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="builder"/> is <c>null</c>.</exception>
+        public static SecretStoreBuilder AddInMemory(this SecretStoreBuilder builder, ICacheConfiguration cacheConfiguration)
+        {
+            Guard.NotNull(builder, nameof(builder), "Requires a secret store builder to add the in-memory secret provider to the secret store");
+            
+            builder.AddInMemory(cacheConfiguration, secretProviderName: null);
+            return builder;
+        }
+
+        /// <summary>
+        /// Adds the <see cref="InMemorySecretProvider"/> to the secret store without any in-memory stored secrets.
+        /// </summary>
+        /// <param name="builder">The secret store builder to add the secret provider.</param>
+        /// <param name="secretProviderName">The name to register the secret provider by.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="builder"/> is <c>null</c>.</exception>
+        public static SecretStoreBuilder AddInMemory(this SecretStoreBuilder builder, string secretProviderName)
+        {
+            Guard.NotNull(builder, nameof(builder), "Requires a secret store builder to add the in-memory secret provider to the secret store");
+
+            builder.AddProvider(new InMemorySecretProvider(), options => options.Name = secretProviderName);
+            return builder;
+        }
+
+        /// <summary>
+        /// Adds the <see cref="InMemoryCachedSecretProvider"/> to the secret store without any in-memory stored secrets.
+        /// </summary>
+        /// <param name="builder">The secret store builder to add the secret provider.</param>
+        /// <param name="cacheConfiguration">The <see cref="ICacheConfiguration" /> which defines how the cache works.</param>
+        /// <param name="secretProviderName">The name to register the secret provider by.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="builder"/> or the <paramref name="cacheConfiguration"/> is <c>null</c>.</exception>
+        public static SecretStoreBuilder AddInMemory(this SecretStoreBuilder builder, ICacheConfiguration cacheConfiguration, string secretProviderName)
+        {
+            Guard.NotNull(builder, nameof(builder), "Requires a secret store builder to add the in-memory secret provider to the secret store");
+            Guard.NotNull(cacheConfiguration, nameof(cacheConfiguration), "Requires a configuration instance to describe how the caching of secrets should work");
+            
+            builder.AddProvider(new InMemoryCachedSecretProvider(cacheConfiguration), options => options.Name = secretProviderName);
+            return builder;
+        }
+
+        /// <summary>
+        /// Adds the <see cref="InMemorySecretProvider"/> to the secret store without any in-memory stored secrets.
+        /// </summary>
+        /// <param name="builder">The secret store builder to add the secret provider.</param>
+        /// <param name="secretName">The required secret name to store the secret in-memory.</param>
+        /// <param name="secretValue">The tested secret value to retrieve upon providing the <paramref name="secretName"/>.</param>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="secretName"/> is blank.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="builder"/> is <c>null</c>.</exception>
+        public static SecretStoreBuilder AddInMemory(this SecretStoreBuilder builder, string secretName, string secretValue)
+        {
+            Guard.NotNull(builder, nameof(builder), "Requires a secret store builder to add the in-memory secret provider to the secret store");
+            Guard.NotNullOrWhitespace(secretName, nameof(secretName), "Requires a non-blank test secret name to store the secret value in-memory");
+            
+            builder.AddInMemory(secretName, secretValue, secretProviderName: null);
+            return builder;
+        }
+        
+        /// <summary>
+        /// Adds the <see cref="InMemoryCachedSecretProvider"/> to the secret store without any in-memory stored secrets.
+        /// </summary>
+        /// <param name="builder">The secret store builder to add the secret provider.</param>
+        /// <param name="secretName">The required secret name to store the secret in-memory.</param>
+        /// <param name="secretValue">The tested secret value to retrieve upon providing the <paramref name="secretName"/>.</param>
+        /// <param name="cacheConfiguration">The <see cref="ICacheConfiguration" /> which defines how the cache works.</param>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="secretName"/> is blank.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="builder"/> or the <paramref name="cacheConfiguration"/> is <c>null</c>.</exception>
+        public static SecretStoreBuilder AddInMemory(
+            this SecretStoreBuilder builder, 
+            string secretName, 
+            string secretValue, 
+            ICacheConfiguration cacheConfiguration)
+        {
+            Guard.NotNull(builder, nameof(builder), "Requires a secret store builder to add the in-memory secret provider to the secret store");
+            Guard.NotNullOrWhitespace(secretName, nameof(secretName), "Requires a non-blank test secret name to store the secret value in-memory");
+            Guard.NotNull(cacheConfiguration, nameof(cacheConfiguration), "Requires a configuration instance to describe how the caching of secrets should work");
+
+            builder.AddInMemory(secretName, secretValue, cacheConfiguration, secretProviderName: null);
+            return builder;
+        }
+        
+        /// <summary>
+        /// Adds the <see cref="InMemorySecretProvider"/> to the secret store without any in-memory stored secrets.
+        /// </summary>
+        /// <param name="builder">The secret store builder to add the secret provider.</param>
+        /// <param name="secretName">The required secret name to store the secret in-memory.</param>
+        /// <param name="secretValue">The tested secret value to retrieve upon providing the <paramref name="secretName"/>.</param>
+        /// <param name="secretProviderName">The name to register the secret provider by.</param>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="secretName"/> is blank.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="builder"/> is <c>null</c>.</exception>
+        public static SecretStoreBuilder AddInMemory(this SecretStoreBuilder builder, string secretName, string secretValue, string secretProviderName)
+        {
+            Guard.NotNull(builder, nameof(builder), "Requires a secret store builder to add the in-memory secret provider to the secret store");
+            Guard.NotNullOrWhitespace(secretName, nameof(secretName), "Requires a non-blank test secret name to store the secret value in-memory");
+            
+            builder.AddProvider(new InMemorySecretProvider(secretName, secretValue), options => options.Name = secretProviderName);
+            return builder;
+        }
+        
+        /// <summary>
+        /// Adds the <see cref="InMemoryCachedSecretProvider"/> to the secret store without any in-memory stored secrets.
+        /// </summary>
+        /// <param name="builder">The secret store builder to add the secret provider.</param>
+        /// <param name="secretName">The required secret name to store the secret in-memory.</param>
+        /// <param name="secretValue">The tested secret value to retrieve upon providing the <paramref name="secretName"/>.</param>
+        /// <param name="cacheConfiguration">The <see cref="ICacheConfiguration" /> which defines how the cache works.</param>
+        /// <param name="secretProviderName">The name to register the secret provider by.</param>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="secretName"/> is blank.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="builder"/> or the <paramref name="cacheConfiguration"/> is <c>null</c>.</exception>
+        public static SecretStoreBuilder AddInMemory(
+            this SecretStoreBuilder builder, 
+            string secretName, 
+            string secretValue, 
+            ICacheConfiguration cacheConfiguration,
+            string secretProviderName)
+        {
+            Guard.NotNull(builder, nameof(builder), "Requires a secret store builder to add the in-memory secret provider to the secret store");
+            Guard.NotNullOrWhitespace(secretName, nameof(secretName), "Requires a non-blank test secret name to store the secret value in-memory");
+            Guard.NotNull(cacheConfiguration, nameof(cacheConfiguration), "Requires a configuration instance to describe how the caching of secrets should work");
+
+            builder.AddProvider(new InMemoryCachedSecretProvider(secretName, secretValue, cacheConfiguration), options => options.Name = secretProviderName);
+            return builder;
+        }
+        
+        /// <summary>
+        /// Adds the <see cref="InMemorySecretProvider"/> to the secret store without any in-memory stored secrets.
+        /// </summary>
+        /// <param name="builder">The secret store builder to add the secret provider.</param>
+        /// <param name="secrets">The set of secret name-value pairs that represents the complete set of available in-memory secrets.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="builder"/> is <c>null</c>.</exception>
+        public static SecretStoreBuilder AddInMemory(this SecretStoreBuilder builder, IDictionary<string, string> secrets)
+        {
+            Guard.NotNull(builder, nameof(builder), "Requires a secret store builder to add the in-memory secret provider to the secret store");
+            Guard.NotNull(secrets, nameof(secrets), "Requires a set of secrets to initialize the in-memory secret provider");
+            
+            builder.AddInMemory(secrets, secretProviderName: null);
+            return builder;
+        }
+        
+        /// <summary>
+        /// Adds the <see cref="InMemoryCachedSecretProvider"/> to the secret store without any in-memory stored secrets.
+        /// </summary>
+        /// <param name="builder">The secret store builder to add the secret provider.</param>
+        /// <param name="secrets">The set of secret name-value pairs that represents the complete set of available in-memory secrets.</param>
+        /// <param name="cacheConfiguration">The <see cref="ICacheConfiguration" /> which defines how the cache works.</param>
+        /// <exception cref="ArgumentNullException">
+        ///     Thrown when the <paramref name="builder"/>, the <paramref name="secrets"/>, or the <paramref name="cacheConfiguration"/> is <c>null</c>.
+        /// </exception>
+        public static SecretStoreBuilder AddInMemory(
+            this SecretStoreBuilder builder, 
+            IDictionary<string, string> secrets, 
+            ICacheConfiguration cacheConfiguration)
+        {
+            Guard.NotNull(builder, nameof(builder), "Requires a secret store builder to add the in-memory secret provider to the secret store");
+            Guard.NotNull(secrets, nameof(secrets), "Requires a set of secrets to initialize the in-memory secret provider");
+            Guard.NotNull(cacheConfiguration, nameof(cacheConfiguration), "Requires a configuration instance to describe how the caching of secrets should work");
+            
+            builder.AddInMemory(secrets, cacheConfiguration, secretProviderName: null);
+            return builder;
+        }
+        
+        /// <summary>
+        /// Adds the <see cref="InMemorySecretProvider"/> to the secret store without any in-memory stored secrets.
+        /// </summary>
+        /// <param name="builder">The secret store builder to add the secret provider.</param>
+        /// <param name="secrets">The set of secret name-value pairs that represents the complete set of available in-memory secrets.</param>
+        /// <param name="secretProviderName">The name to register the secret provider by.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="builder"/> or the <paramref name="secrets"/> is <c>null</c>.</exception>
+        public static SecretStoreBuilder AddInMemory(this SecretStoreBuilder builder, IDictionary<string, string> secrets, string secretProviderName)
+        {
+            Guard.NotNull(builder, nameof(builder), "Requires a secret store builder to add the in-memory secret provider to the secret store");
+            Guard.NotNull(secrets, nameof(secrets), "Requires a set of secrets to initialize the in-memory secret provider");
+            
+            builder.AddProvider(new InMemorySecretProvider(secrets), options => options.Name = secretProviderName);
+            return builder;
+        }
+        
+        /// <summary>
+        /// Adds the <see cref="InMemoryCachedSecretProvider"/> to the secret store without any in-memory stored secrets.
+        /// </summary>
+        /// <param name="builder">The secret store builder to add the secret provider.</param>
+        /// <param name="secrets">The set of secret name-value pairs that represents the complete set of available in-memory secrets.</param>
+        /// <param name="cacheConfiguration">The <see cref="ICacheConfiguration" /> which defines how the cache works.</param>
+        /// <param name="secretProviderName">The name to register the secret provider by.</param>
+        /// <exception cref="ArgumentNullException">
+        ///     Thrown when the <paramref name="builder"/>, the <paramref name="secrets"/>, or the <paramref name="cacheConfiguration"/> is <c>null</c>.
+        /// </exception>
+        public static SecretStoreBuilder AddInMemory(
+            this SecretStoreBuilder builder, 
+            IDictionary<string, string> secrets, 
+            ICacheConfiguration cacheConfiguration,
+            string secretProviderName)
+        {
+            Guard.NotNull(builder, nameof(builder), "Requires a secret store builder to add the in-memory secret provider to the secret store");
+            Guard.NotNull(secrets, nameof(secrets), "Requires a set of secrets to initialize the in-memory secret provider");
+            Guard.NotNull(cacheConfiguration, nameof(cacheConfiguration), "Requires a configuration instance to describe how the caching of secrets should work");
+
+            builder.AddProvider(new InMemoryCachedSecretProvider(secrets, cacheConfiguration), options => options.Name = secretProviderName);
+            return builder;
+        }
+    }
+}

--- a/src/Arcus.Testing.Security.Providers.InMemory/InMemoryCachedSecretProvider.cs
+++ b/src/Arcus.Testing.Security.Providers.InMemory/InMemoryCachedSecretProvider.cs
@@ -1,0 +1,115 @@
+﻿using System;
+using System.Collections.Generic;
+using Arcus.Security.Core.Caching;
+using Arcus.Security.Core.Caching.Configuration;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace Arcus.Testing.Security.Providers.InMemory
+{
+    /// <summary>
+    /// Represents an <see cref="ICachedSecretProvider"/> that stores the secrets in-memory.
+    /// </summary>
+    public class InMemoryCachedSecretProvider : CachedSecretProvider
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InMemoryCachedSecretProvider"/> class without any secrets.
+        /// </summary>
+        public InMemoryCachedSecretProvider() : base(new InMemorySecretProvider())
+        {
+        }
+        
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InMemoryCachedSecretProvider"/> class.
+        /// </summary>
+        /// <param name="secretName">The required secret name to store the secret in-memory.</param>
+        /// <param name="secretValue">The tested secret value to retrieve upon providing the <paramref name="secretName"/>.</param>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="secretName"/> is blank.</exception>
+        public InMemoryCachedSecretProvider(string secretName, string secretValue)
+            : base(new InMemorySecretProvider(secretName, secretValue))
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InMemoryCachedSecretProvider"/> class.
+        /// </summary>
+        /// <param name="secrets">The set of secret name-value pairs that represents the complete set of available in-memory secrets.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="secrets"/> is <c>null</c>.</exception>
+        public InMemoryCachedSecretProvider(IDictionary<string, string> secrets)
+            : base(new InMemorySecretProvider(secrets))
+        {
+        }
+        
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InMemoryCachedSecretProvider"/> class without any secrets.
+        /// </summary>
+        /// <param name="cacheConfiguration">The <see cref="ICacheConfiguration" /> which defines how the cache works.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="cacheConfiguration"/> is <c>null</c>.</exception>
+        public InMemoryCachedSecretProvider(ICacheConfiguration cacheConfiguration) 
+            : base(new InMemorySecretProvider(), cacheConfiguration)
+        {
+        }
+        
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InMemoryCachedSecretProvider"/> class.
+        /// </summary>
+        /// <param name="secretName">The required secret name to store the secret in-memory.</param>
+        /// <param name="secretValue">The tested secret value to retrieve upon providing the <paramref name="secretName"/>.</param>
+        /// <param name="cacheConfiguration">The <see cref="ICacheConfiguration" /> which defines how the cache works.</param>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="secretName"/> is blank.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="cacheConfiguration"/> is <c>null</c>.</exception>
+        public InMemoryCachedSecretProvider(string secretName, string secretValue, ICacheConfiguration cacheConfiguration)
+            : base(new InMemorySecretProvider(secretName, secretValue), cacheConfiguration)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InMemoryCachedSecretProvider"/> class.
+        /// </summary>
+        /// <param name="secrets">The set of secret name-value pairs that represents the complete set of available in-memory secrets.</param>
+        /// <param name="cacheConfiguration">The <see cref="ICacheConfiguration" /> which defines how the cache works.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="secrets"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="cacheConfiguration"/> is <c>null</c>.</exception>
+        public InMemoryCachedSecretProvider(IDictionary<string, string> secrets, ICacheConfiguration cacheConfiguration)
+            : base(new InMemorySecretProvider(secrets), cacheConfiguration)
+        {
+        }
+        
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InMemoryCachedSecretProvider"/> class without any secrets.
+        /// </summary>
+        /// <param name="cacheConfiguration">The <see cref="ICacheConfiguration" /> which defines how the cache works.</param>
+        /// <param name="memoryCache">The <see cref="IMemoryCache" /> implementation that can cache data in memory.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="cacheConfiguration"/> or <paramref name="memoryCache"/> is <c>null</c>.</exception>
+        public InMemoryCachedSecretProvider(ICacheConfiguration cacheConfiguration, IMemoryCache memoryCache) 
+            : base(new InMemorySecretProvider(), cacheConfiguration, memoryCache)
+        {
+        }
+        
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InMemoryCachedSecretProvider"/> class.
+        /// </summary>
+        /// <param name="secretName">The required secret name to store the secret in-memory.</param>
+        /// <param name="secretValue">The tested secret value to retrieve upon providing the <paramref name="secretName"/>.</param>
+        /// <param name="cacheConfiguration">The <see cref="ICacheConfiguration" /> which defines how the cache works.</param>
+        /// <param name="memoryCache">The <see cref="IMemoryCache" /> implementation that can cache data in memory.</param>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="secretName"/> is blank.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="cacheConfiguration"/> or <paramref name="memoryCache"/> is <c>null</c>.</exception>
+        public InMemoryCachedSecretProvider(string secretName, string secretValue, ICacheConfiguration cacheConfiguration, IMemoryCache memoryCache)
+            : base(new InMemorySecretProvider(secretName, secretValue), cacheConfiguration, memoryCache)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InMemoryCachedSecretProvider"/> class.
+        /// </summary>
+        /// <param name="secrets">The set of secret name-value pairs that represents the complete set of available in-memory secrets.</param>
+        /// <param name="cacheConfiguration">The <see cref="ICacheConfiguration" /> which defines how the cache works.</param>
+        /// <param name="memoryCache">The <see cref="IMemoryCache" /> implementation that can cache data in memory.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="secrets"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="cacheConfiguration"/> or <paramref name="memoryCache"/> is <c>null</c>.</exception>
+        public InMemoryCachedSecretProvider(IDictionary<string, string> secrets, ICacheConfiguration cacheConfiguration, IMemoryCache memoryCache)
+            : base(new InMemorySecretProvider(secrets), cacheConfiguration, memoryCache)
+        {
+        }
+    }
+}

--- a/src/Arcus.Testing.Security.Providers.InMemory/InMemorySecretProvider.cs
+++ b/src/Arcus.Testing.Security.Providers.InMemory/InMemorySecretProvider.cs
@@ -1,0 +1,92 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Arcus.Security.Core;
+using GuardNet;
+
+namespace Arcus.Testing.Security.Providers.InMemory
+{
+    /// <summary>
+    /// Represents an <see cref="ISecretProvider"/> implementation that stores the secret values in-memory.
+    /// </summary>
+    public class InMemorySecretProvider : ISecretProvider
+    {
+        private readonly IDictionary<string, string> _secrets = new Dictionary<string, string>();
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InMemorySecretProvider"/> class without any secrets.
+        /// </summary>
+        public InMemorySecretProvider()
+        {
+        }
+        
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InMemorySecretProvider"/> class.
+        /// </summary>
+        /// <param name="secretName">The required secret name to store the secret in-memory.</param>
+        /// <param name="secretValue">The tested secret value to retrieve upon providing the <paramref name="secretName"/>.</param>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="secretName"/> is blank.</exception>
+        public InMemorySecretProvider(string secretName, string secretValue)
+        {
+            Guard.NotNullOrWhitespace(secretName, nameof(secretName), "Requires a non-blank test secret name to store the secret value in-memory");
+
+            _secrets = new Dictionary<string, string>
+            {
+                [secretName] = secretValue
+            };
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InMemorySecretProvider"/> class.
+        /// </summary>
+        /// <param name="secrets">The set of secret name-value pairs that represents the complete set of available in-memory secrets.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="secrets"/> is <c>null</c>.</exception>
+        public InMemorySecretProvider(IDictionary<string, string> secrets)
+        {
+            Guard.NotNull(secrets, nameof(secrets), "Requires a set of secrets to initialize the in-memory secret provider");
+
+            _secrets = secrets;
+        }
+
+        /// <summary>
+        /// Retrieves the secret value, based on the given name.
+        /// </summary>
+        /// <param name="secretName">The name of the secret key</param>
+        /// <returns>Returns a <see cref="T:Arcus.Security.Core.Secret" /> that contains the secret key</returns>
+        /// <exception cref="T:System.ArgumentException">The <paramref name="secretName" /> must not be empty</exception>
+        /// <exception cref="T:System.ArgumentNullException">The <paramref name="secretName" /> must not be null</exception>
+        /// <exception cref="T:Arcus.Security.Core.SecretNotFoundException">The secret was not found, using the given name</exception>
+        public async Task<Secret> GetSecretAsync(string secretName)
+        {
+            Guard.NotNullOrWhitespace(secretName, nameof(secretName), "Requires a non-blank secret name to look up the test secret value");
+
+            string secretValue = await GetRawSecretAsync(secretName);
+            if (secretValue is null)
+            {
+                return null;
+            }
+
+            return new Secret(secretValue);
+        }
+
+        /// <summary>
+        /// Retrieves the secret value, based on the given name.
+        /// </summary>
+        /// <param name="secretName">The name of the secret key</param>
+        /// <returns>Returns the secret key.</returns>
+        /// <exception cref="T:System.ArgumentException">The <paramref name="secretName" /> must not be empty</exception>
+        /// <exception cref="T:System.ArgumentNullException">The <paramref name="secretName" /> must not be null</exception>
+        /// <exception cref="T:Arcus.Security.Core.SecretNotFoundException">The secret was not found, using the given name</exception>
+        public Task<string> GetRawSecretAsync(string secretName)
+        {
+            Guard.NotNullOrWhitespace(secretName, nameof(secretName), "Requires a non-blank secret name to look up the test secret value");
+
+            if (_secrets.TryGetValue(secretName, out string secretValue))
+            {
+                return Task.FromResult(secretValue);
+            }
+
+            return Task.FromResult<string>(null);
+        }
+    }
+}

--- a/src/Arcus.Testing.Tests.Integration/Arcus.Testing.Tests.Integration.csproj
+++ b/src/Arcus.Testing.Tests.Integration/Arcus.Testing.Tests.Integration.csproj
@@ -7,10 +7,10 @@
 
   <ItemGroup>
     <PackageReference Include="Guard.Net" Version="1.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.8" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.8" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.8" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.8" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/src/Arcus.Testing.Tests.Unit/Arcus.Testing.Tests.Unit.csproj
+++ b/src/Arcus.Testing.Tests.Unit/Arcus.Testing.Tests.Unit.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Bogus" Version="29.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.8" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
     <PackageReference Include="Moq" Version="4.14.5" />
     <PackageReference Include="xunit" Version="2.3.1" />
@@ -16,6 +17,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Arcus.Testing.Logging\Arcus.Testing.Logging.csproj" />
+    <ProjectReference Include="..\Arcus.Testing.Security.Providers.InMemory\Arcus.Testing.Security.Providers.InMemory.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Arcus.Testing.Tests.Unit/Blanks.cs
+++ b/src/Arcus.Testing.Tests.Unit/Blanks.cs
@@ -1,0 +1,32 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+
+namespace Arcus.Testing.Tests.Unit
+{
+    /// <summary>
+    /// Represents a collection of blank inputs, used for data-driven tests.
+    /// </summary>
+    public class Blanks : IEnumerable<object[]>
+    {
+        /// <summary>
+        /// Returns an enumerator that iterates through the collection.
+        /// </summary>
+        /// <returns>An enumerator that can be used to iterate through the collection.</returns>
+        public IEnumerator<object[]> GetEnumerator()
+        {
+            yield return new object[] {null};
+            yield return new object[] {""};
+            yield return new object[] {" "};
+            yield return new object[] {"        "};
+        }
+
+        /// <summary>
+        /// Returns an enumerator that iterates through a collection.
+        /// </summary>
+        /// <returns>An <see cref="T:System.Collections.IEnumerator" /> object that can be used to iterate through the collection.</returns>
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+}

--- a/src/Arcus.Testing.Tests.Unit/Security/InMemoryCachedSecretProviderTests.cs
+++ b/src/Arcus.Testing.Tests.Unit/Security/InMemoryCachedSecretProviderTests.cs
@@ -1,0 +1,161 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Arcus.Security.Core;
+using Arcus.Security.Core.Caching.Configuration;
+using Arcus.Testing.Security.Providers.InMemory;
+using Xunit;
+
+namespace Arcus.Testing.Tests.Unit.Security
+{
+    [Trait("Category", "Unit")]
+    public class InMemoryCachedSecretProviderTests
+    {
+        [Fact]
+        public async Task CreateWithoutSecrets_GetsRawSecret_ReturnsNull()
+        {
+            // Arrange
+            var provider = new InMemoryCachedSecretProvider();
+            
+            // Act
+            string secretValue = await provider.GetRawSecretAsync("MySecret");
+            
+            // Assert
+            Assert.Null(secretValue);
+        }
+
+        [Fact]
+        public async Task CreateWithoutSecrets_GetSecret_ReturnsNull()
+        {
+            // Arrange
+            var provider = new InMemoryCachedSecretProvider();
+            
+            // Act
+            Secret secret = await provider.GetSecretAsync("MySecret");
+            
+            // Assert
+            Assert.Null(secret);
+        }
+
+        [Fact]
+        public async Task CreateWithSecretValue_GetsRawSecret_EqualsInitializedSecretValue()
+        {
+            // Arrange
+            string secretName = "MySecret";
+            string expected = $"secret-{Guid.NewGuid()}";
+            var provider = new InMemoryCachedSecretProvider(secretName, expected);
+            
+            // Act
+            string actual = await provider.GetRawSecretAsync(secretName);
+            
+            // Assert
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public async Task CreateWithSecretValue_GetsSecret_EqualsInitializedSecretValue()
+        {
+            // Arrange
+            string secretName = "MySecret";
+            string expected = $"secret-{Guid.NewGuid()}";
+            var provider = new InMemoryCachedSecretProvider(secretName, expected);
+            
+            // Act
+            Secret actual = await provider.GetSecretAsync(secretName);
+            
+            // Assert
+            Assert.Equal(expected, actual.Value);
+        }
+
+        [Fact]
+        public async Task CreateWithSecrets_GetsRawSecret_EqualsInitializedSecretValue()
+        {
+            // Arrange
+            var secrets = new Dictionary<string, string>
+            {
+                ["MySecret-1"] = $"secret-{Guid.NewGuid()}",
+                ["MySecret-2"] = $"secret-{Guid.NewGuid()}",
+                ["MySecret-3"] = $"secret-{Guid.NewGuid()}"
+            };
+            var provider = new InMemoryCachedSecretProvider(secrets);
+
+            // Act
+            IEnumerable<Task<string>> getSecrets = secrets.Select(secret => provider.GetRawSecretAsync(secret.Key));
+
+            // Assert
+            string[] results = await Task.WhenAll(getSecrets);
+            Assert.Equal(secrets.Count, results.Length);
+            Assert.All(secrets.Values, value => Assert.Contains(value, results));
+        }
+
+        [Fact]
+        public async Task CreateWithSecrets_GetsSecret_EqualsInitializedSecretValue()
+        {
+            // Arrange
+            var secrets = new Dictionary<string, string>
+            {
+                ["MySecret-1"] = $"secret-{Guid.NewGuid()}",
+                ["MySecret-2"] = $"secret-{Guid.NewGuid()}",
+                ["MySecret-3"] = $"secret-{Guid.NewGuid()}"
+            };
+            var provider = new InMemoryCachedSecretProvider(secrets);
+
+            // Act
+            IEnumerable<Task<Secret>> getSecrets = secrets.Select(secret => provider.GetSecretAsync(secret.Key));
+
+            // Assert
+            Secret[] results = await Task.WhenAll(getSecrets);
+            string[] values = results.Select(result => result.Value).ToArray();
+            Assert.Equal(secrets.Count, results.Length);
+            Assert.All(secrets.Values, value => Assert.Contains(value, values));
+        }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void Create_WithoutSecretName_Fails(string secretName)
+        {
+            Assert.ThrowsAny<ArgumentException>(() => new InMemoryCachedSecretProvider(secretName, "some secret value"));
+        }
+
+        [Fact]
+        public void Create_WithoutSecrets_Fails()
+        {
+            Assert.ThrowsAny<ArgumentException>(() => new InMemoryCachedSecretProvider(secrets: null));
+        }
+
+        [Fact]
+        public void Create_WithSecretPairWithoutCacheConfiguration_Fails()
+        {
+            Assert.ThrowsAny<ArgumentException>(() =>
+                new InMemoryCachedSecretProvider("MySecret", $"secret-{Guid.NewGuid()}", cacheConfiguration: null));
+        }
+        
+        [Fact]
+        public void Create_WithSecretsWithoutCacheConfiguration_Fails()
+        {
+            Assert.ThrowsAny<ArgumentException>(() =>
+                new InMemoryCachedSecretProvider(secrets: new Dictionary<string, string>
+                {
+                    ["MySecret"] = $"secret-{Guid.NewGuid()}"
+                }, cacheConfiguration: null));
+        }
+        
+        [Fact]
+        public void Create_WithSecretPairWithCacheConfigurationWithoutMemoryCache_Fails()
+        {
+            Assert.ThrowsAny<ArgumentException>(() =>
+                new InMemoryCachedSecretProvider("MySecret", $"secret-{Guid.NewGuid()}", CacheConfiguration.Default, memoryCache: null));
+        }
+        
+        [Fact]
+        public void Create_WithSecretsWithCacheConfigurationWithoutMemoryCache_Fails()
+        {
+            Assert.ThrowsAny<ArgumentException>(() =>
+                new InMemoryCachedSecretProvider(secrets: new Dictionary<string, string>
+                {
+                    ["MySecret"] = $"secret-{Guid.NewGuid()}"
+                }, CacheConfiguration.Default, memoryCache: null));
+        }
+    }
+}

--- a/src/Arcus.Testing.Tests.Unit/Security/InMemorySecretProviderTests.cs
+++ b/src/Arcus.Testing.Tests.Unit/Security/InMemorySecretProviderTests.cs
@@ -1,0 +1,126 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Arcus.Security.Core;
+using Arcus.Testing.Security.Providers.InMemory;
+using Xunit;
+
+namespace Arcus.Testing.Tests.Unit.Security
+{
+    [Trait("Category", "Unit")]
+    public class InMemorySecretProviderTests
+    {
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void Create_WithoutSecretName_Fails(string secretName)
+        {
+            Assert.ThrowsAny<ArgumentException>(() => new InMemorySecretProvider(secretName, "some secret value"));
+        }
+
+        [Fact]
+        public void Create_WithoutSecrets_Fails()
+        {
+            Assert.ThrowsAny<ArgumentException>(() => new InMemorySecretProvider(secrets: null));
+        }
+
+        [Fact]
+        public async Task CreateWithoutSecrets_GetsRawSecret_ReturnsNull()
+        {
+            // Arrange
+            var provider = new InMemorySecretProvider();
+            
+            // Act
+            string secretValue = await provider.GetRawSecretAsync("MySecret");
+            
+            // Assert
+            Assert.Null(secretValue);
+        }
+        
+        [Fact]
+        public async Task CreateWithoutSecrets_GetSecret_ReturnsNull()
+        {
+            // Arrange
+            var provider = new InMemorySecretProvider();
+            
+            // Act
+            Secret secret = await provider.GetSecretAsync("MySecret");
+            
+            // Assert
+            Assert.Null(secret);
+        }
+        
+        [Fact]
+        public async Task CreateWithSecretValue_GetsRawSecret_EqualsInitializedSecretValue()
+        {
+            // Arrange
+            string secretName = "MySecret";
+            string expected = $"secret-{Guid.NewGuid()}";
+            var provider = new InMemorySecretProvider(secretName, expected);
+            
+            // Act
+            string actual = await provider.GetRawSecretAsync(secretName);
+            
+            // Assert
+            Assert.Equal(expected, actual);
+        }
+        
+        [Fact]
+        public async Task CreateWithSecretValue_GetsSecret_EqualsInitializedSecretValue()
+        {
+            // Arrange
+            string secretName = "MySecret";
+            string expected = $"secret-{Guid.NewGuid()}";
+            var provider = new InMemorySecretProvider(secretName, expected);
+            
+            // Act
+            Secret actual = await provider.GetSecretAsync(secretName);
+            
+            // Assert
+            Assert.Equal(expected, actual.Value);
+        }
+        
+        [Fact]
+        public async Task CreateWithSecrets_GetsRawSecret_EqualsInitializedSecretValue()
+        {
+            // Arrange
+            var secrets = new Dictionary<string, string>
+            {
+                ["MySecret-1"] = $"secret-{Guid.NewGuid()}",
+                ["MySecret-2"] = $"secret-{Guid.NewGuid()}",
+                ["MySecret-3"] = $"secret-{Guid.NewGuid()}"
+            };
+            var provider = new InMemorySecretProvider(secrets);
+
+            // Act
+            IEnumerable<Task<string>> getSecrets = secrets.Select(secret => provider.GetRawSecretAsync(secret.Key));
+
+            // Assert
+            string[] results = await Task.WhenAll(getSecrets);
+            Assert.Equal(secrets.Count, results.Length);
+            Assert.All(secrets.Values, value => Assert.Contains(value, results));
+        }
+        
+        [Fact]
+        public async Task CreateWithSecrets_GetsSecret_EqualsInitializedSecretValue()
+        {
+            // Arrange
+            var secrets = new Dictionary<string, string>
+            {
+                ["MySecret-1"] = $"secret-{Guid.NewGuid()}",
+                ["MySecret-2"] = $"secret-{Guid.NewGuid()}",
+                ["MySecret-3"] = $"secret-{Guid.NewGuid()}"
+            };
+            var provider = new InMemorySecretProvider(secrets);
+
+            // Act
+            IEnumerable<Task<Secret>> getSecrets = secrets.Select(secret => provider.GetSecretAsync(secret.Key));
+
+            // Assert
+            Secret[] results = await Task.WhenAll(getSecrets);
+            string[] values = results.Select(result => result.Value).ToArray();
+            Assert.Equal(secrets.Count, results.Length);
+            Assert.All(secrets.Values, value => Assert.Contains(value, values));
+        }
+    }
+}

--- a/src/Arcus.Testing.Tests.Unit/Security/SecretStoreBuilderExtensionsTests.cs
+++ b/src/Arcus.Testing.Tests.Unit/Security/SecretStoreBuilderExtensionsTests.cs
@@ -1,0 +1,286 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Arcus.Security.Core;
+using Arcus.Security.Core.Caching;
+using Arcus.Security.Core.Caching.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Xunit;
+
+namespace Arcus.Testing.Tests.Unit.Security
+{
+    [Trait("Category", "Unit")]
+    public class SecretStoreBuilderExtensionsTests
+    {
+        [Fact]
+        public void ConfigureSecretStore_WithEmptyInMemory_RegistersSecretProvider()
+        {
+            // Arrange
+            var builder = new HostBuilder();
+
+            // Act
+            builder.ConfigureSecretStore((config, stores) => stores.AddInMemory());
+
+            // Assert
+            using (IHost host = builder.Build())
+            {
+                Assert.NotNull(host.Services.GetService<ISecretProvider>());
+            }
+        }
+
+        [Fact]
+        public async Task ConfigureSecretStore_WithInMemorySecret_GetRawSecretSucceeds()
+        {
+            // Arrange
+            var builder = new HostBuilder();
+            string secretName = "MySecret";
+            string expected = $"secret-{Guid.NewGuid()}";
+
+            // Act
+            builder.ConfigureSecretStore((config, stores) => stores.AddInMemory(secretName, expected));
+
+            // Assert
+            using (IHost host = builder.Build())
+            {
+                var provider = host.Services.GetRequiredService<ISecretProvider>();
+                string actual = await provider.GetRawSecretAsync(secretName);
+                Assert.Equal(expected, actual);
+            }
+        }
+
+        [Fact]
+        public async Task ConfigureSecretStore_WithInMemorySecret_GetSecretSucceeds()
+        {
+            // Arrange
+            var builder = new HostBuilder();
+            string secretName = "MySecret";
+            string expected = $"secret-{Guid.NewGuid()}";
+
+            // Act
+            builder.ConfigureSecretStore((config, stores) => stores.AddInMemory(secretName, expected));
+
+            // Assert
+            using (IHost host = builder.Build())
+            {
+                var provider = host.Services.GetRequiredService<ISecretProvider>();
+                Secret actual = await provider.GetSecretAsync(secretName);
+                Assert.Equal(expected, actual.Value);
+            }
+        }
+
+        [Fact]
+        public async Task ConfigureSecretStore_WithInMemorySecrets_GetRawSecretSucceeds()
+        {
+            // Arrange
+            var builder = new HostBuilder();
+            var secrets = new Dictionary<string, string>
+            {
+                ["MySecret-1"] = $"secret-{Guid.NewGuid()}",
+                ["MySecret-2"] = $"secret-{Guid.NewGuid()}",
+                ["MySecret-3"] = $"secret-{Guid.NewGuid()}"
+            };
+
+            // Act
+            builder.ConfigureSecretStore((config, stores) => stores.AddInMemory(secrets));
+
+            // Assert
+            using (IHost host = builder.Build())
+            {
+                var provider = host.Services.GetRequiredService<ISecretProvider>();
+                IEnumerable<Task<string>> getSecrets = secrets.Select(async secret => await provider.GetRawSecretAsync(secret.Key));
+                string[] results = await Task.WhenAll(getSecrets);
+                
+                Assert.Equal(secrets.Count, results.Length);
+                Assert.All(secrets.Values, secretValue => Assert.Contains(secretValue, results));
+            }
+        }
+
+        [Fact]
+        public async Task ConfigureSecretStore_WithInMemorySecrets_GetSecretSucceeds()
+        {
+            // Arrange
+            var builder = new HostBuilder();
+            var secrets = new Dictionary<string, string>
+            {
+                ["MySecret-1"] = $"secret-{Guid.NewGuid()}",
+                ["MySecret-2"] = $"secret-{Guid.NewGuid()}",
+                ["MySecret-3"] = $"secret-{Guid.NewGuid()}"
+            };
+
+            // Act
+            builder.ConfigureSecretStore((config, stores) => stores.AddInMemory(secrets));
+
+            // Assert
+            using (IHost host = builder.Build())
+            {
+                var provider = host.Services.GetRequiredService<ISecretProvider>();
+                IEnumerable<Task<Secret>> getSecrets = secrets.Select(async secret => await provider.GetSecretAsync(secret.Key));
+                Secret[] results = await Task.WhenAll(getSecrets);
+                string[] secretValues = results.Select(result => result.Value).ToArray();
+                
+                Assert.Equal(secrets.Count, results.Length);
+                Assert.All(secrets.Values, secretValue => Assert.Contains(secretValue, secretValues));
+            }
+        }
+
+        [Fact]
+        public async Task ConfigureSecretStore_WithoutInMemoryCaching_FailsToAccessGetRawSecretWithCaching()
+        {
+            // Arrange
+            var builder = new HostBuilder();
+            string secretName = "MySecret";
+            string expected = $"secret-{Guid.NewGuid()}";
+            
+            // Act
+            builder.ConfigureSecretStore((config, stores) => stores.AddInMemory(secretName, expected));
+            
+            // Assert
+            using (IHost host = builder.Build())
+            {
+                var provider = host.Services.GetRequiredService<ICachedSecretProvider>();
+                await Assert.ThrowsAnyAsync<NotSupportedException>(
+                    () => provider.GetRawSecretAsync(secretName, ignoreCache: false));
+            }
+        }
+        
+        [Fact]
+        public async Task ConfigureSecretStore_WithoutInMemoryCaching_SucceedsToAccessGetRawSecretWithCaching()
+        {
+            // Arrange
+            var builder = new HostBuilder();
+            string secretName = "MySecret";
+            string expected = $"secret-{Guid.NewGuid()}";
+            
+            // Act
+            builder.ConfigureSecretStore((config, stores) => stores.AddInMemory(secretName, expected, CacheConfiguration.Default));
+            
+            // Assert
+            using (IHost host = builder.Build())
+            {
+                var provider = host.Services.GetRequiredService<ICachedSecretProvider>();
+                string actual = await provider.GetRawSecretAsync("MySecret", ignoreCache: false);
+                Assert.Equal(expected, actual);
+            }
+        }
+
+        [Fact]
+        public void ConfigureSecretStore_WithoutSecretName_Fails()
+        {
+            // Arrange
+            var builder = new HostBuilder();
+            
+            // Act
+            builder.ConfigureSecretStore((config, stores) =>
+            {
+                stores.AddInMemory(secretName: null, secretValue: $"secret-{Guid.NewGuid()}");
+            });
+            
+            // Assert
+            Assert.ThrowsAny<ArgumentException>(() => builder.Build());
+        }
+
+        [Fact]
+        public void ConfiguresSecretStore_WithoutSecrets_Fails()
+        {
+            // Arrange
+            var builder = new HostBuilder();
+            
+            // Act
+            builder.ConfigureSecretStore((config, stores) => stores.AddInMemory(secrets: null));
+            
+            // Assert
+            Assert.ThrowsAny<ArgumentException>(() => builder.Build());
+        }
+        
+        [Fact]
+        public void ConfigureSecretStore_WithoutSecretNameWithCacheConfiguration_Fails()
+        {
+            // Arrange
+            var builder = new HostBuilder();
+            
+            // Act
+            builder.ConfigureSecretStore((config, stores) =>
+            {
+                stores.AddInMemory(
+                    secretName: null,
+                    secretValue: $"secret-{Guid.NewGuid()}",
+                    cacheConfiguration: CacheConfiguration.Default);
+            });
+            
+            // Assert
+            Assert.ThrowsAny<ArgumentException>(() => builder.Build());
+        }
+
+        [Fact]
+        public void ConfiguresSecretStore_WithoutSecretsWithCacheConfiguration_Fails()
+        {
+            // Arrange
+            var builder = new HostBuilder();
+            
+            // Act
+            builder.ConfigureSecretStore((config, stores) =>
+            {
+                stores.AddInMemory(secrets: null, cacheConfiguration: CacheConfiguration.Default);
+            });
+            
+            // Assert
+            Assert.ThrowsAny<ArgumentException>(() => builder.Build());
+        }
+        
+        [Fact]
+        public void ConfigureSecretStore_WithSecretNameWithoutCacheConfiguration_Fails()
+        {
+            // Arrange
+            var builder = new HostBuilder();
+            
+            // Act
+            builder.ConfigureSecretStore((config, stores) =>
+            {
+                stores.AddInMemory(
+                    secretName: "MySecret", 
+                    secretValue: $"secret-{Guid.NewGuid()}", 
+                    cacheConfiguration: null);
+            });
+            
+            // Assert
+            Assert.ThrowsAny<ArgumentException>(() => builder.Build());
+        }
+
+        [Fact]
+        public void ConfiguresSecretStore_WithSecretsWithoutCacheConfiguration_Fails()
+        {
+            // Arrange
+            var builder = new HostBuilder();
+            
+            // Act
+            builder.ConfigureSecretStore((config, stores) =>
+            {
+                stores.AddInMemory(secrets: new Dictionary<string, string>
+                {
+                    ["MySecret"] = $"secret-{Guid.NewGuid()}"
+                }, cacheConfiguration: null);
+            });
+            
+            // Assert
+            Assert.ThrowsAny<ArgumentException>(() => builder.Build());
+        }
+
+        [Fact]
+        public void ConfigureSecretStore_WithoutCacheConfiguration_Fails()
+        {
+            // Arrange
+            var builder = new HostBuilder();
+            
+            // Act
+            builder.ConfigureSecretStore((config, stores) =>
+            {
+                stores.AddInMemory(cacheConfiguration: null);
+            });
+            
+            // Assert
+            Assert.ThrowsAny<ArgumentException>(() => builder.Build());
+        }
+    }
+}

--- a/src/Arcus.Testing.sln
+++ b/src/Arcus.Testing.sln
@@ -11,6 +11,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Arcus.Testing.Tests.Unit", 
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{64013B91-7B1E-4F88-8FD7-CCF583D4A4CA}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Arcus.Testing.Security.Providers.InMemory", "Arcus.Testing.Security.Providers.InMemory\Arcus.Testing.Security.Providers.InMemory.csproj", "{13FFF971-9F7E-4350-B193-85F6485F41B7}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -29,6 +31,10 @@ Global
 		{3D66B14F-2CC7-44E6-A53F-1E45F9A6BCF6}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3D66B14F-2CC7-44E6-A53F-1E45F9A6BCF6}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3D66B14F-2CC7-44E6-A53F-1E45F9A6BCF6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{13FFF971-9F7E-4350-B193-85F6485F41B7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{13FFF971-9F7E-4350-B193-85F6485F41B7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{13FFF971-9F7E-4350-B193-85F6485F41B7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{13FFF971-9F7E-4350-B193-85F6485F41B7}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Adds a in-memory `ISecretProvider` implementation for testing purposes with necessary extensions to easily register the instance in the secret store.

Closes #34 