### PR TITLE
fix: correct xunit serilog extension namespace

### DIFF
--- a/src/Arcus.Testing.Logging/Extensions/LoggerSinkConfigurationExtensions.Deprecated.cs
+++ b/src/Arcus.Testing.Logging/Extensions/LoggerSinkConfigurationExtensions.Deprecated.cs
@@ -1,10 +1,10 @@
 ﻿using System;
-using Arcus.Testing.Logging;
 using GuardNet;
+using Serilog;
+using Serilog.Configuration;
 using Xunit.Abstractions;
 
-// ReSharper disable once CheckNamespace
-namespace Serilog.Configuration
+namespace Arcus.Testing.Logging.Extensions
 {
     /// <summary>
     /// Extensions on the <see cref="LoggerSinkConfiguration"/> to more easily add Serilog sinks related to logging.
@@ -17,6 +17,7 @@ namespace Serilog.Configuration
         /// <param name="config">The Serilog sink configuration where the xUnit test logging will be added.</param>
         /// <param name="outputWriter">The xUnit test output writer to write custom test output.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="config"/> or <paramref name="outputWriter"/> is <c>null</c>.</exception>
+        [Obsolete("Use the 'XunitTestLogging' extension in the 'Serilog.Configuration' namespace instead, remove the 'Arcus.Testing.Logging.Extensions' from your using statements")]
         public static LoggerConfiguration XunitTestLogging(
             this LoggerSinkConfiguration config, 
             ITestOutputHelper outputWriter)

--- a/src/Arcus.Testing.Tests.Unit/Logging/LoggerSinkConfigurationExtensionsTests.cs
+++ b/src/Arcus.Testing.Tests.Unit/Logging/LoggerSinkConfigurationExtensionsTests.cs
@@ -1,10 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using Arcus.Testing.Logging.Extensions;
 using Serilog;
+using Serilog.Configuration;
 using Xunit;
 using Xunit.Abstractions;
+using LoggerSinkConfigurationExtensions = Arcus.Testing.Logging.Extensions.LoggerSinkConfigurationExtensions;
 
 namespace Arcus.Testing.Tests.Unit.Logging
 {
@@ -29,6 +30,24 @@ namespace Arcus.Testing.Tests.Unit.Logging
         }
 
         [Fact]
+        public void AddXunitTestLoggingDeprecated_WithXunitOutputWriter_Succeeds()
+        {
+            // Arrange
+            var config = new LoggerConfiguration();
+            
+            // Act
+#pragma warning disable CS0618 // Until deprecated extension is removed.
+            LoggerSinkConfigurationExtensions.XunitTestLogging(config.WriteTo, this);
+#pragma warning restore CS0618
+
+            // Assert
+            ILogger logger = config.CreateLogger();
+            var expected = "This information message should be present in the xUnit test output writer";
+            logger.Information(expected);
+            Assert.Single(_messages, expected);
+        }
+
+        [Fact]
         public void AddXunitTestLogging_WithoutOutputWriter_Fails()
         {
             // Arrange
@@ -37,6 +56,19 @@ namespace Arcus.Testing.Tests.Unit.Logging
             // Act / Assert
             Assert.ThrowsAny<ArgumentException>(
                 () => config.WriteTo.XunitTestLogging(outputWriter: null));
+        }
+
+        [Fact]
+        public void AddXunitTestLoggingDeprecated_WithoutOutputWriter_Fails()
+        {
+            // Arrange
+            var config = new LoggerConfiguration();
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(
+#pragma warning disable CS0618 // Until deprecated extension is removed.
+                () => LoggerSinkConfigurationExtensions.XunitTestLogging(config.WriteTo, outputWriter: null));
+#pragma warning restore CS0618
         }
 
         public void WriteLine(string message)


### PR DESCRIPTION
Correct the xUnit Serilog sink extension to the correct namespace: `Serilog.Configuration`.

Closes #81