### PR TITLE
chore: use version ranges for Arcus deps

### DIFF
--- a/src/Arcus.Testing.Security.Providers.InMemory/Arcus.Testing.Security.Providers.InMemory.csproj
+++ b/src/Arcus.Testing.Security.Providers.InMemory/Arcus.Testing.Security.Providers.InMemory.csproj
@@ -18,7 +18,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Arcus.Security.Core" Version="1.5.0" />
+    <PackageReference Include="Arcus.Security.Core" Version="[1.5.0,2.0.0)" />
     <PackageReference Include="Guard.Net" Version="1.2.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
   </ItemGroup>


### PR DESCRIPTION
Use NuGet version ranges for Arcus packages.

Relates to https://github.com/arcus-azure/arcus/issues/129