### PR TITLE
feat: add sync secret retrieval to in-memory secret provider

### DIFF
--- a/docs/preview/features/inmemory-secret-provider.md
+++ b/docs/preview/features/inmemory-secret-provider.md
@@ -1,4 +1,4 @@
----
+﻿---
 title: Security
 layout: default
 ---
@@ -17,6 +17,8 @@ PM> Install-Package -Name Arcus.Testing.Security.Providers.InMemory
 
 As an addition to the [Arcus Security](https://github.com/arcus-azure/arcus.security) package, we have added an in-memory `ISecretProvider` implementation. 
 This secret provider is created so you can test you secret store configuration with non-secret values in a easy manner, without implementing your own `ISecretProvider`.
+
+⚡ Supports [synchronous secret retrieval](https://security.arcus-azure.net/Features/secrets/general).
 
 After installing the package, the `.AddInMemory` extension should be available to you:
 

--- a/src/Arcus.Testing.Security.Providers.InMemory/Arcus.Testing.Security.Providers.InMemory.csproj
+++ b/src/Arcus.Testing.Security.Providers.InMemory/Arcus.Testing.Security.Providers.InMemory.csproj
@@ -25,15 +25,17 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-    <PackageReference Include="Arcus.Security.Core" Version="[1.7.0,2.0.0)" />
     <PackageReference Include="Guard.Net" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' != 'net6.0'">
-    <PackageReference Include="Arcus.Security.Core" Version="[1.5.0,2.0.0)" />
     <PackageReference Include="Guard.Net" Version="1.2.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.8" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Arcus.Security.Core" Version="[1.9.0,2.0.0)" />
   </ItemGroup>
 
 </Project>

--- a/src/Arcus.Testing.Tests.Unit/Security/InMemorySecretProviderTests.cs
+++ b/src/Arcus.Testing.Tests.Unit/Security/InMemorySecretProviderTests.cs
@@ -25,7 +25,7 @@ namespace Arcus.Testing.Tests.Unit.Security
         }
 
         [Fact]
-        public async Task CreateWithoutSecrets_GetsRawSecret_ReturnsNull()
+        public async Task CreateWithoutSecrets_GetsRawSecretAsync_ReturnsNull()
         {
             // Arrange
             var provider = new InMemorySecretProvider();
@@ -36,15 +36,41 @@ namespace Arcus.Testing.Tests.Unit.Security
             // Assert
             Assert.Null(secretValue);
         }
+
+        [Fact]
+        public void CreateWithoutSecrets_GetsRawSecret_ReturnsNull()
+        {
+            // Arrange
+            var provider = new InMemorySecretProvider();
+            
+            // Act
+            string secretValue = provider.GetRawSecret("MySecret");
+            
+            // Assert
+            Assert.Null(secretValue);
+        }
         
         [Fact]
-        public async Task CreateWithoutSecrets_GetSecret_ReturnsNull()
+        public async Task CreateWithoutSecrets_GetSecretAsync_ReturnsNull()
         {
             // Arrange
             var provider = new InMemorySecretProvider();
             
             // Act
             Secret secret = await provider.GetSecretAsync("MySecret");
+            
+            // Assert
+            Assert.Null(secret);
+        }
+
+        [Fact]
+        public void CreateWithoutSecrets_GetSecret_ReturnsNull()
+        {
+            // Arrange
+            var provider = new InMemorySecretProvider();
+            
+            // Act
+            Secret secret = provider.GetSecret("MySecret");
             
             // Assert
             Assert.Null(secret);
@@ -64,9 +90,24 @@ namespace Arcus.Testing.Tests.Unit.Security
             // Assert
             Assert.Equal(expected, actual);
         }
+
+        [Fact]
+        public void CreateWithSecretValue_GetsRawSecretAsync_EqualsInitializedSecretValue()
+        {
+            // Arrange
+            string secretName = "MySecret";
+            string expected = $"secret-{Guid.NewGuid()}";
+            var provider = new InMemorySecretProvider(secretName, expected);
+            
+            // Act
+            string actual = provider.GetRawSecret(secretName);
+            
+            // Assert
+            Assert.Equal(expected, actual);
+        }
         
         [Fact]
-        public async Task CreateWithSecretValue_GetsSecret_EqualsInitializedSecretValue()
+        public async Task CreateWithSecretValue_GetsSecretAsync_EqualsInitializedSecretValue()
         {
             // Arrange
             string secretName = "MySecret";
@@ -79,9 +120,24 @@ namespace Arcus.Testing.Tests.Unit.Security
             // Assert
             Assert.Equal(expected, actual.Value);
         }
+
+        [Fact]
+        public void CreateWithSecretValue_GetsSecret_EqualsInitializedSecretValue()
+        {
+            // Arrange
+            string secretName = "MySecret";
+            string expected = $"secret-{Guid.NewGuid()}";
+            var provider = new InMemorySecretProvider(secretName, expected);
+            
+            // Act
+            Secret actual = provider.GetSecret(secretName);
+            
+            // Assert
+            Assert.Equal(expected, actual.Value);
+        }
         
         [Fact]
-        public async Task CreateWithSecrets_GetsRawSecret_EqualsInitializedSecretValue()
+        public async Task CreateWithSecrets_GetsRawSecretAsync_EqualsInitializedSecretValue()
         {
             // Arrange
             var secrets = new Dictionary<string, string>
@@ -100,9 +156,29 @@ namespace Arcus.Testing.Tests.Unit.Security
             Assert.Equal(secrets.Count, results.Length);
             Assert.All(secrets.Values, value => Assert.Contains(value, results));
         }
+
+        [Fact]
+        public void CreateWithSecrets_GetsRawSecret_EqualsInitializedSecretValue()
+        {
+            // Arrange
+            var secrets = new Dictionary<string, string>
+            {
+                ["MySecret-1"] = $"secret-{Guid.NewGuid()}",
+                ["MySecret-2"] = $"secret-{Guid.NewGuid()}",
+                ["MySecret-3"] = $"secret-{Guid.NewGuid()}"
+            };
+            var provider = new InMemorySecretProvider(secrets);
+
+            // Act
+            string[] results = secrets.Select(secret => provider.GetRawSecret(secret.Key)).ToArray();
+
+            // Assert
+            Assert.Equal(secrets.Count, results.Length);
+            Assert.All(secrets.Values, value => Assert.Contains(value, results));
+        }
         
         [Fact]
-        public async Task CreateWithSecrets_GetsSecret_EqualsInitializedSecretValue()
+        public async Task CreateWithSecrets_GetsSecretAsync_EqualsInitializedSecretValue()
         {
             // Arrange
             var secrets = new Dictionary<string, string>
@@ -118,6 +194,27 @@ namespace Arcus.Testing.Tests.Unit.Security
 
             // Assert
             Secret[] results = await Task.WhenAll(getSecrets);
+            string[] values = results.Select(result => result.Value).ToArray();
+            Assert.Equal(secrets.Count, results.Length);
+            Assert.All(secrets.Values, value => Assert.Contains(value, values));
+        }
+
+        [Fact]
+        public void CreateWithSecrets_GetsSecret_EqualsInitializedSecretValue()
+        {
+            // Arrange
+            var secrets = new Dictionary<string, string>
+            {
+                ["MySecret-1"] = $"secret-{Guid.NewGuid()}",
+                ["MySecret-2"] = $"secret-{Guid.NewGuid()}",
+                ["MySecret-3"] = $"secret-{Guid.NewGuid()}"
+            };
+            var provider = new InMemorySecretProvider(secrets);
+
+            // Act
+            Secret[] results = secrets.Select(secret => provider.GetSecret(secret.Key)).ToArray();
+
+            // Assert
             string[] values = results.Select(result => result.Value).ToArray();
             Assert.Equal(secrets.Count, results.Length);
             Assert.All(secrets.Values, value => Assert.Contains(value, values));


### PR DESCRIPTION
Add synchronous secret retrieval to the testing in-memory secret provider.