### PR TITLE
chore: update to netstandard2.1

### DIFF
--- a/build/variables/build.yml
+++ b/build/variables/build.yml
@@ -1,4 +1,4 @@
 variables:
-  DotNet.Sdk.Version: '3.1.201'
+  DotNet.Sdk.Version: '6.0.100'
   Project: 'Arcus.Testing'
   Vm.Image: 'ubuntu-latest'

--- a/src/Arcus.Testing.Logging/Arcus.Testing.Logging.csproj
+++ b/src/Arcus.Testing.Logging/Arcus.Testing.Logging.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <Authors>Arcus</Authors>
     <Company>Arcus</Company>
     <Description>Provides logging capabilities during Arcus testing</Description>
@@ -19,7 +19,7 @@
 
   <ItemGroup>
     <PackageReference Include="Guard.Net" Version="1.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.8" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageReference Include="Serilog" Version="2.10.0" />
     <PackageReference Include="xunit.abstractions" Version="2.0.1" />
   </ItemGroup>

--- a/src/Arcus.Testing.Logging/Arcus.Testing.Logging.csproj
+++ b/src/Arcus.Testing.Logging/Arcus.Testing.Logging.csproj
@@ -19,7 +19,7 @@
 
   <ItemGroup>
     <PackageReference Include="Guard.Net" Version="1.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.8" />
     <PackageReference Include="Serilog" Version="2.10.0" />
     <PackageReference Include="xunit.abstractions" Version="2.0.1" />
   </ItemGroup>

--- a/src/Arcus.Testing.Security.Providers.InMemory/Arcus.Testing.Security.Providers.InMemory.csproj
+++ b/src/Arcus.Testing.Security.Providers.InMemory/Arcus.Testing.Security.Providers.InMemory.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <Authors>Arcus</Authors>
     <Company>Arcus</Company>
     <Description>Provides security capabilities during Arcus testing</Description>
@@ -20,7 +20,7 @@
   <ItemGroup>
     <PackageReference Include="Arcus.Security.Core" Version="1.5.0" />
     <PackageReference Include="Guard.Net" Version="1.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.8" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Arcus.Testing.Tests.Integration/Arcus.Testing.Tests.Integration.csproj
+++ b/src/Arcus.Testing.Tests.Integration/Arcus.Testing.Tests.Integration.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/Arcus.Testing.Tests.Unit/Arcus.Testing.Tests.Unit.csproj
+++ b/src/Arcus.Testing.Tests.Unit/Arcus.Testing.Tests.Unit.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 


### PR DESCRIPTION
Updates the projects from `netstandard2.0` to `netstandard2.1`.

Relates to https://github.com/arcus-azure/arcus/issues/106