### PR TITLE
feat: add exception explicitly to the test output

### DIFF
--- a/src/Arcus.Testing.Logging/XunitTestLogger.cs
+++ b/src/Arcus.Testing.Logging/XunitTestLogger.cs
@@ -32,7 +32,14 @@ namespace Arcus.Testing.Logging
         public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
         {
             var message = formatter(state, exception);
-            _testOutput.WriteLine($"{DateTimeOffset.UtcNow:s} {logLevel} > {message}");
+            if (exception is null)
+            {
+                _testOutput.WriteLine($"{DateTimeOffset.UtcNow:s} {logLevel} > {message}");
+            }
+            else
+            {
+                _testOutput.WriteLine($"{DateTimeOffset.UtcNow:s} {logLevel} > {message}: {exception}");
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
When a failure occurred, it wasn't always shown in the test output. This will make sure it's always shown if it's passed along.

Closes #38