### PR TITLE
feat: add serilog in-memory log sink

### DIFF
--- a/docs/preview/features/logging.md
+++ b/docs/preview/features/logging.md
@@ -110,7 +110,7 @@ logger.LogInformation("This is an informational message");
 IEnumerable<string> messages = logger.Messages;
 ```
 
-## Srilog in-memory log sink
+## Serilog in-memory log sink
 
 The `Arcus.Testing.Logging` library provides a `InMemoryLogSink` which is a [Serilog log sink](https://github.com/serilog/serilog/wiki/Configuration-Basics#sinks) 
 that collectes written log emits in-memory so the test infrastructure can assert on the actual rendered messages and possible properties available on the log emit.

--- a/docs/preview/features/logging.md
+++ b/docs/preview/features/logging.md
@@ -5,6 +5,11 @@ layout: default
 
 # Logging
 
+This page describes functionality related to logging in tests.
+* [xUnit test logging](#xunit-test-logging)
+* [In-memory test logging](#in-memory-test-logging)
+* [Serilog in-memory log sink](#serilog-in-memory-log-sink)
+
 ## Installation
 
 The following functionality is available when installing this package:
@@ -77,7 +82,7 @@ using Microsoft.Extensions.Logging;
 
 ILogger logger = new InMemoryLogger();
 
-logger.LogInformation("This is a informational message");
+logger.LogInformation("This is an informational message");
 
 // Either get the message directly, or
 IEnumerable<string> messages = logger.Messages;
@@ -100,7 +105,29 @@ using Microsoft.Extensions.Logging;
 
 ILogger<MyType> logger = new InMemoryLogger<MyType>();
 
-logger.LogInformation("This is a informational message");
+logger.LogInformation("This is an informational message");
 
 IEnumerable<string> messages = logger.Messages;
+```
+
+## Srilog in-memory log sink
+
+The `Arcus.Testing.Logging` library provides a `InMemoryLogSink` which is a [Serilog log sink](https://github.com/serilog/serilog/wiki/Configuration-Basics#sinks) 
+that collectes written log emits in-memory so the test infrastructure can assert on the actual rendered messages and possible properties available on the log emit.
+
+```csharp
+using Arcus.Testing.Logging;
+using Serilog;
+using Serilog.Core;
+using Serilog.Events;
+
+var logSink = new InMemoryLogSink();
+var logger = new LoggerConfiguration()
+    .WriteTo.Sink(logSink)
+    .CreateLogger();
+
+logger.Information("This is an informational message");
+
+IEnumerable<LogEvent> emits = logSink.CurrentLogEmits;
+IEnumeratble<string> messages = logSink.CurrentLogMessages;
 ```

--- a/src/Arcus.Testing.Logging/Arcus.Testing.Logging.csproj
+++ b/src/Arcus.Testing.Logging/Arcus.Testing.Logging.csproj
@@ -20,6 +20,7 @@
   <ItemGroup>
     <PackageReference Include="Guard.Net" Version="1.2.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.8" />
+    <PackageReference Include="Serilog" Version="2.10.0" />
     <PackageReference Include="xunit.abstractions" Version="2.0.1" />
   </ItemGroup>
 

--- a/src/Arcus.Testing.Logging/InMemoryLogSink.cs
+++ b/src/Arcus.Testing.Logging/InMemoryLogSink.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
+using GuardNet;
 using Serilog.Core;
 using Serilog.Events;
 
@@ -29,6 +30,7 @@ namespace Arcus.Testing.Logging
         /// <param name="logEvent">The log event to write.</param>
         public void Emit(LogEvent logEvent)
         {
+            Guard.NotNull(logEvent, nameof(logEvent), "Requires a Serilog log event to be collected in-memory");
             _logEmits.Enqueue(logEvent);
         }
     }

--- a/src/Arcus.Testing.Logging/InMemoryLogSink.cs
+++ b/src/Arcus.Testing.Logging/InMemoryLogSink.cs
@@ -1,0 +1,35 @@
+﻿using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using Serilog.Core;
+using Serilog.Events;
+
+namespace Arcus.Testing.Logging
+{
+    /// <summary>
+    /// Represents a logging sink that collects the emitted log events in-memory.
+    /// </summary>
+    public class InMemoryLogSink : ILogEventSink
+    {
+        private readonly ConcurrentQueue<LogEvent> _logEmits = new ConcurrentQueue<LogEvent>();
+        
+        /// <summary>
+        /// Gets the current log emits available on the sink.
+        /// </summary>
+        public IEnumerable<LogEvent> CurrentLogEmits => _logEmits.ToArray();
+
+        /// <summary>
+        /// Gets the current messages of the log emits available on the sink.
+        /// </summary>
+        public IEnumerable<string> CurrentLogMessages => CurrentLogEmits.Select(emit => emit.RenderMessage());
+        
+        /// <summary>
+        /// Emit the provided log event to the sink.
+        /// </summary>
+        /// <param name="logEvent">The log event to write.</param>
+        public void Emit(LogEvent logEvent)
+        {
+            _logEmits.Enqueue(logEvent);
+        }
+    }
+}

