### PR TITLE
feat: add test event hubs message pump

### DIFF
--- a/docs/preview/features/eventhubs-messsage-pump.md
+++ b/docs/preview/features/eventhubs-messsage-pump.md
@@ -6,7 +6,7 @@ layout: default
 # Testing Azure EventHubs message handling
 
 ## Installation
-The following functionality is available when installing this package:
+Install this package to easily test your EventHubs message handlers:
 
 ```shell
 PM> Install-Package -Name Arcus.Testing.Messaging.Pumps.EventHubs

--- a/docs/preview/features/eventhubs-messsage-pump.md
+++ b/docs/preview/features/eventhubs-messsage-pump.md
@@ -1,0 +1,175 @@
+﻿---
+title: Testing Azure EventHubs message handling
+layout: default
+---
+
+# Testing Azure EventHubs message handling
+
+## Installation
+The following functionality is available when installing this package:
+
+```shell
+PM> Install-Package -Name Arcus.Testing.Messaging.Pumps.EventHubs
+```
+
+## Test Azure EventHubs message pump
+As an addition on the [Arcus Azure EventHubs message pump](https://messaging.arcus-azure.net/Features/message-handling/event-hubs), we have provided a test version of the message pump to verify your custom Azure EventHubs message handler implementations.
+These hander implementations can be tested separately, and could be tested by interacting with the message router directly, but simulating messages like it would be from Azure EventHubs itself is a bit trickier.
+This test message pump functionality allows you to verify certain cases without the need of an actual Azure resource.
+
+We provide an extension that acts as an Azure EventHubs message pump and lets you decide how messages should be produced.
+
+Consider the following message handler implementations to test:
+```csharp
+using Arcus.Messaging.Abstractions;
+using Arcus.Messaging.Abstractions.EventHubs;
+using Arcus.Messaging.Abstractions.EventHubs.MessageHandling;
+
+public class SensorReadingAzureEventHubsMessageHandler : IAzureEventHubsMessageHandler<SensorReading>
+{
+    public async Task ProcessMessageAsync(
+        SensorReading reading,
+        AzureEventHubsMessageContext context,
+        MessageCorrelationInfo correlationInfo,
+        CancellationToken cancellationToken)
+    {
+        // Proces sensor reading...
+    }
+}
+
+public class SensorTelemetryAzureEventHubsMessageHandler : IAzureEventHubsMessageHandler<SensorTelemetry>
+{
+    public async Task ProcessMessageAsync(
+        SensorTelemetry telemetry,
+        AzureEventHubsMessageContext context,
+        MessageCorrelationInfo correlationInfo,
+        CancellationToken cancellationToken)
+    {
+        // Proces sensor telemetry...
+    }
+}
+```
+
+Testing these together requires us to register them into an application. The following example shows how instead of calling `.AddEventHubsMessagePump(...)`, you can call the testing variant `.AddTestEventHubsMessagePump(...)`.
+The extension allows you to pass in a 'message producer'. This producer allows you to control which kind of messages the test message pump should simulate. This example shows how a single `SensorReading` message can be added to the message pump.
+
+```csharp
+using System;
+using Xunit;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+public class MessageHandlingTests
+{
+    private readonly ITestOutputWriter _outputWriter;
+
+    public MessageHandlingTests(ITestOutputWriter outputWriter)
+    {
+        _outputWriter = outputWriter;
+    }
+
+    [Fact]
+    public async Task RegisterSensorReadingAndSensorTelemetryMessageHandler_PublishSensorReading_ProcessSensorReadingCorrectly()
+    {
+        // Arrange
+        var reading = new SensorReading(sensorId: "123", timestamp: DateTimeOffset.UtcNow);
+        var handler = new SensorReadingAzureEventHubsMessageHandler();
+
+        IHostBuilder builder =
+            Host.CreateDefaultBuilder()
+                .ConfigureLogging(logging => logging.AddXunitTestLogging(_outputWriter))
+                .ConfigureServices(services =>
+                {
+                    services.AddTestEventHubsMessagePump(producer => producer.AddMessageBody(reading))
+                            .WithEventHubsMessageHandler<SensorReadingAzureEventHubsMessageHandler, SensorReading>(provider => handler)
+                            .WithEventHubsMessageHandler<SensorTelemetryAzureEventHubsMessageHandler, SensorTelemetry>();
+                });
+
+        using (IHost host = builder.Build())
+        {
+            try
+            {
+                // Act
+                host.StartAsync();
+
+                // Assert
+                Assert.True(handler.IsProcessed);
+            }
+            finally
+            {
+                await host.StopAsync();
+            }
+        }
+    }
+}
+```
+
+Note that in this example, we use `Assert.True(handler.IsProcessed)` to determine if the `SensorReading` message was correctly processed. In your application, you may want to inject your message handlers with test versions of dependencies and determine via those dependencies if the correct message handler was called.
+You can use one of the `.WithEventHubsMessageHandler<,>(...)` extensions to pass in your instance of the message handler so you can use it later in the test assertion, like it is shown in the example.
+
+> 💡 Note that the example uses `logging.AddXunitTestLogging`. This is available in the `Arcus.Testing.Logging` package. See [this page on logging](./logging.md) for more information.
+
+## Message producer configuration
+The test message pump can be configured extensively to meet your needs. You can even pass in your own implementation of a test message producer to have full control over how the Azure EventHubs messages should look like.
+When a custom message body is passed, an `EventHubsReceivedMessage` will be created with the [correlation properties](https://messaging.arcus-azure.net/Features/message-handling/service-bus#message-correlation) already filled out. This allows for you to also test any the correlation specific functionality in your message handlers.
+
+```csharp
+services.AddTestEventHubsMessagePump(producer =>
+{
+    // Pass in a single custom message, which will become a `EventData`.
+    producer.AddMessageBody(sensorReading);
+
+    // Pass in multiple custom messages, which will become `EventData` instances.
+    producer.AddMessageBodies(sensorReadings);
+
+    // Pass in your own `EventData`.
+    // 💡 Use Arcus' `EventDataBuilder` to create such messages.
+    EventData message = 
+      EventDataBuilder.CreateForBody(BinaryData.FromObjectAsJson(sensorReading))
+                      .Build();
+    producer.AddMessage(message);
+
+    // Pass in your own `EventHubsReceivedMessage` instances.
+    // 💡 Use Arcus' `EventDataBuilder` to create such messages.
+    EventData message = 
+      EventDataBuilder.CreateForBody(BinaryData.FromObjectAsJson(sensorReading))
+                      .Build();
+    producer.AddMessages(new[] { message });
+});
+```
+
+If the creation of Azure EventHubs messages is rather complex, you require asynchronous serialization, or you want to re-use your message producing; you can implement your own message producer.
+This requires you to implement the `IAzureEventHubsMessageProducer` interface.
+```csharp
+public class MyTestMessageProducer : IAzureEventHubsMessageProducer
+{
+    public async Task<EventData[]> ProduceMessagesAsync()
+    {
+        var reading = new SensorReading(sensorId: "123", timestamp: DateTimeOffset.UtcNow);
+
+        EventData message = 
+            EventDataBuilder.CreateForBody(BinaryData.FromObjectAsJson(reading))
+                            .Build();
+
+        return Task.FromResult(new[] { message });
+    }
+}
+```
+
+Such implementation can be pased along during the registration:
+```csharp
+var producer = new MyTestMessageProducer();
+services.AddTestEventHubsMessagePump(producer);
+```
+
+## Message routing configuration
+The test Azure EventHubs registration internally uses the Azure EventHubs message router. To configure this router, use one of the extension overloads. This gives you access to the message router options, like in a general Azure EventHubs message pump registration.
+```csharp
+services.AddTestEventHubsMessagePump(..., options =>
+{
+    options.Deserialization.AdditionalMembers = AdditionalMemberHandling.Error
+});
+```
+
+For more information on the message router options, see the [Arcus messaging feature documentation](https://messaging.arcus-azure.net/Features/message-handling/event-hubs#pump-configuration).

--- a/docs/preview/features/eventhubs-messsage-pump.md
+++ b/docs/preview/features/eventhubs-messsage-pump.md
@@ -157,7 +157,7 @@ public class MyTestMessageProducer : IAzureEventHubsMessageProducer
 }
 ```
 
