### PR TITLE
feat: add serilog xunit test log sink

### DIFF
--- a/docs/preview/features/logging.md
+++ b/docs/preview/features/logging.md
@@ -9,6 +9,7 @@ This page describes functionality related to logging in tests.
 * [xUnit test logging](#xunit-test-logging)
 * [In-memory test logging](#in-memory-test-logging)
 * [Serilog in-memory log sink](#serilog-in-memory-log-sink)
+* [Serilog xUnit log sink](#serilog-xunit-log-sink)
 
 ## Installation
 
@@ -118,6 +119,7 @@ that collectes written log emits in-memory so the test infrastructure can assert
 ```csharp
 using Arcus.Testing.Logging;
 using Serilog;
+using Serilog.Configuration;
 using Serilog.Core;
 using Serilog.Events;
 
@@ -130,4 +132,23 @@ logger.Information("This is an informational message");
 
 IEnumerable<LogEvent> emits = logSink.CurrentLogEmits;
 IEnumeratble<string> messages = logSink.CurrentLogMessages;
+```
+
+## Serilog xUnit log sink
+
+The `Arcus.Testing.Logging` library provides a `XunitTestLogSink` which is a [Serilog log sink](https://github.com/serilog/serilog/wiki/Configuration-Basics#sinks) that delegates written log emits to the xUnit test output.
+This can help in testing logging infrastructure as the xUnit test output will contain the information that is being tested.
+
+```csharp
+using Serilog;
+using Serilog.Configuration;
+
+// Injected in your test class.
+ITestOutputHelper outputWriter = ...
+
+var logger = new LoggerConfiguration()
+    .WriteTo.XunitTestLogging(outputWriter)
+    .CreateLogger();
+
+logger.Information("This informational message will be delegated to the xUnit test output");
 ```

--- a/src/Arcus.Testing.Logging/Extensions/LoggerSinkConfigurationExtensions.cs
+++ b/src/Arcus.Testing.Logging/Extensions/LoggerSinkConfigurationExtensions.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using GuardNet;
+using Serilog;
+using Serilog.Configuration;
+using Xunit.Abstractions;
+
+namespace Arcus.Testing.Logging.Extensions
+{
+    /// <summary>
+    /// Extensions on the <see cref="LoggerSinkConfiguration"/> to more easily add Serilog sinks related to logging.
+    /// </summary>
+    public static class LoggerSinkConfigurationExtensions
+    {
+        /// <summary>
+        /// Adds the <see cref="XunitLogEventSink"/> to the Serilog configuration to delegate Serilog log messages to the xUnit test <paramref name="outputWriter"/>.
+        /// </summary>
+        /// <param name="config">The Serilog sink configuration where the xUnit test logging will be added.</param>
+        /// <param name="outputWriter">The xUnit test output writer to write custom test output.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="config"/> or <paramref name="outputWriter"/> is <c>null</c>.</exception>
+        public static LoggerConfiguration XunitTestLogging(
+            this LoggerSinkConfiguration config, 
+            ITestOutputHelper outputWriter)
+        {
+            Guard.NotNull(config, nameof(config), "Requires a Serilog logger configuration instance to add the xUnit test logging");
+            Guard.NotNull(outputWriter, nameof(outputWriter), "Requires a xUnit test output writer to write Serilog log messages to the xUnit test output");
+
+            return config.Sink(new XunitLogEventSink(outputWriter));
+        }
+    }
+}

--- a/src/Arcus.Testing.Logging/XunitTestLogSink.cs
+++ b/src/Arcus.Testing.Logging/XunitTestLogSink.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using GuardNet;
+using Serilog.Core;
+using Serilog.Events;
+using Xunit.Abstractions;
+
+namespace Arcus.Testing.Logging
+{
+    /// <summary>
+    /// <see cref="ILogEventSink"/> representation of an <see cref="ITestOutputHelper"/> instance.
+    /// </summary>
+    public class XunitLogEventSink : ILogEventSink
+    {
+        private readonly ITestOutputHelper _outputWriter;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="XunitLogEventSink"/> class.
+        /// </summary>
+        /// <param name="outputWriter">The xUnit test output writer to write custom test output.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="outputWriter"/> is <c>null</c>.</exception>
+        public XunitLogEventSink(ITestOutputHelper outputWriter)
+        {
+            Guard.NotNull(outputWriter, nameof(outputWriter), "Requires a xUnit test output writer to write Serilog log messages to the xUnit test output");
+            _outputWriter = outputWriter;
+        }
+
+        /// <summary>
+        /// Emit the provided log event to the sink.
+        /// </summary>
+        /// <param name="logEvent">The log event to write.</param>
+        public void Emit(LogEvent logEvent)
+        {
+            _outputWriter.WriteLine(logEvent.RenderMessage());
+        }
+    }
+}

--- a/src/Arcus.Testing.Tests.Unit/Logging/LoggerSinkConfigurationExtensionsTests.cs
+++ b/src/Arcus.Testing.Tests.Unit/Logging/LoggerSinkConfigurationExtensionsTests.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using Arcus.Testing.Logging.Extensions;
+using Serilog;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Arcus.Testing.Tests.Unit.Logging
+{
+    public class LoggerSinkConfigurationExtensionsTests : ITestOutputHelper
+    {
+        private readonly ICollection<string> _messages = new Collection<string>();
+
+        [Fact]
+        public void AddXunitTestLogging_WithXunitOutputWriter_Succeeds()
+        {
+            // Arrange
+            var config = new LoggerConfiguration();
+            
+            // Act
+            config.WriteTo.AddXunitTestLogging(this);
+
+            // Assert
+            ILogger logger = config.CreateLogger();
+            var expected = "This information message should be present in the xUnit test output writer";
+            logger.Information(expected);
+            Assert.Single(_messages, expected);
+        }
+
+        [Fact]
+        public void AddXunitTestLogging_WithoutOutputWriter_Fails()
+        {
+            // Arrange
+            var config = new LoggerConfiguration();
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(
+                () => config.WriteTo.AddXunitTestLogging(outputWriter: null));
+        }
+
+        public void WriteLine(string message)
+        {
+            _messages.Add(message);
+        }
+
+        public void WriteLine(string format, params object[] args)
+        {
+            _messages.Add(string.Format(format, args));
+        }
+    }
+}

--- a/src/Arcus.Testing.Tests.Unit/Logging/LoggerSinkConfigurationExtensionsTests.cs
+++ b/src/Arcus.Testing.Tests.Unit/Logging/LoggerSinkConfigurationExtensionsTests.cs
@@ -19,7 +19,7 @@ namespace Arcus.Testing.Tests.Unit.Logging
             var config = new LoggerConfiguration();
             
             // Act
-            config.WriteTo.AddXunitTestLogging(this);
+            config.WriteTo.XunitTestLogging(this);
 
             // Assert
             ILogger logger = config.CreateLogger();
@@ -36,7 +36,7 @@ namespace Arcus.Testing.Tests.Unit.Logging
 
             // Act / Assert
             Assert.ThrowsAny<ArgumentException>(
-                () => config.WriteTo.AddXunitTestLogging(outputWriter: null));
+                () => config.WriteTo.XunitTestLogging(outputWriter: null));
         }
 
         public void WriteLine(string message)


### PR DESCRIPTION
Multiple Arcus repo's are dupicating an implementation of a Serilog xUnit test log sink.
Adding it to the Arcus Testing repo will remove this duplication and simplify the test projects.