### PR TITLE
feat: add test az servicebus message pump

### DIFF
--- a/docs/preview/features/servicebus-messsage-pump.md
+++ b/docs/preview/features/servicebus-messsage-pump.md
@@ -14,7 +14,7 @@ PM> Install-Package -Name Arcus.Testing.Messaging.Pumps.ServiceBus
 
 ## Test Azure Service Bus message pump
 As an addition on the [Arcus Azure Service Bus message pump](https://messaging.arcus-azure.net/Features/message-handling/service-bus), we have provided a test version of the message pump to verify your custom Azure Service Bus message handler implementations.
-These hander implementations can be tested separately, and could be tested by interacting with the message router directly, but simulating messages like it would be from Azure Service Bus itself is a bit ticker.
+These hander implementations can be tested separately, and could be tested by interacting with the message router directly, but simulating messages like it would be from Azure Service Bus itself is a bit trickier.
 This test message pump functionality allows you to verify certain cases without the need of an actual Azure resource.
 
 We provide an extension that acts as an Azure Service Bus message pump and lets you decide how messages should be produced.

--- a/docs/preview/features/servicebus-messsage-pump.md
+++ b/docs/preview/features/servicebus-messsage-pump.md
@@ -1,0 +1,179 @@
+﻿---
+title: Testing Azure Service Bus message handling
+layout: default
+---
+
+# Testing Azure Service Bus message handling
+
+## Installation
+The following functionality is available when installing this package:
+
+```shell
+PM> Install-Package -Name Arcus.Testing.Messaging.Pumps.ServiceBus
+```
+
+## Test Azure Service Bus message pump
+As an addition on the [Arcus Azure Service Bus message pump](), we have provided a test version of the message pump to verify your custom Azure Service Bus message handler implementations.
+These hander implementations can be tested separately, and could be tested by interacting with the message router directly, but simulating messages like it would be from Azure Service Bus itself is a bit ticker.
+This test message pump functionality allows you to verify certain cases without the need of an actual Azure resource.
+
+We provide an extension that acts as an Azure Service Bus message pump and lets you decide how messages should be produced.
+
+Consider the following message handler implementations to test:
+```csharp
+using Arcus.Messaging.Abstractions;
+using Arcus.Messaging.Abstractions.ServiceBus;
+using Arcus.Messaging.Abstractions.ServiceBus.MessageHandling;
+
+public class OrderAzureServiceBusMessageHandler : IAzureServiceBusMessageHandler<Order>
+{
+    public async Task ProcessMessageAsync(
+        Order message,
+        AzureServiceBusMessageContext context,
+        MessageCorrelationInfo correlationInfo,
+        CancellationToken cancellationToken)
+    {
+        // Proces order...
+    }
+}
+
+public class ShipmentAzureServiceBusMessageHandler : IAzureServiceBusMessageHandler<Shipment>
+{
+    public async Task ProcessMessageAsync(
+        Shipment message,
+        AzureServiceBusMessageContext context,
+        MessageCorrelationInfo correlationInfo,
+        CancellationToken cancellationToken)
+    {
+        // Proces order...
+    }
+}
+```
+
+Testing these together requires us to register them into an application. The following example shows how instead of calling `.AddServiceBusMessagePump(...)`, you can call the testing variant `.AddTestServiceBusMessagePump(...)`.
+The extension allows you to pass in a 'message producer'. This producer allows you to control which kind of messages the test message pump should simulate. This example shows how a single `Order` message can be added to the message pump.
+
+```csharp
+using System;
+using Xunit;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+public class MessageHandlingTests
+{
+    private readonly ITestOutputWriter _outputWriter;
+
+    public MessageHandlingTests(ITestOutputWriter outputWriter)
+    {
+        _outputWriter = outputWriter;
+    }
+
+    [Fact]
+    public async Task RegisterOrderAndShipmentMessageHandler_PublishOrder_ProcessOrderCorrectly()
+    {
+        // Arrange
+        var order = new Order(orderId: "123", scheduled: DateTimeOffset.UtcNow);
+        var handler = new OrderAzureServiceBusMessageHandler();
+
+        IHostBuilder builder =
+            Host.CreateDefaultBuilder()
+                .ConfigureLogging(logging => logging.AddXunitTestLogging(_outputWriter))
+                .ConfigureServices(services =>
+                {
+                    services.AddTestServiceBusMessagePump(producer => producer.AddMessageBody(order))
+                            .WithServiceBusMessageHandler<OrderAzureServiceBusMessageHandler, Order>(provider => handler)
+                            .WithServiceBusMessageHandler<ShipmentAzureServiceBusMessageHandler, Shipment>();
+                });
+
+        using (IHost host = builder.Build())
+        {
+            try
+            {
+                // Act
+                host.StartAsync();
+
+                // Assert
+                Assert.True(handler.IsProcessed);
+            }
+            finally
+            {
+                await host.StopAsync();
+            }
+        }
+    }
+}
+```
+
+Note that in this example, we use `Assert.True(handler.IsProcessed)` to determine if the `Order` message was correctly processed. In your application, you may want to inject your message handlers with test versions of dependencies and determine via those dependencies if the correct message handler was called.
+You can use one of the `.WithServiceBusMessageHandler<,>(...)` extensions to pass in your instance of the message handler so you can use it later in the test assertion, like it is shown in the example.
+
+> 💡 Note that the example uses `logging.AddXunitTestLogging`. This is available in the `Arcus.Testing.Logging` package. See [this page on logging](./logging.md) for more information.
+
+## Message producer configuration
+The test message pump can be configured extensively to meet your needs. You can even pass in your own implementation of a test message producer to have full control over how the Azure Service Bus messages should look like.
+When a custom message body is passed, an `ServiceBusReceivedMessage` will be created with the [correlation properties]() already filled out. This allows for you to also test any the correlation specific functionality in your message handlers.
+
+```csharp
+services.AddTestServiceBusMessagePump(producer =>
+{
+    // Pass in a single custom message, which will become a `ServiceBusReceivedMessage`.
+    producer.AddMessageBody(order);
+
+    // Pass in multiple custom messages, which will become `ServiceBusReceivedMessage` instances.
+    producer.AddMessageBodies(orders);
+
+    // Pass in your own `ServiceBusReceivedMessage`.
+    // 💡 Use Microsoft's `ServiceBusModelFactory` to create such messages.
+    var message = ServiceBusModelFactory.ServiceBusReceivedMessage(
+        body: BinaryData.FromObjectAsJson(shipment),
+        messageId: Guid.NewGuid().ToString());
+    producer.AddMessage(message);
+
+    // Pass in your own `ServiceBusReceivedMessage` instances.
+    // 💡 Use Microsoft's `ServiceBusModelFactory` to create such messages.
+    var message = ServiceBusModelFactory.ServiceBusReceivedMessage(
+        body: BinaryData.FromObjectAsJson(shipment),
+        messageId: Guid.NewGuid().ToString());
+    producer.AddMessages(new[] { message });
+});
+```
+
+If the creation of Azure Service Bus messages is rather complex, you require asynchronous serialization, or you want to re-use your message producing; you can implement your own message producer.
+This requires you to implement the `IAzureServiceBusMessageProducer` interface.
+```csharp
+public class MyTestMessageProducer : IAzureServiceBusMessageProducer
+{
+    public async Task<ServiceBusReceivedMessage[]> ProduceMessagesAsync()
+    {
+        var order = new Order(orderId: "123", scheduled: DateTimeOffset.UtcNow);
+
+        var message = ServiceBusModelFactory.ServiceBusReceivedMessage(
+            body: BinaryData.FromObjectAsJson(shipment),
+            messageId: Guid.NewGuid().ToString(),
+            properties: new Dictionary<string, object>
+            {
+                ["X-My-Custom-Key"] = "My-Custom-Value"
+            });
+
+        return Task.FromResult(new[] { message });
+    }
+}
+```
+
+Such implementation can be pased along during the registration:
+```csharp
+var producer = new MyTestMessageProducer();
+services.AddTestServiceBusMessagePump(producer);
+```
+
+## Message routing configuration
+The test Azure Service Bus registration internally uses the Azure Service Bus message router. To configure this router, use one of the extension overloads. This gives you access to the message router options, like in a general Azure Service Bus message pump registration.
+```csharp
+services.AddTestServiceBusMessagePump(..., options =>
+{
+    options.Deserialization.AdditionalMembers = AdditionalMemberHandling.Error
+});
+```
+
+For more information on the message router options, see the [Arcus messaging feature documentation]().

--- a/docs/preview/features/servicebus-messsage-pump.md
+++ b/docs/preview/features/servicebus-messsage-pump.md
@@ -13,7 +13,7 @@ PM> Install-Package -Name Arcus.Testing.Messaging.Pumps.ServiceBus
 ```
 
 ## Test Azure Service Bus message pump
-As an addition on the [Arcus Azure Service Bus message pump](), we have provided a test version of the message pump to verify your custom Azure Service Bus message handler implementations.
+As an addition on the [Arcus Azure Service Bus message pump](https://messaging.arcus-azure.net/Features/message-handling/service-bus), we have provided a test version of the message pump to verify your custom Azure Service Bus message handler implementations.
 These hander implementations can be tested separately, and could be tested by interacting with the message router directly, but simulating messages like it would be from Azure Service Bus itself is a bit ticker.
 This test message pump functionality allows you to verify certain cases without the need of an actual Azure resource.
 
@@ -112,7 +112,7 @@ You can use one of the `.WithServiceBusMessageHandler<,>(...)` extensions to pas
 
 ## Message producer configuration
 The test message pump can be configured extensively to meet your needs. You can even pass in your own implementation of a test message producer to have full control over how the Azure Service Bus messages should look like.
-When a custom message body is passed, an `ServiceBusReceivedMessage` will be created with the [correlation properties]() already filled out. This allows for you to also test any the correlation specific functionality in your message handlers.
+When a custom message body is passed, an `ServiceBusReceivedMessage` will be created with the [correlation properties](https://messaging.arcus-azure.net/Features/message-handling/service-bus#message-correlation) already filled out. This allows for you to also test any the correlation specific functionality in your message handlers.
 
 ```csharp
 services.AddTestServiceBusMessagePump(producer =>
@@ -176,4 +176,4 @@ services.AddTestServiceBusMessagePump(..., options =>
 });
 ```
 
-For more information on the message router options, see the [Arcus messaging feature documentation]().
+For more information on the message router options, see the [Arcus messaging feature documentation](https://messaging.arcus-azure.net/Features/message-handling/service-bus#pump-configuration).

--- a/src/Arcus.Testing.Messaging.Pumps.ServiceBus/Arcus.Testing.Messaging.Pumps.ServiceBus.csproj
+++ b/src/Arcus.Testing.Messaging.Pumps.ServiceBus/Arcus.Testing.Messaging.Pumps.ServiceBus.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net6.0;netcoreapp3.1;netstandard2.1</TargetFrameworks>
+    <Authors>Arcus</Authors>
+    <Company>Arcus</Company>
+    <Description>Provides messaging capabilities during Arcus testing</Description>
+    <Copyright>Copyright (c) Arcus</Copyright>
+    <PackageLicenseUrl>https://github.com/arcus-azure/arcus.testing/blob/master/LICENSE</PackageLicenseUrl>
+    <PackageProjectUrl>https://github.com/arcus-azure/arcus.testing</PackageProjectUrl>
+    <PackageIconUrl>https://raw.githubusercontent.com/arcus-azure/arcus/master/media/arcus.png</PackageIconUrl>
+    <RepositoryUrl>https://github.com/arcus-azure/arcus.testing</RepositoryUrl>
+    <RepositoryType>Git</RepositoryType>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageTags>Azure;Testing;Messaging;Pumps;ServiceBus</PackageTags>
+    <PackageId>Arcus.Testing.Messaging.Pumps.ServiceBus</PackageId>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <NoWarn>NU5125;NU5048</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Arcus.Messaging.Pumps.ServiceBus" Version="[1.3.0,2.0.0)" />
+  </ItemGroup>
+
+</Project>

--- a/src/Arcus.Testing.Messaging.Pumps.ServiceBus/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Arcus.Testing.Messaging.Pumps.ServiceBus/Extensions/IServiceCollectionExtensions.cs
@@ -1,0 +1,100 @@
+﻿using System;
+using Arcus.Messaging.Abstractions.ServiceBus.MessageHandling;
+using Arcus.Testing.Messaging.Pumps.ServiceBus;
+using GuardNet;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+// ReSharper disable once CheckNamespace
+namespace Microsoft.Extensions.DependencyInjection
+{
+    /// <summary>
+    /// Represents a set of extensions on the <see cref="IServiceCollection"/> to easily add the <see cref="TestServiceBusMessagePump"/>.
+    /// </summary>
+    // ReSharper disable once InconsistentNaming
+    public static class IServiceCollectionExtensions
+    {
+        /// <summary>
+        /// Adds a test Azure Service Bus message pump to simulate received messages.
+        /// </summary>
+        /// <param name="services">The available registered services in the application.</param>
+        /// <param name="configureProducer">The function to configure the message producer which will simulate messages on the message pump.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="services"/> or the <paramref name="configureProducer"/> is <c>null</c>.</exception>
+        public static ServiceBusMessageHandlerCollection AddTestServiceBusMessagePump(
+            this IServiceCollection services,
+            Action<TestAzureServiceBusMessageProducer> configureProducer)
+        {
+            Guard.NotNull(services, nameof(services), "Requires a series of registered application services to add the test Azure Service Bus message pump");
+            Guard.NotNull(configureProducer, nameof(configureProducer), "Requires a function to configure the message producer which will simulate messages on the message pump");
+
+            return AddTestServiceBusMessagePump(services, configureProducer, configureOptions: null);
+        }
+
+        /// <summary>
+        /// Adds a test Azure Service Bus message pump to simulate received messages.
+        /// </summary>
+        /// <param name="services">The available registered services in the application.</param>
+        /// <param name="configureProducer">The function to configure the message producer which will simulate messages on the message pump.</param>
+        /// <param name="configureOptions">The additional message routing options to configure the message router that will process the simulated messages.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="services"/> or the <paramref name="configureProducer"/> is <c>null</c>.</exception>
+        public static ServiceBusMessageHandlerCollection AddTestServiceBusMessagePump(
+            this IServiceCollection services,
+            Action<TestAzureServiceBusMessageProducer> configureProducer,
+            Action<AzureServiceBusMessageRouterOptions> configureOptions)
+        {
+            Guard.NotNull(services, nameof(services), "Requires a series of registered application services to add the test Azure Service Bus message pump");
+            Guard.NotNull(configureProducer, nameof(configureProducer), "Requires a function to configure the message producer which will simulate messages on the message pump");
+
+            var producer = new TestAzureServiceBusMessageProducer();
+            configureProducer(producer);
+
+            return AddTestServiceBusMessagePump(services, producer, configureOptions);
+        }
+
+        /// <summary>
+        /// Adds a test Azure Service Bus message pump to simulate received messages.
+        /// </summary>
+        /// <param name="services">The available registered services in the application.</param>
+        /// <param name="messageProducer">The function to configure the message producer which will simulate messages on the message pump.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="services"/> or the <paramref name="messageProducer"/> is <c>null</c>.</exception>
+        public static ServiceBusMessageHandlerCollection AddTestServiceBusMessagePump(
+            this IServiceCollection services,
+            IAzureServiceBusMessageProducer messageProducer)
+        {
+            Guard.NotNull(services, nameof(services), "Requires a series of registered application services to add the test Azure Service Bus message pump");
+            Guard.NotNull(messageProducer, nameof(messageProducer), "Requires a message producer instance to simulate messages on the message pump");
+
+            return AddTestServiceBusMessagePump(services, messageProducer, configureOptions: null);
+        }
+
+        /// <summary>
+        /// Adds a test Azure Service Bus message pump to simulate received messages.
+        /// </summary>
+        /// <param name="services">The available registered services in the application.</param>
+        /// <param name="messageProducer">The function to configure the message producer which will simulate messages on the message pump.</param>
+        /// <param name="configureOptions">The additional message routing options to configure the message router that will process the simulated messages.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="services"/> or the <paramref name="messageProducer"/> is <c>null</c>.</exception>
+        public static ServiceBusMessageHandlerCollection AddTestServiceBusMessagePump(
+            this IServiceCollection services,
+            IAzureServiceBusMessageProducer messageProducer,
+            Action<AzureServiceBusMessageRouterOptions> configureOptions)
+        {
+            Guard.NotNull(services, nameof(services), "Requires a series of registered application services to add the test Azure Service Bus message pump");
+            Guard.NotNull(messageProducer, nameof(messageProducer), "Requires a message producer instance to simulate messages on the message pump");
+
+            ServiceBusMessageHandlerCollection collection = services.AddServiceBusMessageRouting(configureOptions);
+            services.AddHostedService(provider =>
+            {
+                var router = provider.GetRequiredService<IAzureServiceBusMessageRouter>();
+
+                ILogger<TestServiceBusMessagePump> logger =
+                    provider.GetService<ILogger<TestServiceBusMessagePump>>()
+                    ?? NullLogger<TestServiceBusMessagePump>.Instance;
+
+                return new TestServiceBusMessagePump(messageProducer, router, logger);
+            });
+
+            return collection;
+        }
+    }
+}

--- a/src/Arcus.Testing.Messaging.Pumps.ServiceBus/IAzureServiceBusMessageProducer.cs
+++ b/src/Arcus.Testing.Messaging.Pumps.ServiceBus/IAzureServiceBusMessageProducer.cs
@@ -1,0 +1,16 @@
+﻿using System.Threading.Tasks;
+using Azure.Messaging.ServiceBus;
+
+namespace Arcus.Testing.Messaging.Pumps.ServiceBus
+{
+    /// <summary>
+    /// Represents a message producer that produces Azure Service Bus messages like it would come from an actual Azure resource.
+    /// </summary>
+    public interface IAzureServiceBusMessageProducer
+    {
+        /// <summary>
+        /// Produce an Azure Service Bus message like it would come from an actual Service Bus resource.
+        /// </summary>
+        Task<ServiceBusReceivedMessage[]> ProduceMessagesAsync();
+    }
+}

--- a/src/Arcus.Testing.Messaging.Pumps.ServiceBus/TestAzureServiceBusMessageProducer.cs
+++ b/src/Arcus.Testing.Messaging.Pumps.ServiceBus/TestAzureServiceBusMessageProducer.cs
@@ -1,0 +1,103 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Arcus.Messaging.Abstractions;
+using Azure.Messaging.ServiceBus;
+using GuardNet;
+using Newtonsoft.Json;
+
+namespace Arcus.Testing.Messaging.Pumps.ServiceBus
+{
+    /// <summary>
+    /// Represents a message producer that produces Azure Service Bus messages like it would come from an actual Azure resource.
+    /// </summary>
+    public class TestAzureServiceBusMessageProducer : IAzureServiceBusMessageProducer
+    {
+        private readonly ICollection<Func<ServiceBusReceivedMessage[]>> _createMessagesCollection = new Collection<Func<ServiceBusReceivedMessage[]>>();
+
+        /// <summary>
+        /// Adds an Azure Service Bus <paramref name="message"/> on the message pump.
+        /// </summary>
+        /// <param name="message">The message to produce on the message pump.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="message"/> is <c>null</c>.</exception>
+        public TestAzureServiceBusMessageProducer AddMessage(ServiceBusReceivedMessage message)
+        {
+            Guard.NotNull(message, nameof(message), "Requires an Azure Service Bus message to produce on the message pump");
+            return AddMessages(new[] { message });
+        }
+
+        /// <summary>
+        /// Adds a series of Azure Service Bus <paramref name="messages"/> on the message pump.
+        /// </summary>
+        /// <param name="messages">The series of messages to produce on the message pump.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="messages"/> is <c>null</c>.</exception>
+        public TestAzureServiceBusMessageProducer AddMessages(IEnumerable<ServiceBusReceivedMessage> messages)
+        {
+            Guard.NotNull(messages, nameof(messages), "Requires a series of Azure Service Bus messages to produce on the message pump");
+
+            _createMessagesCollection.Add(messages.ToArray);
+            return this;
+        }
+
+        /// <summary>
+        /// Add a series of custom <paramref name="message"/> which will result in <see cref="ServiceBusReceivedMessage"/> on the message pump.
+        /// </summary>
+        /// <typeparam name="TMessageBody">The custom type of the message body.</typeparam>
+        /// <param name="message">The series of custom message bodies which will translate to <see cref="ServiceBusReceivedMessage"/> instances.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="message"/> is <c>null</c>.</exception>
+        public TestAzureServiceBusMessageProducer AddMessageBody<TMessageBody>(TMessageBody message)
+        {
+            return AddMessageBodies(new[] { message });
+        }
+
+        /// <summary>
+        /// Add a series of custom <paramref name="messages"/> which will result in <see cref="ServiceBusReceivedMessage"/> on the message pump.
+        /// </summary>
+        /// <typeparam name="TMessageBody">The custom type of the message body.</typeparam>
+        /// <param name="messages">The series of custom message bodies which will translate to <see cref="ServiceBusReceivedMessage"/> instances.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="messages"/> is <c>null</c>.</exception>
+        public TestAzureServiceBusMessageProducer AddMessageBodies<TMessageBody>(IEnumerable<TMessageBody> messages)
+        {
+            Guard.NotNull(messages, nameof(messages), "Requires a series of message bodies to produce Azure Service Bus messages to the message pump");
+
+            ServiceBusReceivedMessage CreateServiceBusMessage(TMessageBody message)
+            {
+                BinaryData body = null;
+                if (message != null)
+                {
+                    body = BinaryData.FromObjectAsJson(message); 
+                }
+
+                return ServiceBusModelFactory.ServiceBusReceivedMessage(
+                    body: body, 
+                    messageId: Guid.NewGuid().ToString(),
+                    correlationId: Guid.NewGuid().ToString(),
+                    properties: new Dictionary<string, object>
+                    {
+                        [PropertyNames.Encoding] = Encoding.UTF8.WebName,
+                        [PropertyNames.ContentType] = "application/json",
+                        [PropertyNames.TransactionId] = Guid.NewGuid().ToString(),
+                        [PropertyNames.OperationParentId] = Guid.NewGuid().ToString()
+                    });
+            }
+
+            _createMessagesCollection.Add(() => messages.Select(CreateServiceBusMessage).ToArray());
+            return this;
+        }
+
+        /// <summary>
+        /// Produce an Azure Service Bus message like it would come from an actual Service Bus resource.
+        /// </summary>
+        public Task<ServiceBusReceivedMessage[]> ProduceMessagesAsync()
+        {
+            ServiceBusReceivedMessage[] messages = 
+                _createMessagesCollection.SelectMany(createMessages => createMessages())
+                                         .ToArray();
+
+            return Task.FromResult(messages);
+        }
+    }
+}

--- a/src/Arcus.Testing.Messaging.Pumps.ServiceBus/TestServiceBusMessagePump.cs
+++ b/src/Arcus.Testing.Messaging.Pumps.ServiceBus/TestServiceBusMessagePump.cs
@@ -54,14 +54,16 @@ namespace Arcus.Testing.Messaging.Pumps.ServiceBus
         {
             _logger.LogInformation("Started test Azure Service Bus message pump");
 
+            var receiver = new TestServiceBusReceiver();
             ServiceBusReceivedMessage[] messages = await _messageProducer.ProduceMessagesAsync();
+
             foreach (ServiceBusReceivedMessage message in messages)
             {
                 try
                 {
                     AzureServiceBusMessageContext context = message.GetMessageContext(jobId: Guid.NewGuid().ToString());
                     MessageCorrelationInfo correlationInfo = message.GetCorrelationInfo();
-                    await _messageRouter.RouteMessageAsync(message, context, correlationInfo, cancellationToken);
+                    await _messageRouter.RouteMessageAsync(receiver, message, context, correlationInfo, cancellationToken);
                 }
                 catch (Exception exception)
                 {

--- a/src/Arcus.Testing.Messaging.Pumps.ServiceBus/TestServiceBusMessagePump.cs
+++ b/src/Arcus.Testing.Messaging.Pumps.ServiceBus/TestServiceBusMessagePump.cs
@@ -1,0 +1,85 @@
+﻿using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Arcus.Messaging.Abstractions;
+using Arcus.Messaging.Abstractions.ServiceBus;
+using Arcus.Messaging.Abstractions.ServiceBus.MessageHandling;
+using Arcus.Messaging.Pumps.Abstractions;
+using Azure.Messaging.ServiceBus;
+using GuardNet;
+using Microsoft.Azure.ServiceBus;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Arcus.Testing.Messaging.Pumps.ServiceBus
+{
+    /// <summary>
+    /// Represents an <see cref="IHostedService"/> that acts as a <see cref="MessagePump"/> for <see cref="ServiceBusReceivedMessage"/> messages.
+    /// </summary>
+    public class TestServiceBusMessagePump : IHostedService
+    {
+        private readonly IAzureServiceBusMessageProducer _messageProducer;
+        private readonly IAzureServiceBusMessageRouter _messageRouter;
+        private readonly ILogger<TestServiceBusMessagePump> _logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TestServiceBusMessagePump" /> class.
+        /// </summary>
+        /// <param name="messageProducer">The producer instance to simulate received messages on the message pump.</param>
+        /// <param name="messageRouter">The router instance to process the simulated received messages on the message pump.</param>
+        /// <param name="logger">The logger instance to write diagnostic information during the message simulation on the message pump.</param>
+        /// <exception cref="ArgumentNullException">
+        ///     Thrown when the <paramref name="messageProducer"/>, <paramref name="messageRouter"/>, or the <paramref name="logger"/> is <c>null</c>.
+        /// </exception>
+        public TestServiceBusMessagePump(
+            IAzureServiceBusMessageProducer messageProducer,
+            IAzureServiceBusMessageRouter messageRouter,
+            ILogger<TestServiceBusMessagePump> logger)
+        {
+            Guard.NotNull(messageProducer, nameof(messageProducer), "Requires an Azure Service Bus message producer to simulate received messages on the message pump");
+            Guard.NotNull(messageRouter, nameof(messageRouter), "Requires an Azure Service Bus message router to process the simulated received messages on the message pump");
+            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to write diagnostic information during the message simulation on the message pump");
+
+            _messageProducer = messageProducer;
+            _messageRouter = messageRouter;
+            _logger = logger;
+        }
+
+        /// <summary>
+        /// Triggered when the application host is ready to start the service.
+        /// </summary>
+        /// <param name="cancellationToken">Indicates that the start process has been aborted.</param>
+        public async Task StartAsync(CancellationToken cancellationToken)
+        {
+            _logger.LogInformation("Started test Azure Service Bus message pump");
+
+            ServiceBusReceivedMessage[] messages = await _messageProducer.ProduceMessagesAsync();
+            foreach (ServiceBusReceivedMessage message in messages)
+            {
+                try
+                {
+                    AzureServiceBusMessageContext context = message.GetMessageContext(jobId: Guid.NewGuid().ToString());
+                    MessageCorrelationInfo correlationInfo = message.GetCorrelationInfo();
+                    await _messageRouter.RouteMessageAsync(message, context, correlationInfo, cancellationToken);
+                }
+                catch (Exception exception)
+                {
+                    var bodyString = message.Body.ToString();
+                    var  propertiesDescription = $"[{string.Join(", ", message.ApplicationProperties.Select(prop => $"{prop.Key}={prop.Value}"))}]";
+                    _logger.LogCritical(exception, "Failed to route test Azure Service Bus message {MessageId} (Body: {Body}, Properties: {Properties})", message.MessageId, bodyString, propertiesDescription);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Triggered when the application host is performing a graceful shutdown.
+        /// </summary>
+        /// <param name="cancellationToken">Indicates that the shutdown process should no longer be graceful.</param>
+        public Task StopAsync(CancellationToken cancellationToken)
+        {
+            _logger.LogInformation("Stopped test Azure Service Bus message pump");
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Arcus.Testing.Messaging.Pumps.ServiceBus/TestServiceBusReceiver.cs
+++ b/src/Arcus.Testing.Messaging.Pumps.ServiceBus/TestServiceBusReceiver.cs
@@ -1,0 +1,146 @@
+﻿using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Messaging.ServiceBus;
+
+namespace Arcus.Testing.Messaging.Pumps.ServiceBus
+{
+    /// <summary>
+    /// Represents an <see cref="ServiceBusReceiver"/> for testing.
+    /// </summary>
+    public class TestServiceBusReceiver : ServiceBusReceiver
+    {
+#if NET6_0
+        /// <summary>
+        /// The path of the Service Bus entity that the receiver is connected to, specific to the
+        /// Service Bus namespace that contains it.
+        /// </summary>
+        public override string EntityPath { get; } = "Arcus.Testing.EntityPath";
+
+        /// <summary>
+        /// The fully qualified Service Bus namespace that the receiver is associated with.  This is likely
+        /// to be similar to <c>{yournamespace}.servicebus.windows.net</c>.
+        /// </summary>
+        public override string FullyQualifiedNamespace { get; } = "Arcus.Testing.FullyQualifiedNamespace"; 
+#endif
+
+        /// <summary>
+        /// Completes a <see cref="T:Azure.Messaging.ServiceBus.ServiceBusReceivedMessage" />. This will delete the message from the service.
+        /// </summary>
+        /// <param name="message">The message to complete.</param>
+        /// <param name="cancellationToken">An optional <see cref="T:System.Threading.CancellationToken" /> instance to signal the request to cancel the operation.</param>
+        /// <remarks>
+        /// This operation can only be performed on a message that was received by this receiver
+        /// when <see cref="P:Azure.Messaging.ServiceBus.ServiceBusReceiver.ReceiveMode" /> is set to <see cref="F:Azure.Messaging.ServiceBus.ServiceBusReceiveMode.PeekLock" />.
+        /// </remarks>
+        /// <returns>A task to be resolved on when the operation has completed.</returns>
+        /// <exception cref="T:Azure.Messaging.ServiceBus.ServiceBusException">
+        ///   The lock for the message has expired or the message has already been completed. This does not apply for session-enabled
+        ///   entities.
+        ///   The <see cref="P:Azure.Messaging.ServiceBus.ServiceBusException.Reason" /> will be set to <see cref="F:Azure.Messaging.ServiceBus.ServiceBusFailureReason.MessageLockLost" /> in this case.
+        /// </exception>
+        /// <exception cref="T:Azure.Messaging.ServiceBus.ServiceBusException">
+        ///   The lock for the session has expired or the message has already been completed. This only applies for session-enabled
+        ///   entities.
+        ///   The <see cref="P:Azure.Messaging.ServiceBus.ServiceBusException.Reason" /> will be set to <see cref="F:Azure.Messaging.ServiceBus.ServiceBusFailureReason.SessionLockLost" /> in this case.
+        /// </exception>
+        public override Task CompleteMessageAsync(
+            ServiceBusReceivedMessage message,
+            CancellationToken cancellationToken = new CancellationToken())
+        {
+            return Task.CompletedTask;
+        }
+
+        /// <summary>
+        /// Abandons a <see cref="T:Azure.Messaging.ServiceBus.ServiceBusReceivedMessage" />.This will make the message available again for immediate processing as the lock on the message held by the receiver will be released.
+        /// </summary>
+        /// <param name="message">The <see cref="T:Azure.Messaging.ServiceBus.ServiceBusReceivedMessage" /> to abandon.</param>
+        /// <param name="propertiesToModify">The properties of the message to modify while abandoning the message.</param>
+        /// <param name="cancellationToken">An optional <see cref="T:System.Threading.CancellationToken" /> instance to signal the request to cancel the operation.</param>
+        /// <remarks>
+        /// Abandoning a message will increase the delivery count on the message.
+        /// This operation can only be performed on messages that were received by this receiver
+        /// when <see cref="P:Azure.Messaging.ServiceBus.ServiceBusReceiver.ReceiveMode" /> is set to <see cref="F:Azure.Messaging.ServiceBus.ServiceBusReceiveMode.PeekLock" />.
+        /// </remarks>
+        /// <returns>A task to be resolved on when the operation has completed.</returns>
+        /// <exception cref="T:Azure.Messaging.ServiceBus.ServiceBusException">
+        ///   The lock for the message has expired or the message has already been completed. This does not apply for session-enabled
+        ///   entities.
+        ///   The <see cref="P:Azure.Messaging.ServiceBus.ServiceBusException.Reason" /> will be set to <see cref="F:Azure.Messaging.ServiceBus.ServiceBusFailureReason.MessageLockLost" /> in this case.
+        /// </exception>
+        /// <exception cref="T:Azure.Messaging.ServiceBus.ServiceBusException">
+        ///   The lock for the session has expired or the message has already been completed. This only applies for session-enabled
+        ///   entities.
+        ///   The <see cref="P:Azure.Messaging.ServiceBus.ServiceBusException.Reason" /> will be set to <see cref="F:Azure.Messaging.ServiceBus.ServiceBusFailureReason.SessionLockLost" /> in this case.
+        /// </exception>
+        public override Task AbandonMessageAsync(
+            ServiceBusReceivedMessage message,
+            IDictionary<string, object> propertiesToModify = null,
+            CancellationToken cancellationToken = new CancellationToken())
+        {
+            return Task.CompletedTask;
+        }
+
+        /// <summary>Moves a message to the dead-letter subqueue.</summary>
+        /// <param name="message">The <see cref="T:Azure.Messaging.ServiceBus.ServiceBusReceivedMessage" /> to dead-letter.</param>
+        /// <param name="propertiesToModify">The properties of the message to modify while moving to subqueue.</param>
+        /// <param name="cancellationToken">An optional <see cref="T:System.Threading.CancellationToken" /> instance to signal the request to cancel the operation.</param>
+        /// <remarks>
+        /// In order to receive a message from the dead-letter queue or transfer dead-letter queue,
+        /// set the <see cref="P:Azure.Messaging.ServiceBus.ServiceBusReceiverOptions.SubQueue" /> property to <see cref="F:Azure.Messaging.ServiceBus.SubQueue.DeadLetter" />
+        /// or <see cref="F:Azure.Messaging.ServiceBus.SubQueue.TransferDeadLetter" /> when calling
+        /// <see cref="M:Azure.Messaging.ServiceBus.ServiceBusClient.CreateReceiver(System.String,Azure.Messaging.ServiceBus.ServiceBusReceiverOptions)" /> or
+        /// <see cref="M:Azure.Messaging.ServiceBus.ServiceBusClient.CreateReceiver(System.String,System.String,Azure.Messaging.ServiceBus.ServiceBusReceiverOptions)" />.
+        /// This operation can only be performed when <see cref="P:Azure.Messaging.ServiceBus.ServiceBusReceiver.ReceiveMode" /> is set to <see cref="F:Azure.Messaging.ServiceBus.ServiceBusReceiveMode.PeekLock" />.
+        /// </remarks>
+        /// <exception cref="T:Azure.Messaging.ServiceBus.ServiceBusException">
+        ///   The lock for the message has expired or the message has already been completed. This does not apply for session-enabled
+        ///   entities.
+        ///   The <see cref="P:Azure.Messaging.ServiceBus.ServiceBusException.Reason" /> will be set to <see cref="F:Azure.Messaging.ServiceBus.ServiceBusFailureReason.MessageLockLost" /> in this case.
+        /// </exception>
+        /// <exception cref="T:Azure.Messaging.ServiceBus.ServiceBusException">
+        ///   The lock for the session has expired or the message has already been completed. This only applies for session-enabled
+        ///   entities.
+        ///   The <see cref="P:Azure.Messaging.ServiceBus.ServiceBusException.Reason" /> will be set to <see cref="F:Azure.Messaging.ServiceBus.ServiceBusFailureReason.SessionLockLost" /> in this case.
+        /// </exception>
+        public override Task DeadLetterMessageAsync(
+            ServiceBusReceivedMessage message,
+            IDictionary<string, object> propertiesToModify = null,
+            CancellationToken cancellationToken = new CancellationToken())
+        {
+            return Task.CompletedTask;
+        }
+
+        /// <summary>Moves a message to the dead-letter subqueue.</summary>
+        /// <param name="message">The <see cref="T:Azure.Messaging.ServiceBus.ServiceBusReceivedMessage" /> to dead-letter.</param>
+        /// <param name="deadLetterReason">The reason for dead-lettering the message.</param>
+        /// <param name="deadLetterErrorDescription">The error description for dead-lettering the message.</param>
+        /// <param name="cancellationToken">An optional <see cref="T:System.Threading.CancellationToken" /> instance to signal the request to cancel the operation.</param>
+        /// <remarks>
+        /// In order to receive a message from the dead-letter queue or transfer dead-letter queue,
+        /// set the <see cref="P:Azure.Messaging.ServiceBus.ServiceBusReceiverOptions.SubQueue" /> property to <see cref="F:Azure.Messaging.ServiceBus.SubQueue.DeadLetter" />
+        /// or <see cref="F:Azure.Messaging.ServiceBus.SubQueue.TransferDeadLetter" /> when calling
+        /// <see cref="M:Azure.Messaging.ServiceBus.ServiceBusClient.CreateReceiver(System.String,Azure.Messaging.ServiceBus.ServiceBusReceiverOptions)" /> or
+        /// <see cref="M:Azure.Messaging.ServiceBus.ServiceBusClient.CreateReceiver(System.String,System.String,Azure.Messaging.ServiceBus.ServiceBusReceiverOptions)" />.
+        /// This operation can only be performed when <see cref="P:Azure.Messaging.ServiceBus.ServiceBusReceiver.ReceiveMode" /> is set to <see cref="F:Azure.Messaging.ServiceBus.ServiceBusReceiveMode.PeekLock" />.
+        /// </remarks>
+        /// <exception cref="T:Azure.Messaging.ServiceBus.ServiceBusException">
+        ///   The lock for the message has expired or the message has already been completed. This does not apply for session-enabled
+        ///   entities.
+        ///   The <see cref="P:Azure.Messaging.ServiceBus.ServiceBusException.Reason" /> will be set to <see cref="F:Azure.Messaging.ServiceBus.ServiceBusFailureReason.MessageLockLost" /> in this case.
+        /// </exception>
+        /// <exception cref="T:Azure.Messaging.ServiceBus.ServiceBusException">
+        ///   The lock for the session has expired or the message has already been completed. This only applies for session-enabled
+        ///   entities.
+        ///   The <see cref="P:Azure.Messaging.ServiceBus.ServiceBusException.Reason" /> will be set to <see cref="F:Azure.Messaging.ServiceBus.ServiceBusFailureReason.SessionLockLost" /> in this case.
+        /// </exception>
+        public override Task DeadLetterMessageAsync(
+            ServiceBusReceivedMessage message,
+            string deadLetterReason,
+            string deadLetterErrorDescription = null,
+            CancellationToken cancellationToken = new CancellationToken())
+        {
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Arcus.Testing.Tests.Unit/Arcus.Testing.Tests.Unit.csproj
+++ b/src/Arcus.Testing.Tests.Unit/Arcus.Testing.Tests.Unit.csproj
@@ -16,6 +16,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Arcus.Testing.Logging\Arcus.Testing.Logging.csproj" />
+    <ProjectReference Include="..\Arcus.Testing.Messaging.Pumps.ServiceBus\Arcus.Testing.Messaging.Pumps.ServiceBus.csproj" />
     <ProjectReference Include="..\Arcus.Testing.Security.Providers.InMemory\Arcus.Testing.Security.Providers.InMemory.csproj" />
   </ItemGroup>
 

--- a/src/Arcus.Testing.Tests.Unit/Messaging/ServiceBus/Fixture/Container.cs
+++ b/src/Arcus.Testing.Tests.Unit/Messaging/ServiceBus/Fixture/Container.cs
@@ -1,0 +1,10 @@
+﻿using Newtonsoft.Json;
+
+namespace Arcus.Testing.Tests.Unit.Messaging.ServiceBus.Fixture
+{
+    public class Container
+    {
+        [JsonProperty("serialNumber")]
+        public string SerialNumber { get; set; }
+    }
+}

--- a/src/Arcus.Testing.Tests.Unit/Messaging/ServiceBus/Fixture/Order.cs
+++ b/src/Arcus.Testing.Tests.Unit/Messaging/ServiceBus/Fixture/Order.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using Bogus;
+using Newtonsoft.Json;
+
+namespace Arcus.Testing.Tests.Unit.Messaging.ServiceBus.Fixture
+{
+    public class Order
+    {
+        [JsonProperty("orderId")]
+        public string OrderId { get; set; }
+
+        [JsonProperty("product")]
+        public Product Product { get; set; }
+
+        [JsonProperty("scheduled")]
+        public DateTimeOffset Scheduled { get; set; }
+
+        public static Order Generate()
+        {
+            var productGenerator = new Faker<Product>()
+                .RuleFor(p => p.ProductName, faker => faker.Commerce.ProductName());
+
+            var orderGenerator = new Faker<Order>()
+                .RuleFor(o => o.OrderId, faker => faker.Random.Guid().ToString())
+                .RuleFor(o => o.Scheduled, faker => faker.Date.RecentOffset())
+                .RuleFor(o => o.Product, faker => productGenerator.Generate());
+
+            return orderGenerator.Generate();
+        }
+    }
+}

--- a/src/Arcus.Testing.Tests.Unit/Messaging/ServiceBus/Fixture/OrderAzureServiceBusMessageHandler.cs
+++ b/src/Arcus.Testing.Tests.Unit/Messaging/ServiceBus/Fixture/OrderAzureServiceBusMessageHandler.cs
@@ -1,0 +1,149 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Arcus.Messaging.Abstractions;
+using Arcus.Messaging.Abstractions.ServiceBus;
+using Arcus.Messaging.Abstractions.ServiceBus.MessageHandling;
+using Bogus;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace Arcus.Testing.Tests.Unit.Messaging.ServiceBus.Fixture
+{
+    public class Order
+    {
+        [JsonProperty("orderId")]
+        public string OrderId { get; set; }
+
+        [JsonProperty("product")]
+        public Product Product { get; set; }
+
+        [JsonProperty("scheduled")]
+        public DateTimeOffset Scheduled { get; set; }
+
+        public static Order Generate()
+        {
+            var productGenerator = new Faker<Product>()
+                .RuleFor(p => p.ProductName, faker => faker.Commerce.ProductName());
+
+            var orderGenerator = new Faker<Order>()
+                .RuleFor(o => o.OrderId, faker => faker.Random.Guid().ToString())
+                .RuleFor(o => o.Scheduled, faker => faker.Date.RecentOffset())
+                .RuleFor(o => o.Product, faker => productGenerator.Generate());
+
+            return orderGenerator.Generate();
+        }
+    }
+
+    public class Product
+    {
+        [JsonProperty("productName")]
+        public string ProductName { get; set; }
+    }
+
+    public class Shipment
+    {
+        [JsonProperty("container")]
+        public Container Container { get; set; }
+
+        [JsonProperty("arrived")]
+        public DateTimeOffset Arrived { get; set; }
+
+        public static Shipment Generate()
+        {
+            var containerGenerator = new Faker<Container>()
+                .RuleFor(c => c.SerialNumber, faker => faker.Random.AlphaNumeric(12));
+
+            var shipmentGenerator = new Faker<Shipment>()
+                .RuleFor(s => s.Container, faker => containerGenerator.Generate())
+                .RuleFor(s => s.Arrived, faker => faker.Date.RecentOffset());
+
+            return shipmentGenerator.Generate();
+        }
+    }
+
+    public class Container
+    {
+        [JsonProperty("serialNumber")]
+        public string SerialNumber { get; set; }
+    }
+
+    public class OrderAzureServiceBusMessageHandler : IAzureServiceBusMessageHandler<Order>
+    {
+        private readonly Order[] _expected;
+        private int _expectedCount;
+
+        public bool IsProcessed { get; private set; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OrderAzureServiceBusMessageHandler" /> class.
+        /// </summary>
+        public OrderAzureServiceBusMessageHandler(params Order[] expected)
+        {
+            _expected = expected;
+            _expectedCount = 0;
+        }
+
+        public Task ProcessMessageAsync(
+            Order message,
+            AzureServiceBusMessageContext messageContext,
+            MessageCorrelationInfo correlationInfo,
+            CancellationToken cancellationToken)
+        {
+            Assert.Single(_expected, expected =>
+            {
+                return message != null
+                       && message.OrderId == expected.OrderId
+                       && message.Scheduled == expected.Scheduled
+                       && message.Product?.ProductName == expected.Product.ProductName;
+            });
+            IsProcessed = ++_expectedCount == _expected.Length;
+            
+            return Task.CompletedTask;
+        }
+    }
+
+    public class ShipmentAzureServiceBusMessageHandler : IAzureServiceBusMessageHandler<Shipment>
+    {
+        private readonly Shipment[] _expected;
+        private int _expectedCount;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ShipmentAzureServiceBusMessageHandler" /> class.
+        /// </summary>
+        public ShipmentAzureServiceBusMessageHandler()
+        {
+            
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ShipmentAzureServiceBusMessageHandler" /> class.
+        /// </summary>
+        public ShipmentAzureServiceBusMessageHandler(params Shipment[] expected)
+        {
+            _expected = expected;
+        }
+
+        public bool IsProcessed { get; private set; }
+
+        public Task ProcessMessageAsync(
+            Shipment message,
+            AzureServiceBusMessageContext messageContext,
+            MessageCorrelationInfo correlationInfo,
+            CancellationToken cancellationToken)
+        {
+            Assert.Single(_expected, expected =>
+            {
+                return message != null
+                       && message.Arrived == expected.Arrived
+                       && message.Container?.SerialNumber == expected.Container.SerialNumber;
+            });
+            IsProcessed = ++_expectedCount == _expected.Length;
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Arcus.Testing.Tests.Unit/Messaging/ServiceBus/Fixture/OrderAzureServiceBusMessageHandler.cs
+++ b/src/Arcus.Testing.Tests.Unit/Messaging/ServiceBus/Fixture/OrderAzureServiceBusMessageHandler.cs
@@ -1,16 +1,14 @@
-﻿using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading;
+﻿using System.Threading;
 using System.Threading.Tasks;
 using Arcus.Messaging.Abstractions;
 using Arcus.Messaging.Abstractions.ServiceBus;
 using Arcus.Messaging.Abstractions.ServiceBus.MessageHandling;
+using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
 namespace Arcus.Testing.Tests.Unit.Messaging.ServiceBus.Fixture
 {
-    public class OrderAzureServiceBusMessageHandler : IAzureServiceBusMessageHandler<Order>
+    public class OrderAzureServiceBusMessageHandler : AzureServiceBusMessageHandler<Order>
     {
         private readonly Order[] _expected;
         private int _expectedCount;
@@ -20,13 +18,13 @@ namespace Arcus.Testing.Tests.Unit.Messaging.ServiceBus.Fixture
         /// <summary>
         /// Initializes a new instance of the <see cref="OrderAzureServiceBusMessageHandler" /> class.
         /// </summary>
-        public OrderAzureServiceBusMessageHandler(params Order[] expected)
+        public OrderAzureServiceBusMessageHandler(params Order[] expected) : base(NullLogger.Instance)
         {
             _expected = expected;
             _expectedCount = 0;
         }
 
-        public Task ProcessMessageAsync(
+        public override async Task ProcessMessageAsync(
             Order message,
             AzureServiceBusMessageContext messageContext,
             MessageCorrelationInfo correlationInfo,
@@ -40,8 +38,7 @@ namespace Arcus.Testing.Tests.Unit.Messaging.ServiceBus.Fixture
                        && message.Product?.ProductName == expected.Product.ProductName;
             });
             IsProcessed = ++_expectedCount == _expected.Length;
-            
-            return Task.CompletedTask;
+            await CompleteMessageAsync();
         }
     }
 }

--- a/src/Arcus.Testing.Tests.Unit/Messaging/ServiceBus/Fixture/Product.cs
+++ b/src/Arcus.Testing.Tests.Unit/Messaging/ServiceBus/Fixture/Product.cs
@@ -1,0 +1,10 @@
+﻿using Newtonsoft.Json;
+
+namespace Arcus.Testing.Tests.Unit.Messaging.ServiceBus.Fixture
+{
+    public class Product
+    {
+        [JsonProperty("productName")]
+        public string ProductName { get; set; }
+    }
+}

--- a/src/Arcus.Testing.Tests.Unit/Messaging/ServiceBus/Fixture/Shipment.cs
+++ b/src/Arcus.Testing.Tests.Unit/Messaging/ServiceBus/Fixture/Shipment.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using Bogus;
+using Newtonsoft.Json;
+
+namespace Arcus.Testing.Tests.Unit.Messaging.ServiceBus.Fixture
+{
+    public class Shipment
+    {
+        [JsonProperty("container")]
+        public Container Container { get; set; }
+
+        [JsonProperty("arrived")]
+        public DateTimeOffset Arrived { get; set; }
+
+        public static Shipment Generate()
+        {
+            var containerGenerator = new Faker<Container>()
+                .RuleFor(c => c.SerialNumber, faker => faker.Random.AlphaNumeric(12));
+
+            var shipmentGenerator = new Faker<Shipment>()
+                .RuleFor(s => s.Container, faker => containerGenerator.Generate())
+                .RuleFor(s => s.Arrived, faker => faker.Date.RecentOffset());
+
+            return shipmentGenerator.Generate();
+        }
+    }
+}

--- a/src/Arcus.Testing.Tests.Unit/Messaging/ServiceBus/Fixture/ShipmentAzureServiceBusMessageHandler.cs
+++ b/src/Arcus.Testing.Tests.Unit/Messaging/ServiceBus/Fixture/ShipmentAzureServiceBusMessageHandler.cs
@@ -17,7 +17,6 @@ namespace Arcus.Testing.Tests.Unit.Messaging.ServiceBus.Fixture
         /// </summary>
         public ShipmentAzureServiceBusMessageHandler()
         {
-            
         }
 
         /// <summary>

--- a/src/Arcus.Testing.Tests.Unit/Messaging/ServiceBus/Fixture/ShipmentAzureServiceBusMessageHandler.cs
+++ b/src/Arcus.Testing.Tests.Unit/Messaging/ServiceBus/Fixture/ShipmentAzureServiceBusMessageHandler.cs
@@ -1,7 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading;
+﻿using System.Threading;
 using System.Threading.Tasks;
 using Arcus.Messaging.Abstractions;
 using Arcus.Messaging.Abstractions.ServiceBus;
@@ -10,24 +7,31 @@ using Xunit;
 
 namespace Arcus.Testing.Tests.Unit.Messaging.ServiceBus.Fixture
 {
-    public class OrderAzureServiceBusMessageHandler : IAzureServiceBusMessageHandler<Order>
+    public class ShipmentAzureServiceBusMessageHandler : IAzureServiceBusMessageHandler<Shipment>
     {
-        private readonly Order[] _expected;
+        private readonly Shipment[] _expected;
         private int _expectedCount;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ShipmentAzureServiceBusMessageHandler" /> class.
+        /// </summary>
+        public ShipmentAzureServiceBusMessageHandler()
+        {
+            
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ShipmentAzureServiceBusMessageHandler" /> class.
+        /// </summary>
+        public ShipmentAzureServiceBusMessageHandler(params Shipment[] expected)
+        {
+            _expected = expected;
+        }
 
         public bool IsProcessed { get; private set; }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="OrderAzureServiceBusMessageHandler" /> class.
-        /// </summary>
-        public OrderAzureServiceBusMessageHandler(params Order[] expected)
-        {
-            _expected = expected;
-            _expectedCount = 0;
-        }
-
         public Task ProcessMessageAsync(
-            Order message,
+            Shipment message,
             AzureServiceBusMessageContext messageContext,
             MessageCorrelationInfo correlationInfo,
             CancellationToken cancellationToken)
@@ -35,12 +39,11 @@ namespace Arcus.Testing.Tests.Unit.Messaging.ServiceBus.Fixture
             Assert.Single(_expected, expected =>
             {
                 return message != null
-                       && message.OrderId == expected.OrderId
-                       && message.Scheduled == expected.Scheduled
-                       && message.Product?.ProductName == expected.Product.ProductName;
+                       && message.Arrived == expected.Arrived
+                       && message.Container?.SerialNumber == expected.Container.SerialNumber;
             });
             IsProcessed = ++_expectedCount == _expected.Length;
-            
+
             return Task.CompletedTask;
         }
     }

--- a/src/Arcus.Testing.Tests.Unit/Messaging/ServiceBus/TestServiceBusMessagePumpTests.cs
+++ b/src/Arcus.Testing.Tests.Unit/Messaging/ServiceBus/TestServiceBusMessagePumpTests.cs
@@ -1,0 +1,194 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Arcus.Messaging.Abstractions.MessageHandling;
+using Arcus.Testing.Tests.Unit.Messaging.ServiceBus.Fixture;
+using Azure.Messaging.ServiceBus;
+using Bogus;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Arcus.Testing.Tests.Unit.Messaging.ServiceBus
+{
+    public class TestServiceBusMessagePumpTests
+    {
+        private readonly ITestOutputHelper _outputWriter;
+
+        private static readonly Faker BogusGenerator = new Faker();
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TestServiceBusMessagePumpTests" /> class.
+        /// </summary>
+        public TestServiceBusMessagePumpTests(ITestOutputHelper outputWriter)
+        {
+            _outputWriter = outputWriter;
+        }
+
+        [Fact]
+        public async Task TestMessagePump_WithSingleMessageBody_ProcessesCorrectly()
+        {
+            // Arrange
+            var order = Order.Generate();
+            var handler = new OrderAzureServiceBusMessageHandler(order);
+
+            // Act / Assert
+            await StartNewHostAsync(
+                services => services.AddTestServiceBusMessagePump(produce => produce.AddMessageBody(order))
+                                    .WithServiceBusMessageHandler<ShipmentAzureServiceBusMessageHandler, Shipment>()
+                                    .WithServiceBusMessageHandler<OrderAzureServiceBusMessageHandler, Order>(provider => handler), 
+                () => Assert.True(handler.IsProcessed));
+        }
+
+        [Fact]
+        public async Task TestMessagePump_WithUnknownSingleMessageBody_DoesNotProcesses()
+        {
+            // Arrange
+            var order = Order.Generate();
+            var handler = new OrderAzureServiceBusMessageHandler(order);
+            var shipment = Shipment.Generate();
+
+            // Act / Assert
+            await StartNewHostAsync(
+                services => services.AddTestServiceBusMessagePump(produce => produce.AddMessageBody(shipment))
+                                    .WithServiceBusMessageHandler<OrderAzureServiceBusMessageHandler, Order>(provider => handler), 
+                () => Assert.False(handler.IsProcessed));
+        }
+
+        [Fact]
+        public async Task TestMessagePump_WithMultipleMessageBodies_ProcessesCorrectly()
+        {
+            // Arrange
+            IEnumerable<Order> orders = BogusGenerator.Make(10, Order.Generate);
+            var handler = new OrderAzureServiceBusMessageHandler(orders.ToArray());
+
+            // Act / Assert
+            await StartNewHostAsync(
+                services => services.AddTestServiceBusMessagePump(produce => produce.AddMessageBodies(orders))
+                                    .WithServiceBusMessageHandler<ShipmentAzureServiceBusMessageHandler, Shipment>()
+                                    .WithServiceBusMessageHandler<OrderAzureServiceBusMessageHandler, Order>(provider => handler), 
+                () => Assert.True(handler.IsProcessed));
+        }
+
+        [Fact]
+        public async Task TestMessagePump_WithUnknownMultipleMessageBodies_DoesNotProcesses()
+        {
+            // Arrange
+            var order = Order.Generate();
+            var handler = new OrderAzureServiceBusMessageHandler(order);
+            IEnumerable<Shipment> shipments = BogusGenerator.Make(10, Shipment.Generate);
+
+            // Act / Assert
+            await StartNewHostAsync(
+                services => services.AddTestServiceBusMessagePump(produce => produce.AddMessageBodies(shipments))
+                                    .WithServiceBusMessageHandler<OrderAzureServiceBusMessageHandler, Order>(provider => handler), 
+                () => Assert.False(handler.IsProcessed));
+        }
+
+        [Fact]
+        public async Task TestMessagePump_WithSingleMessage_ProcessesCorrectly()
+        {
+            // Arrange
+            var order = Order.Generate();
+            var handler = new OrderAzureServiceBusMessageHandler(order);
+            ServiceBusReceivedMessage message = 
+                ServiceBusModelFactory.ServiceBusReceivedMessage(
+                    body: BinaryData.FromObjectAsJson(order),
+                    messageId: Guid.NewGuid().ToString());
+
+            // Act / Assert
+            await StartNewHostAsync(
+                services => services.AddTestServiceBusMessagePump(produce => produce.AddMessage(message))
+                                    .WithServiceBusMessageHandler<ShipmentAzureServiceBusMessageHandler, Shipment>()
+                                    .WithServiceBusMessageHandler<OrderAzureServiceBusMessageHandler, Order>(provider => handler), 
+                () => Assert.True(handler.IsProcessed));
+        }
+
+        [Fact]
+        public async Task TestMessagePump_WithUnknownSingleMessage_DoesNotProcesses()
+        {
+            // Arrange
+            var order = Order.Generate();
+            var handler = new OrderAzureServiceBusMessageHandler(order);
+            var shipment = Shipment.Generate();
+            ServiceBusReceivedMessage message = ServiceBusModelFactory.ServiceBusReceivedMessage(
+                body: BinaryData.FromObjectAsJson(shipment),
+                messageId: Guid.NewGuid().ToString());
+
+            // Act / Assert
+            await StartNewHostAsync(
+                services => services.AddTestServiceBusMessagePump(produce => produce.AddMessage(message))
+                                    .WithServiceBusMessageHandler<OrderAzureServiceBusMessageHandler, Order>(provider => handler), 
+                () => Assert.False(handler.IsProcessed));
+        }
+
+        [Fact]
+        public async Task TestMessagePump_WithMultipleMessages_ProcessesCorrectly()
+        {
+            // Arrange
+            IEnumerable<Order> orders = BogusGenerator.Make(10, Order.Generate);
+            var handler = new OrderAzureServiceBusMessageHandler(orders.ToArray());
+            IEnumerable<ServiceBusReceivedMessage> messages = orders.Select(order =>
+            {
+                return ServiceBusModelFactory.ServiceBusReceivedMessage(
+                        body: BinaryData.FromObjectAsJson(order),
+                        messageId: Guid.NewGuid().ToString());
+            });
+
+            // Act / Assert
+            await StartNewHostAsync(
+                services => services.AddTestServiceBusMessagePump(produce => produce.AddMessages(messages))
+                                    .WithServiceBusMessageHandler<ShipmentAzureServiceBusMessageHandler, Shipment>()
+                                    .WithServiceBusMessageHandler<OrderAzureServiceBusMessageHandler, Order>(provider => handler), 
+                () => Assert.True(handler.IsProcessed));
+        }
+
+        [Fact]
+        public async Task TestMessagePump_WithUnknownMultipleMessages_DoesNotProcesses()
+        {
+            // Arrange
+            var order = Order.Generate();
+            var handler = new OrderAzureServiceBusMessageHandler(order);
+            IEnumerable<Shipment> shipments = BogusGenerator.Make(10, Shipment.Generate);
+            IEnumerable<ServiceBusReceivedMessage> messages = shipments.Select(shipment =>
+            {
+                return ServiceBusModelFactory.ServiceBusReceivedMessage(
+                    body: BinaryData.FromObjectAsJson(shipment),
+                    messageId: Guid.NewGuid().ToString());
+            });
+
+            // Act / Assert
+            await StartNewHostAsync(
+                services => services.AddTestServiceBusMessagePump(produce => produce.AddMessages(messages))
+                                    .WithServiceBusMessageHandler<OrderAzureServiceBusMessageHandler, Order>(provider => handler), 
+                () => Assert.False(handler.IsProcessed));
+        }
+
+        private async Task StartNewHostAsync(
+            Action<IServiceCollection> configureServices,
+            Action test)
+        {
+            IHostBuilder builder =
+                Host.CreateDefaultBuilder()
+                    .ConfigureLogging(logging => logging.AddXunitTestLogging(_outputWriter))
+                    .ConfigureServices(configureServices);
+
+            using (IHost host = builder.Build())
+            {
+                try
+                {
+                    await host.StartAsync();
+                    test();
+                }
+                finally
+                {
+                    await host.StopAsync();
+                }
+            }
+        }
+    }
+}

--- a/src/Arcus.Testing.sln
+++ b/src/Arcus.Testing.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29409.12
+# Visual Studio Version 17
+VisualStudioVersion = 17.3.32825.248
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Arcus.Testing.Logging", "Arcus.Testing.Logging\Arcus.Testing.Logging.csproj", "{D0484271-ABA1-4C2F-B0ED-E207130C1DE8}"
 EndProject
@@ -11,7 +11,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Arcus.Testing.Tests.Unit", 
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{64013B91-7B1E-4F88-8FD7-CCF583D4A4CA}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Arcus.Testing.Security.Providers.InMemory", "Arcus.Testing.Security.Providers.InMemory\Arcus.Testing.Security.Providers.InMemory.csproj", "{13FFF971-9F7E-4350-B193-85F6485F41B7}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Arcus.Testing.Security.Providers.InMemory", "Arcus.Testing.Security.Providers.InMemory\Arcus.Testing.Security.Providers.InMemory.csproj", "{13FFF971-9F7E-4350-B193-85F6485F41B7}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Arcus.Testing.Messaging.Pumps.ServiceBus", "Arcus.Testing.Messaging.Pumps.ServiceBus\Arcus.Testing.Messaging.Pumps.ServiceBus.csproj", "{3F7076F3-A88B-43B2-84C9-70A9E632012A}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -35,6 +37,10 @@ Global
 		{13FFF971-9F7E-4350-B193-85F6485F41B7}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{13FFF971-9F7E-4350-B193-85F6485F41B7}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{13FFF971-9F7E-4350-B193-85F6485F41B7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3F7076F3-A88B-43B2-84C9-70A9E632012A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3F7076F3-A88B-43B2-84C9-70A9E632012A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3F7076F3-A88B-43B2-84C9-70A9E632012A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3F7076F3-A88B-43B2-84C9-70A9E632012A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Adds a test version of the Azure Service Bus message pump so that messages from Service Bus can be simulated and custom message handlers can be tested together.

Closes #