--- a/src/Arcus.Testing.Logging/InMemoryLogger.cs
+++ b/src/Arcus.Testing.Logging/InMemoryLogger.cs
@@ -12,17 +12,17 @@ namespace Arcus.Testing.Logging
     /// </summary>
     public class InMemoryLogger : ILogger
     {
-        private readonly ConcurrentBag<LogEntry> _entries = new ConcurrentBag<LogEntry>();
+        private readonly ConcurrentQueue<LogEntry> _entries = new ConcurrentQueue<LogEntry>();
 
         /// <summary>
         /// Gets the current logged messages.
         /// </summary>
-        public IEnumerable<string> Messages => _entries.Select(e => e.Message).Reverse();
+        public IEnumerable<string> Messages => _entries.Select(e => e.Message);
 
         /// <summary>
         /// Gets the current logged entries.
         /// </summary>
-        public IEnumerable<LogEntry> Entries => _entries.AsEnumerable().Reverse();
+        public IEnumerable<LogEntry> Entries => _entries.AsEnumerable();
 
         /// <summary>Writes a log entry.</summary>
         /// <param name="logLevel">Entry will be written on this level.</param>
@@ -38,7 +38,7 @@ namespace Arcus.Testing.Logging
             string message = formatter(state, exception);
 
             var entry = new LogEntry(eventId, logLevel, message, exception);
-            _entries.Add(entry);
+            _entries.Enqueue(entry);
         }
 
         /// <summary>

--- a/src/Arcus.Testing.Tests.Unit/Logging/InMemoryLogSinkTests.cs
+++ b/src/Arcus.Testing.Tests.Unit/Logging/InMemoryLogSinkTests.cs
@@ -73,5 +73,15 @@ namespace Arcus.Testing.Tests.Unit.Logging
                 message => Assert.Equal(errorMessage, message), 
                 message => Assert.Equal(traceMessage, message));
         }
+
+        [Fact]
+        public void Emit_WithoutLogEvent_Fails()
+        {
+            // Arrange
+            var sink = new InMemoryLogSink();
+            
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(() => sink.Emit(logEvent: null));
+        }
     }
 }

--- a/src/Arcus.Testing.Tests.Unit/Logging/InMemoryLogSinkTests.cs
+++ b/src/Arcus.Testing.Tests.Unit/Logging/InMemoryLogSinkTests.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using Arcus.Testing.Logging;
+using Bogus;
+using Serilog;
+using Serilog.Core;
+using Serilog.Events;
+using Xunit;
+
+namespace Arcus.Testing.Tests.Unit.Logging
+{
+    [Trait(name: "Category", value: "Unit")]
+    public class InMemoryLogSinkTests
+    {
+        private static readonly Faker BogusGenerator = new Faker();
+        
+        [Fact]
+        public void LogsEvent_WithTestSink_CollectsEmits()
+        {
+            // Arrange
+            string expected = BogusGenerator.Lorem.Sentence();
+            var spySink = new InMemoryLogSink();
+            var configuration = new LoggerConfiguration().WriteTo.Sink(spySink);
+            using (Logger logger = configuration.CreateLogger())
+            {
+                // Act
+                logger.Information(expected);
+            }
+
+            // Assert
+            LogEvent logEvent = Assert.Single(spySink.CurrentLogEmits);
+            Assert.Equal(LogEventLevel.Information, logEvent.Level);
+            Assert.Equal(expected, logEvent.RenderMessage());
+            string actual = Assert.Single(spySink.CurrentLogMessages);
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void LogEvents_WithTestSink_CollectsFirstInFirstOut()
+        {
+            // Arrange
+            Exception exception = BogusGenerator.System.Exception();
+            string errorMessage = BogusGenerator.Lorem.Sentence();
+            string traceMessage = BogusGenerator.Lorem.Sentence();
+            
+            var spySink = new InMemoryLogSink();
+            var configuration = 
+                new LoggerConfiguration()
+                    .MinimumLevel.Verbose()
+                    .WriteTo.Sink(spySink);
+            
+            using (Logger logger = configuration.CreateLogger())
+            {
+                // Act
+                logger.Error(exception, errorMessage);
+                logger.Verbose(traceMessage);
+            }
+
+            // Assert
+            Assert.Collection(spySink.CurrentLogEmits,
+                emit =>
+                {
+                    Assert.Equal(LogEventLevel.Error, emit.Level);
+                    Assert.Equal(errorMessage, emit.RenderMessage());
+                    Assert.Equal(exception, emit.Exception);
+                },
+                emit =>
+                {
+                    Assert.Equal(LogEventLevel.Verbose, emit.Level);
+                    Assert.Equal(traceMessage, emit.RenderMessage());
+                });
+            
+            Assert.Collection(spySink.CurrentLogMessages, 
+                message => Assert.Equal(errorMessage, message), 
+                message => Assert.Equal(traceMessage, message));
+        }
+    }
+}


### PR DESCRIPTION
Add Serilog log sink which in-memory collects the log emits so they can be asserted.
This is especially useful when testing opt-in functionality regarding telemetry.