-Such implementation can be pased along during the registration:
+Such implementation can be passed along during the registration:
 ```csharp
 var producer = new MyTestMessageProducer();
 services.AddTestEventHubsMessagePump(producer);

--- a/docs/preview/features/servicebus-messsage-pump.md
+++ b/docs/preview/features/servicebus-messsage-pump.md
@@ -45,7 +45,7 @@ public class ShipmentAzureServiceBusMessageHandler : IAzureServiceBusMessageHand
         MessageCorrelationInfo correlationInfo,
         CancellationToken cancellationToken)
     {
-        // Proces order...
+        // Proces shipment...
     }
 }
 ```

--- a/docs/preview/features/servicebus-messsage-pump.md
+++ b/docs/preview/features/servicebus-messsage-pump.md
@@ -161,7 +161,7 @@ public class MyTestMessageProducer : IAzureServiceBusMessageProducer
 }
 ```
 
-Such implementation can be pased along during the registration:
+Such implementation can be passed along during the registration:
 ```csharp
 var producer = new MyTestMessageProducer();
 services.AddTestServiceBusMessagePump(producer);

--- a/docs/preview/features/servicebus-messsage-pump.md
+++ b/docs/preview/features/servicebus-messsage-pump.md
@@ -6,7 +6,7 @@ layout: default
 # Testing Azure Service Bus message handling
 
 ## Installation
