### PR TITLE
fix: add Semantic config

### DIFF
--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -1,0 +1,3 @@
+# Configuration for Semantic Pull Requests PR validation, see https://github.com/zeke/semantic-pull-requests#configuration for full reference
+# Always validate the PR title, and ignore the commits
+titleOnly: true


### PR DESCRIPTION
Adds Semantic config so that it only validates the PR's title.
Relates to https://github.com/arcus-azure/arcus/issues/121