### PR TITLE
chore: update ci build w/ main branch

### DIFF
--- a/build/ci-build.yml
+++ b/build/ci-build.yml
@@ -3,7 +3,7 @@ name: $(date:yyyyMMdd)$(rev:.r)
 trigger:
   branches:
     include:
-    - master
+    - main
   paths:
     include:
     - src/*


### PR DESCRIPTION
Use the new `main` branch in the CI build.

Relates to https://github.com/arcus-azure/arcus/issues/169