-The following functionality is available when installing this package:
+Install this package to easily test your Service Bus message handlers:
 
 ```shell
 PM> Install-Package -Name Arcus.Testing.Messaging.Pumps.ServiceBus

--- a/src/Arcus.Testing.Messaging.Pumps.EventHubs/Arcus.Testing.Messaging.Pumps.EventHubs.csproj
+++ b/src/Arcus.Testing.Messaging.Pumps.EventHubs/Arcus.Testing.Messaging.Pumps.EventHubs.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net6.0;netcoreapp3.1;netstandard2.1</TargetFrameworks>
+    <Authors>Arcus</Authors>
+    <Company>Arcus</Company>
+    <Description>Provides messaging capabilities during Arcus testing</Description>
+    <Copyright>Copyright (c) Arcus</Copyright>
+    <PackageLicenseUrl>https://github.com/arcus-azure/arcus.testing/blob/master/LICENSE</PackageLicenseUrl>
+    <PackageProjectUrl>https://github.com/arcus-azure/arcus.testing</PackageProjectUrl>
+    <PackageIconUrl>https://raw.githubusercontent.com/arcus-azure/arcus/master/media/arcus.png</PackageIconUrl>
+    <RepositoryUrl>https://github.com/arcus-azure/arcus.testing</RepositoryUrl>
+    <RepositoryType>Git</RepositoryType>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageTags>Azure;Testing;Messaging;Pumps;EventHubs</PackageTags>
+    <PackageId>Arcus.Testing.Messaging.Pumps.EventHubs</PackageId>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <NoWarn>NU5125;NU5048</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Arcus.Messaging.Pumps.EventHubs" Version="[1.3.0,2.0.0)" />
+  </ItemGroup>
+
+</Project>

--- a/src/Arcus.Testing.Messaging.Pumps.EventHubs/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Arcus.Testing.Messaging.Pumps.EventHubs/Extensions/IServiceCollectionExtensions.cs
@@ -1,0 +1,100 @@
+﻿using System;
+using Arcus.Messaging.Abstractions.EventHubs.MessageHandling;
+using Arcus.Testing.Messaging.Pumps.EventHubs;
+using GuardNet;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+// ReSharper disable once CheckNamespace
+namespace Microsoft.Extensions.DependencyInjection
+{
+    /// <summary>
+    /// Represents a set of extensions on the <see cref="IServiceCollection"/> to easily add the <see cref="TestEventHubsMessagePump"/>.
+    /// </summary>
+    // ReSharper disable once InconsistentNaming
+    public static class IServiceCollectionExtensions
+    {
+        /// <summary>
+        /// Adds a test Azure Service Bus message pump to simulate received messages.
+        /// </summary>
+        /// <param name="services">The available registered services in the application.</param>
+        /// <param name="configureProducer">The function to configure the message producer which will simulate messages on the message pump.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="services"/> or the <paramref name="configureProducer"/> is <c>null</c>.</exception>
+        public static EventHubsMessageHandlerCollection AddTestEventHubsMessagePump(
+            this IServiceCollection services,
+            Action<TestAzureEventHubsMessageProducer> configureProducer)
+        {
+            Guard.NotNull(services, nameof(services), "Requires a series of registered application services to add the test Azure Service Bus message pump");
+            Guard.NotNull(configureProducer, nameof(configureProducer), "Requires a function to configure the message producer which will simulate messages on the message pump");
+
+            return AddTestEventHubsMessagePump(services, configureProducer, configureOptions: null);
+        }
+
+        /// <summary>
+        /// Adds a test Azure Service Bus message pump to simulate received messages.
+        /// </summary>
+        /// <param name="services">The available registered services in the application.</param>
+        /// <param name="configureProducer">The function to configure the message producer which will simulate messages on the message pump.</param>
+        /// <param name="configureOptions">The additional message routing options to configure the message router that will process the simulated messages.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="services"/> or the <paramref name="configureProducer"/> is <c>null</c>.</exception>
+        public static EventHubsMessageHandlerCollection AddTestEventHubsMessagePump(
+            this IServiceCollection services,
+            Action<TestAzureEventHubsMessageProducer> configureProducer,
+            Action<AzureEventHubsMessageRouterOptions> configureOptions)
+        {
+            Guard.NotNull(services, nameof(services), "Requires a series of registered application services to add the test Azure Service Bus message pump");
+            Guard.NotNull(configureProducer, nameof(configureProducer), "Requires a function to configure the message producer which will simulate messages on the message pump");
+
+            var producer = new TestAzureEventHubsMessageProducer();
+            configureProducer(producer);
+
+            return AddTestEventHubsMessagePump(services, producer, configureOptions);
+        }
+
+        /// <summary>
+        /// Adds a test Azure Service Bus message pump to simulate received messages.
+        /// </summary>
+        /// <param name="services">The available registered services in the application.</param>
+        /// <param name="messageProducer">The function to configure the message producer which will simulate messages on the message pump.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="services"/> or the <paramref name="messageProducer"/> is <c>null</c>.</exception>
+        public static EventHubsMessageHandlerCollection AddTestEventHubsMessagePump(
+            this IServiceCollection services,
+            IAzureEventHubsMessageProducer messageProducer)
+        {
+            Guard.NotNull(services, nameof(services), "Requires a series of registered application services to add the test Azure Service Bus message pump");
+            Guard.NotNull(messageProducer, nameof(messageProducer), "Requires a message producer instance to simulate messages on the message pump");
+
+            return AddTestEventHubsMessagePump(services, messageProducer, configureOptions: null);
+        }
+
+        /// <summary>
+        /// Adds a test Azure Service Bus message pump to simulate received messages.
+        /// </summary>
+        /// <param name="services">The available registered services in the application.</param>
+        /// <param name="messageProducer">The function to configure the message producer which will simulate messages on the message pump.</param>
+        /// <param name="configureOptions">The additional message routing options to configure the message router that will process the simulated messages.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="services"/> or the <paramref name="messageProducer"/> is <c>null</c>.</exception>
+        public static EventHubsMessageHandlerCollection AddTestEventHubsMessagePump(
+            this IServiceCollection services,
+            IAzureEventHubsMessageProducer messageProducer,
+            Action<AzureEventHubsMessageRouterOptions> configureOptions)
+        {
+            Guard.NotNull(services, nameof(services), "Requires a series of registered application services to add the test Azure Service Bus message pump");
+            Guard.NotNull(messageProducer, nameof(messageProducer), "Requires a message producer instance to simulate messages on the message pump");
+
+            EventHubsMessageHandlerCollection collection = services.AddEventHubsMessageRouting(configureOptions);
+            services.AddHostedService(provider =>
+            {
+                var router = provider.GetRequiredService<IAzureEventHubsMessageRouter>();
+
+                ILogger<TestEventHubsMessagePump> logger =
+                    provider.GetService<ILogger<TestEventHubsMessagePump>>()
+                    ?? NullLogger<TestEventHubsMessagePump>.Instance;
+
+                return new TestEventHubsMessagePump(messageProducer, router, logger);
+            });
+
+            return collection;
+        }
+    }
+}

--- a/src/Arcus.Testing.Messaging.Pumps.EventHubs/IAzureEventHubsMessageProducer.cs
+++ b/src/Arcus.Testing.Messaging.Pumps.EventHubs/IAzureEventHubsMessageProducer.cs
@@ -1,0 +1,16 @@
+﻿using System.Threading.Tasks;
+using Azure.Messaging.EventHubs;
+
+namespace Arcus.Testing.Messaging.Pumps.EventHubs
+{
+    /// <summary>
+    /// Represents a message producer that produces Azure EventHubs messages like it would come from an actual Azure resource.
+    /// </summary>
+    public interface IAzureEventHubsMessageProducer
+    {
+        /// <summary>
+        /// Produce an Azure EventHubs message like it would come from an actual EventHubs resource.
+        /// </summary>
+        Task<EventData[]> ProduceMessagesAsync();
+    }
+}

--- a/src/Arcus.Testing.Messaging.Pumps.EventHubs/TestAzureEventHubsMessageProducer.cs
+++ b/src/Arcus.Testing.Messaging.Pumps.EventHubs/TestAzureEventHubsMessageProducer.cs
@@ -60,7 +60,7 @@ namespace Arcus.Testing.Messaging.Pumps.EventHubs
         {
             Guard.NotNull(messages, nameof(messages), "Requires a series of message bodies to produce Azure Service Bus messages to the message pump");
 
-            EventData CreateServiceBusMessage(TMessageBody message)
+            EventData CreateEventData(TMessageBody message)
             {
                 EventData eventData =
                     EventDataBuilder.CreateForBody(message)
@@ -73,7 +73,7 @@ namespace Arcus.Testing.Messaging.Pumps.EventHubs
                 return eventData;
             }
 
-            _createMessagesCollection.Add(() => messages.Select(CreateServiceBusMessage).ToArray());
+            _createMessagesCollection.Add(() => messages.Select(CreateEventData).ToArray());
             return this;
         }
 

--- a/src/Arcus.Testing.Messaging.Pumps.EventHubs/TestAzureEventHubsMessageProducer.cs
+++ b/src/Arcus.Testing.Messaging.Pumps.EventHubs/TestAzureEventHubsMessageProducer.cs
@@ -1,0 +1,92 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Threading.Tasks;
+using Azure.Messaging.EventHubs;
+using GuardNet;
+
+namespace Arcus.Testing.Messaging.Pumps.EventHubs
+{
+    /// <summary>
+    /// Represents a message producer that produces Azure EventHubs messages like it would come from an actual Azure resource.
+    /// </summary>
+    public class TestAzureEventHubsMessageProducer : IAzureEventHubsMessageProducer
+    {
+        private readonly ICollection<Func<EventData[]>> _createMessagesCollection = new Collection<Func<EventData[]>>();
+
+        /// <summary>
+        /// Adds an Azure Service Bus <paramref name="message"/> on the message pump.
+        /// </summary>
+        /// <param name="message">The message to produce on the message pump.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="message"/> is <c>null</c>.</exception>
+        public TestAzureEventHubsMessageProducer AddMessage(EventData message)
+        {
+            Guard.NotNull(message, nameof(message), "Requires an Azure Service Bus message to produce on the message pump");
+            return AddMessages(new[] { message });
+        }
+
+        /// <summary>
+        /// Adds a series of Azure Service Bus <paramref name="messages"/> on the message pump.
+        /// </summary>
+        /// <param name="messages">The series of messages to produce on the message pump.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="messages"/> is <c>null</c>.</exception>
+        public TestAzureEventHubsMessageProducer AddMessages(IEnumerable<EventData> messages)
+        {
+            Guard.NotNull(messages, nameof(messages), "Requires a series of Azure Service Bus messages to produce on the message pump");
+
+            _createMessagesCollection.Add(messages.ToArray);
+            return this;
+        }
+
+        /// <summary>
+        /// Add a series of custom <paramref name="message"/> which will result in <see cref="EventData"/> on the message pump.
+        /// </summary>
+        /// <typeparam name="TMessageBody">The custom type of the message body.</typeparam>
+        /// <param name="message">The series of custom message bodies which will translate to <see cref="EventData"/> instances.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="message"/> is <c>null</c>.</exception>
+        public TestAzureEventHubsMessageProducer AddMessageBody<TMessageBody>(TMessageBody message)
+        {
+            return AddMessageBodies(new[] { message });
+        }
+
+        /// <summary>
+        /// Add a series of custom <paramref name="messages"/> which will result in <see cref="EventData"/> on the message pump.
+        /// </summary>
+        /// <typeparam name="TMessageBody">The custom type of the message body.</typeparam>
+        /// <param name="messages">The series of custom message bodies which will translate to <see cref="EventData"/> instances.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="messages"/> is <c>null</c>.</exception>
+        public TestAzureEventHubsMessageProducer AddMessageBodies<TMessageBody>(IEnumerable<TMessageBody> messages)
+        {
+            Guard.NotNull(messages, nameof(messages), "Requires a series of message bodies to produce Azure Service Bus messages to the message pump");
+
+            EventData CreateServiceBusMessage(TMessageBody message)
+            {
+                EventData eventData =
+                    EventDataBuilder.CreateForBody(message)
+                                    .WithOperationId(Guid.NewGuid().ToString())
+                                    .WithTransactionId(Guid.NewGuid().ToString())
+                                    .WithOperationParentId(Guid.NewGuid().ToString())
+                                    .Build();
+
+                eventData.MessageId = Guid.NewGuid().ToString();
+                return eventData;
+            }
+
+            _createMessagesCollection.Add(() => messages.Select(CreateServiceBusMessage).ToArray());
+            return this;
+        }
+
+        /// <summary>
+        /// Produce an Azure EventHubs message like it would come from an actual EventHubs resource.
+        /// </summary>
+        public Task<EventData[]> ProduceMessagesAsync()
+        {
+            EventData[] messages = 
+                _createMessagesCollection.SelectMany(createMessages => createMessages())
+                                         .ToArray();
+
+            return Task.FromResult(messages);
+        }
+    }
+}

--- a/src/Arcus.Testing.Messaging.Pumps.EventHubs/TestEventHubsMessagePump.cs
+++ b/src/Arcus.Testing.Messaging.Pumps.EventHubs/TestEventHubsMessagePump.cs
@@ -1,0 +1,85 @@
+﻿using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Arcus.Messaging.Abstractions;
+using Arcus.Messaging.Abstractions.EventHubs;
+using Arcus.Messaging.Abstractions.EventHubs.MessageHandling;
+using Arcus.Messaging.Pumps.Abstractions;
+using Azure.Messaging.EventHubs;
+using GuardNet;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Arcus.Testing.Messaging.Pumps.EventHubs
+{
+    /// <summary>
+    /// Represents an <see cref="IHostedService"/> that acts as a <see cref="MessagePump"/> for <see cref="EventData"/> messages.
+    /// </summary>
+    public class TestEventHubsMessagePump : IHostedService
+    {
+        private readonly IAzureEventHubsMessageProducer _messageProducer;
+        private readonly IAzureEventHubsMessageRouter _messageRouter;
+        private readonly ILogger<TestEventHubsMessagePump> _logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TestEventHubsMessagePump" /> class.
+        /// </summary>
+        /// <param name="messageProducer">The producer instance to simulate received messages on the message pump.</param>
+        /// <param name="messageRouter">The router instance to process the simulated received messages on the message pump.</param>
+        /// <param name="logger">The logger instance to write diagnostic information during the message simulation on the message pump.</param>
+        /// <exception cref="ArgumentNullException">
+        ///     Thrown when the <paramref name="messageProducer"/>, <paramref name="messageRouter"/>, or the <paramref name="logger"/> is <c>null</c>.
+        /// </exception>
+        public TestEventHubsMessagePump(
+            IAzureEventHubsMessageProducer messageProducer,
+            IAzureEventHubsMessageRouter messageRouter,
+            ILogger<TestEventHubsMessagePump> logger)
+        {
+            Guard.NotNull(messageProducer, nameof(messageProducer), "Requires an Azure Service Bus message producer to simulate received messages on the message pump");
+            Guard.NotNull(messageRouter, nameof(messageRouter), "Requires an Azure Service Bus message router to process the simulated received messages on the message pump");
+            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to write diagnostic information during the message simulation on the message pump");
+            
+            _messageProducer = messageProducer;
+            _messageRouter = messageRouter;
+            _logger = logger;
+        }
+
+        /// <summary>
+        /// Triggered when the application host is ready to start the service.
+        /// </summary>
+        /// <param name="cancellationToken">Indicates that the start process has been aborted.</param>
+        public async Task StartAsync(CancellationToken cancellationToken)
+        {
+            _logger.LogInformation("Started test Azure EventHubs message pump");
+
+            EventData[] messages = await _messageProducer.ProduceMessagesAsync();
+            foreach (EventData data in messages)
+            {
+                try
+                {
+                    var messageContext = AzureEventHubsMessageContext.CreateFrom(data, "arcus.testing.servicebus.windows.net", "$Default", "arcus.testing");
+                    MessageCorrelationInfo correlationInfo = data.GetCorrelationInfo();
+
+                    await _messageRouter.RouteMessageAsync(data, messageContext, correlationInfo, cancellationToken);
+                }
+                catch (Exception exception)
+                {
+                    var bodyString = data.EventBody.ToString();
+                    var  propertiesDescription = $"[{string.Join(", ", data.Properties.Select(prop => $"{prop.Key}={prop.Value}"))}]";
+                    _logger.LogCritical(exception, "Failed to route test Azure Service Bus message {MessageId} (Body: {Body}, Properties: {Properties})", data.MessageId, bodyString, propertiesDescription);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Triggered when the application host is performing a graceful shutdown.
+        /// </summary>
+        /// <param name="cancellationToken">Indicates that the shutdown process should no longer be graceful.</param>
+        public Task StopAsync(CancellationToken cancellationToken)
+        {
+            _logger.LogInformation("Stopped test Azure EventHubs message pump");
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Arcus.Testing.Tests.Unit/Arcus.Testing.Tests.Unit.csproj
+++ b/src/Arcus.Testing.Tests.Unit/Arcus.Testing.Tests.Unit.csproj
@@ -16,6 +16,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Arcus.Testing.Logging\Arcus.Testing.Logging.csproj" />
+    <ProjectReference Include="..\Arcus.Testing.Messaging.Pumps.EventHubs\Arcus.Testing.Messaging.Pumps.EventHubs.csproj" />
     <ProjectReference Include="..\Arcus.Testing.Messaging.Pumps.ServiceBus\Arcus.Testing.Messaging.Pumps.ServiceBus.csproj" />
     <ProjectReference Include="..\Arcus.Testing.Security.Providers.InMemory\Arcus.Testing.Security.Providers.InMemory.csproj" />
   </ItemGroup>

--- a/src/Arcus.Testing.Tests.Unit/Messaging/EventHubs/Fixture/SensorReading.cs
+++ b/src/Arcus.Testing.Tests.Unit/Messaging/EventHubs/Fixture/SensorReading.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Bogus;
+
+namespace Arcus.Testing.Tests.Unit.Messaging.EventHubs.Fixture
+{
+    public class SensorReading
+    {
+        public string SensorId { get; set; }
+        public double SensorValue { get; set; }
+        public DateTimeOffset Timestamp { get; set; }
+
+        public static SensorReading Generate()
+        {
+            var generator = new Faker<SensorReading>()
+                .RuleFor(s => s.SensorId, f => f.Random.Guid().ToString())
+                .RuleFor(s => s.SensorValue, f => f.Random.Double())
+                .RuleFor(s => s.Timestamp, f => f.Date.RecentOffset());
+
+            return generator.Generate();
+        }
+    }
+}

--- a/src/Arcus.Testing.Tests.Unit/Messaging/EventHubs/Fixture/SensorReadingAzureEventHubsMessageHandler.cs
+++ b/src/Arcus.Testing.Tests.Unit/Messaging/EventHubs/Fixture/SensorReadingAzureEventHubsMessageHandler.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Arcus.Messaging.Abstractions;
+using Arcus.Messaging.Abstractions.EventHubs;
+using Arcus.Messaging.Abstractions.EventHubs.MessageHandling;
+using Xunit;
+
+namespace Arcus.Testing.Tests.Unit.Messaging.EventHubs.Fixture
+{
+    public class SensorReadingAzureEventHubsMessageHandler : IAzureEventHubsMessageHandler<SensorReading>
+    {
+        private readonly SensorReading[] _expectedReadings;
+        private int _expectedCount;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SensorReadingAzureEventHubsMessageHandler" /> class.
+        /// </summary>
+        public SensorReadingAzureEventHubsMessageHandler(params SensorReading[] expectedReadings)
+        {
+            _expectedReadings = expectedReadings;
+        }
+
+        public bool IsProcessed { get; private set; }
+        
+        public Task ProcessMessageAsync(
+            SensorReading message,
+            AzureEventHubsMessageContext messageContext,
+            MessageCorrelationInfo correlationInfo,
+            CancellationToken cancellationToken)
+        {
+            Assert.Single(_expectedReadings, expected =>
+            {
+                return expected.SensorId == message.SensorId
+                       && Math.Abs(expected.SensorValue - message.SensorValue) == 0
+                       && expected.Timestamp == message.Timestamp;
+            });
+
+            IsProcessed = ++_expectedCount == _expectedReadings.Length;
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Arcus.Testing.Tests.Unit/Messaging/EventHubs/Fixture/SensorTelemetry.cs
+++ b/src/Arcus.Testing.Tests.Unit/Messaging/EventHubs/Fixture/SensorTelemetry.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Bogus;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace Arcus.Testing.Tests.Unit.Messaging.EventHubs.Fixture
+{
+    public class SensorTelemetry
+    {
+        public string SensorId { get; set; }
+        public HealthStatus SensorStatus { get; set; }
+        public DateTimeOffset Timestamp { get; set; }
+
+        public static SensorTelemetry Generate()
+        {
+            var generator = new Faker<SensorTelemetry>()
+                .RuleFor(s => s.SensorId, f => f.Random.Guid().ToString())
+                .RuleFor(s => s.SensorStatus, f => f.PickRandom<HealthStatus>())
+                .RuleFor(s => s.Timestamp, f => f.Date.RecentOffset());
+
+            return generator.Generate();
+        }
+    }
+}

--- a/src/Arcus.Testing.Tests.Unit/Messaging/EventHubs/Fixture/SensorTelemetryAzureEventHubsMessageHandler.cs
+++ b/src/Arcus.Testing.Tests.Unit/Messaging/EventHubs/Fixture/SensorTelemetryAzureEventHubsMessageHandler.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Arcus.Messaging.Abstractions;
+using Arcus.Messaging.Abstractions.EventHubs;
+using Arcus.Messaging.Abstractions.EventHubs.MessageHandling;
+using Arcus.Testing.Messaging.Pumps.EventHubs;
+
+namespace Arcus.Testing.Tests.Unit.Messaging.EventHubs.Fixture
+{
+    public class SensorTelemetryAzureEventHubsMessageHandler : IAzureEventHubsMessageHandler<SensorTelemetry>
+    {
+        public bool IsProcessed { get; private set; }
+        public Task ProcessMessageAsync(
+            SensorTelemetry message,
+            AzureEventHubsMessageContext messageContext,
+            MessageCorrelationInfo correlationInfo,
+            CancellationToken cancellationToken)
+        {
+            IsProcessed = true;
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Arcus.Testing.Tests.Unit/Messaging/EventHubs/TestEventHubsMessagePumpTests.cs
+++ b/src/Arcus.Testing.Tests.Unit/Messaging/EventHubs/TestEventHubsMessagePumpTests.cs
@@ -1,0 +1,182 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Arcus.Testing.Tests.Unit.Messaging.EventHubs.Fixture;
+using Azure.Messaging.EventHubs;
+using Bogus;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Arcus.Testing.Tests.Unit.Messaging.EventHubs
+{
+    public class TestEventHubsMessagePumpTests
+    {
+        private readonly ITestOutputHelper _outputWriter;
+
+        private static readonly Faker BogusGenerator = new Faker();
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TestEventHubsMessagePumpTests" /> class.
+        /// </summary>
+        public TestEventHubsMessagePumpTests(ITestOutputHelper outputWriter)
+        {
+            _outputWriter = outputWriter;
+        }
+
+        [Fact]
+        public async Task TestMessagePump_WithSingleMessageBody_ProcessesCorrectly()
+        {
+            // Arrange
+            var reading = SensorReading.Generate();
+            var handler1 = new SensorReadingAzureEventHubsMessageHandler(reading);
+            var handler2 = new SensorTelemetryAzureEventHubsMessageHandler();
+
+            // Act / Assert
+            await StartNewHostAsync(
+                services => services.AddTestEventHubsMessagePump(produce => produce.AddMessageBody(reading))
+                                    .WithEventHubsMessageHandler<SensorReadingAzureEventHubsMessageHandler, SensorReading>(provider => handler1)
+                                    .WithEventHubsMessageHandler<SensorTelemetryAzureEventHubsMessageHandler, SensorTelemetry>(provider => handler2), 
+                () =>
+                {
+                    Assert.True(handler1.IsProcessed);
+                    Assert.False(handler2.IsProcessed);
+                });
+        }
+
+        [Fact]
+        public async Task TestMessagePump_WithUnknownSingleMessageBody_DoesNotProcesses()
+        {
+            // Arrange
+            var reading = SensorReading.Generate();
+            var handler = new SensorReadingAzureEventHubsMessageHandler(reading);
+            var telemetry = SensorTelemetry.Generate();
+
+            // Act / Assert
+            await StartNewHostAsync(
+                services => services.AddTestEventHubsMessagePump(produce => produce.AddMessageBody(telemetry))
+                                    .WithEventHubsMessageHandler<SensorReadingAzureEventHubsMessageHandler, SensorReading>(provider => handler), 
+                () => Assert.False(handler.IsProcessed));
+        }
+
+        [Fact]
+        public async Task TestMessagePump_WithMultipleMessageBodies_ProcessesCorrectly()
+        {
+            // Arrange
+            IEnumerable<SensorReading> readings = BogusGenerator.Make(10, SensorReading.Generate);
+            var handler = new SensorReadingAzureEventHubsMessageHandler(readings.ToArray());
+
+            // Act / Assert
+            await StartNewHostAsync(
+                services => services.AddTestEventHubsMessagePump(produce => produce.AddMessageBodies(readings))
+                                    .WithEventHubsMessageHandler<SensorTelemetryAzureEventHubsMessageHandler, SensorTelemetry>()
+                                    .WithEventHubsMessageHandler<SensorReadingAzureEventHubsMessageHandler, SensorReading>(provider => handler), 
+                () => Assert.True(handler.IsProcessed));
+        }
+
+        [Fact]
+        public async Task TestMessagePump_WithUnknownMultipleMessageBodies_DoesNotProcesses()
+        {
+            // Arrange
+            var reading = SensorReading.Generate();
+            var handler = new SensorReadingAzureEventHubsMessageHandler(reading);
+            IEnumerable<SensorTelemetry> telemetries = BogusGenerator.Make(10, SensorTelemetry.Generate);
+
+            // Act / Assert
+            await StartNewHostAsync(
+                services => services.AddTestEventHubsMessagePump(produce => produce.AddMessageBodies(telemetries))
+                                    .WithEventHubsMessageHandler<SensorReadingAzureEventHubsMessageHandler, SensorReading>(provider => handler), 
+                () => Assert.False(handler.IsProcessed));
+        }
+
+        [Fact]
+        public async Task TestMessagePump_WithSingleMessage_ProcessesCorrectly()
+        {
+            // Arrange
+            var reading = SensorReading.Generate();
+            var handler = new SensorReadingAzureEventHubsMessageHandler(reading);
+            EventData message = EventDataBuilder.CreateForBody(reading).Build();
+
+            // Act / Assert
+            await StartNewHostAsync(
+                services => services.AddTestEventHubsMessagePump(produce => produce.AddMessage(message))
+                                    .WithEventHubsMessageHandler<SensorTelemetryAzureEventHubsMessageHandler, SensorTelemetry>()
+                                    .WithEventHubsMessageHandler<SensorReadingAzureEventHubsMessageHandler, SensorReading>(provider => handler), 
+                () => Assert.True(handler.IsProcessed));
+        }
+
+        [Fact]
+        public async Task TestMessagePump_WithUnknownSingleMessage_DoesNotProcesses()
+        {
+            // Arrange
+            var reading = SensorReading.Generate();
+            var handler = new SensorReadingAzureEventHubsMessageHandler(reading);
+            var telemetry = SensorTelemetry.Generate();
+            EventData message = EventDataBuilder.CreateForBody(telemetry).Build();
+
+            // Act / Assert
+            await StartNewHostAsync(
+                services => services.AddTestEventHubsMessagePump(produce => produce.AddMessage(message))
+                                    .WithEventHubsMessageHandler<SensorReadingAzureEventHubsMessageHandler, SensorReading>(provider => handler), 
+                () => Assert.False(handler.IsProcessed));
+        }
+
+        [Fact]
+        public async Task TestMessagePump_WithMultipleMessages_ProcessesCorrectly()
+        {
+            // Arrange
+            IEnumerable<SensorReading> readings = BogusGenerator.Make(10, SensorReading.Generate);
+            var handler = new SensorReadingAzureEventHubsMessageHandler(readings.ToArray());
+            IEnumerable<EventData> messages = readings.Select(reading => EventDataBuilder.CreateForBody(reading).Build());
+
+            // Act / Assert
+            await StartNewHostAsync(
+                services => services.AddTestEventHubsMessagePump(produce => produce.AddMessages(messages))
+                                    .WithEventHubsMessageHandler<SensorTelemetryAzureEventHubsMessageHandler, SensorTelemetry>()
+                                    .WithEventHubsMessageHandler<SensorReadingAzureEventHubsMessageHandler, SensorReading>(provider => handler), 
+                () => Assert.True(handler.IsProcessed));
+        }
+
+        [Fact]
+        public async Task TestMessagePump_WithUnknownMultipleMessages_DoesNotProcesses()
+        {
+            // Arrange
+            var reading = SensorReading.Generate();
+            var handler = new SensorReadingAzureEventHubsMessageHandler(reading);
+            IEnumerable<SensorTelemetry> telemetries = BogusGenerator.Make(10, SensorTelemetry.Generate);
+            IEnumerable<EventData> messages = telemetries.Select(telemetry => EventDataBuilder.CreateForBody(telemetry).Build());
+
+            // Act / Assert
+            await StartNewHostAsync(
+                services => services.AddTestEventHubsMessagePump(produce => produce.AddMessages(messages))
+                                    .WithEventHubsMessageHandler<SensorReadingAzureEventHubsMessageHandler, SensorReading>(provider => handler), 
+                () => Assert.False(handler.IsProcessed));
+        }
+
+        private async Task StartNewHostAsync(
+            Action<IServiceCollection> configureServices,
+            Action test)
+        {
+            IHostBuilder builder =
+                Host.CreateDefaultBuilder()
+                    .ConfigureLogging(logging => logging.AddXunitTestLogging(_outputWriter))
+                    .ConfigureServices(configureServices);
+
+            using (IHost host = builder.Build())
+            {
+                try
+                {
+                    await host.StartAsync();
+                    test();
+                }
+                finally
+                {
+                    await host.StopAsync();
+                }
+            }
+        }
+    }
+}

--- a/src/Arcus.Testing.sln
+++ b/src/Arcus.Testing.sln
@@ -13,7 +13,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{64013B91
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Arcus.Testing.Security.Providers.InMemory", "Arcus.Testing.Security.Providers.InMemory\Arcus.Testing.Security.Providers.InMemory.csproj", "{13FFF971-9F7E-4350-B193-85F6485F41B7}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Arcus.Testing.Messaging.Pumps.ServiceBus", "Arcus.Testing.Messaging.Pumps.ServiceBus\Arcus.Testing.Messaging.Pumps.ServiceBus.csproj", "{3F7076F3-A88B-43B2-84C9-70A9E632012A}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Arcus.Testing.Messaging.Pumps.ServiceBus", "Arcus.Testing.Messaging.Pumps.ServiceBus\Arcus.Testing.Messaging.Pumps.ServiceBus.csproj", "{3F7076F3-A88B-43B2-84C9-70A9E632012A}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Arcus.Testing.Messaging.Pumps.EventHubs", "Arcus.Testing.Messaging.Pumps.EventHubs\Arcus.Testing.Messaging.Pumps.EventHubs.csproj", "{E710B99E-F14A-46D4-965D-BB20AE2A7E20}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -41,6 +43,10 @@ Global
 		{3F7076F3-A88B-43B2-84C9-70A9E632012A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3F7076F3-A88B-43B2-84C9-70A9E632012A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3F7076F3-A88B-43B2-84C9-70A9E632012A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E710B99E-F14A-46D4-965D-BB20AE2A7E20}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E710B99E-F14A-46D4-965D-BB20AE2A7E20}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E710B99E-F14A-46D4-965D-BB20AE2A7E20}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E710B99E-F14A-46D4-965D-BB20AE2A7E20}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Adds a test version of an EventHubs message pump so that message handlers can be tested with ease.

Closes #69