### PR TITLE
feat: ignore order for assert xml & json

### DIFF
--- a/docs/preview/02-Features/assertion.md
+++ b/docs/preview/02-Features/assertion.md
@@ -35,7 +35,7 @@ AssertXml.Equal(expected, actual);
 
 💡 Currently, the input contents are trimmed in case if the input is too big to be shown in a humanly readable manner to the test output. In case of large files, it might be best to log those files (or parts that interest you) separately before using this test assertion.
 
-### Configuration
+### Customization
 The test assertion also expose several options to tweak the behavior of the XML comparison.
 
 ```csharp
@@ -43,6 +43,15 @@ AssertXml.Equal(..., options =>
 {
     // Adds one ore more local names of XML nodes that should be excluded from the XML comparison.
     options.IgnoreNode("local-node-name");
+
+    // Sets the type of order which should be used when comparing XML attributes.
+    // REMARK: only the order of XML attributes can be set, XML elements are still compared by their contents.
+    // Default: Ignore.
+    options.Order = AssertXmlOrder.Include;
+
+    // Sets the maximum characters of the expected and actual inputs should be written to the test output.
+    // Default: 500 characters.
+    options.MaxInputCharacters = 1000;
 });
 ```
 
@@ -73,7 +82,7 @@ AssertJson.Equal(expected, actual);
 
 💡 Currently, the input contents are trimmed in case if the input is too big to be shown in a humanly readable manner to the test output. In case of large files, it might be best to log those files (or parts that interest you) separately before using this test assertion.
 
-### Configuration
+### Customization
 The test assertion also expose several options to tweak the behavior of the JSON comparison.
 
 ```csharp
@@ -81,6 +90,15 @@ AssertJson.Equal(..., options =>
 {
     // Adds one ore more property names of JSON nodes that should be excluded from the JSON comparison.
     options.IgnoreNode("node-name");
+
+    // Sets the type of order which should be used when comparing JSON array values.
+    // REMARK: only the order of JSON values can be set, JSON objects within JSON arrays are still compared by their contents.
+    // Default: Ignore.
+    options.Order = AssertJsonOrder.Include;
+
+    // Sets the maximum characters of the expected and actual inputs should be written to the test output.
+    // Default: 500 characters.
+    options.MaxInputCharacters = 1000;
 });
 ```
 

--- a/docs/preview/02-Features/assertion.md
+++ b/docs/preview/02-Features/assertion.md
@@ -39,6 +39,8 @@ AssertXml.Equal(expected, actual);
 The test assertion also expose several options to tweak the behavior of the XML comparison.
 
 ```csharp
+using Arcus.Testing;
+
 AssertXml.Equal(..., options =>
 {
     // Adds one ore more local names of XML nodes that should be excluded from the XML comparison.
@@ -54,6 +56,30 @@ AssertXml.Equal(..., options =>
     options.MaxInputCharacters = 1000;
 });
 ```
+
+### Loading XML documents yourself
+The XML assertion equalization can be called directly with raw contents - internally it parses to a valid XML structure: `XmlDocument`. It it so happens that you want to compare two XML nodes with different serialization settings, you can load the two nodes separately and do the equalization on the loaded nodes.
+
+💡 It provides you with more options to control how your file should be loaded.
+
+```csharp
+using System.Xml;
+using Arcus.Testing;
+
+string xml = ...;
+
+XmlDocument expected = AssertXml.Load(json);
+
+// Or with options (same as available with `AssertJson.Equal`).
+XmlDocument actual = AssertXml.Load(json, options => ...);
+
+// Use overload with nodes instead.
+AssertXml.Equal(expected, actual);
+```
+
+> ❓ Why use the `AssertXml` to load something that is already available with `XmlDocument.LoadXml`?
+
+The `AssertXml.Load` is a special variant on the existing load functionality in such a way that it provides more descriptive information on the input file that was trying to be parsed, plus by throwing an assertion message, it makes the test output more clear on what the problem was and where it happened. 
 
 ## JSON
 The library has an `AssertJson` class that exposes useful test assertions when dealing with JSON outputs. The most popular one is comparing JSON documents.
@@ -86,6 +112,8 @@ AssertJson.Equal(expected, actual);
 The test assertion also expose several options to tweak the behavior of the JSON comparison.
 
 ```csharp
+using Arcus.Testing;
+
 AssertJson.Equal(..., options =>
 {
     // Adds one ore more property names of JSON nodes that should be excluded from the JSON comparison.
@@ -102,6 +130,31 @@ AssertJson.Equal(..., options =>
 });
 ```
 
+### Loading JSON nodes yourself
+The JSON assertion equalization can be called directly with raw contents - internally it parses to a valid JSON structure: `JsonNode`. It it so happens that you want to compare two JSON nodes with different serialization settings, you can load the two nodes separately and do the equalization on the loaded nodes.
+
+💡 It provides you with more options to control how your file should be loaded.
+
+```csharp
+using System.Text.Json.Nodes;
+using Arcus.Testing;
+
+string json = ...;
+
+JsonNode expected = AssertJson.Load(json);
+
+// Or with options (same as available with `AssertJson.Equal`).
+JsonNode actual = AssertJson.Load(json, options => ...);
+
+// Use overload with nodes instead.
+AssertJson.Equal(expected, actual);
+```
+
+> ❓ Why use the `AssertJson` to load something that is already available with `JsonNode.Parse`?
+
+The `AssertJson.Load` is a special variant on the existing load functionality in such a way that it provides more descriptive information on the input file that was trying to be parsed, plus by throwing an assertion message, it makes the test output more clear on what the problem was and where it happened. 
+
+
 ## XSLT
 The library has an `AssertXslt` class that exposes useful test assertions when dealing with XSLT transformation. The most popular one is transforming XML contents to either XML or JSON.
 
@@ -117,6 +170,7 @@ string xslt = "<xsl:stylesheet>...</xsl:stylesheet>";
 
 string expected = "<other-data>...</other-data>"
 string actual = AssertXslt.TransformXml(xslt, input);
+// Use `AssertXml.Equal` to do the equalization.
 
 // XML -> JSON
 // ----------------------------------------------------
@@ -125,6 +179,32 @@ string xslt = "<xsl:stylesheet>...</xsl:stylesheet>";
 
 string expected = "{ \"data\": ... }";
 string actual = AssertXslt.TransformJson(xslt, input);
+// Use `AssertJson.Equal` to do the equalization.
 ```
 
 💡 Both types of transformations can be adapted by passing any runtime XSLT arguments.
+
+> ❓ Why use the `AssertXslt` to load something that is already available with `XsltCompiledTransform.Load`?
+
+The `AssertXslt.TransformXml/Json` are special variants on the existing transform functionality in such a way that it provides more descriptive information on the input file that was trying to be parsed, plus by throwing an assertion message, it makes the test output more clear on what the problem was and where it happened. 
+
+### Loading XSLT transformations yourself
+The asserted XSLT transformation is loading valid `XslCompiledTransform` instances from raw contents, but you can also call this asserted loading yourself before calling the asserted transformation.
+
+```csharp
+using System.Text.Json.Nodes;
+using System.Xml;
+using System.Xml.Xsl;
+using Arcus.Testing;
+
+string xslt = "<xsl:stylesheet>...</xsl:stylesheet>";
+XslCompiledTransform transformer = AssertXslt.Load(xslt);
+
+// Use overload with compiled transform instead.
+XmlDocument xml = AssertXslt.TransformXml(transformer, ...);
+JsonNode json = AssertXslt.TransformJson(transformer, ...);
+```
+
+> ❓ Why use the `AssertXslt.Load` to load something that is already available with `XslCompiledTransform.Load`?
+
+The `AssertXslt.Load` is a special variant on the existing load functionality in such a way that it provides more descriptive information on the input file that ws trying to be parsed, plus by throwing an assertion message, it mes the test output more clear on what the problem was and where it happened.

--- a/docs/preview/02-Features/assertion.md
+++ b/docs/preview/02-Features/assertion.md
@@ -33,7 +33,7 @@ AssertXml.Equal(expected, actual);
 // </diff-root>
 ```
 
-💡 Currently, the input contents are trimmed in case if the input is too big to be shown in a humanly readable manner to the test output. In case of large files, it might be best to log those files (or parts that interest you) separately before using this test assertion.
+💡 Currently, the input contents are trimmed in case the input is too big to be shown in a humanly readable manner to the test output. In case of large files, it might be best to log those files (or parts that interest you) separately before using this test assertion.
 
 ### Customization
 The test assertion also exposes several options to tweak the behavior of the XML comparison.
@@ -106,7 +106,7 @@ AssertJson.Equal(expected, actual);
 // }
 ```
 
-💡 Currently, the input contents are trimmed in case if the input is too big to be shown in a humanly readable manner to the test output. In case of large files, it might be best to log those files (or parts that interest you) separately before using this test assertion.
+💡 Currently, the input contents are trimmed in case the input is too big to be shown in a humanly readable manner to the test output. In case of large files, it might be best to log those files (or parts that interest you) separately before using this test assertion.
 
 ### Customization
 The test assertion also exposes several options to tweak the behavior of the JSON comparison.

--- a/docs/preview/02-Features/assertion.md
+++ b/docs/preview/02-Features/assertion.md
@@ -109,7 +109,7 @@ AssertJson.Equal(expected, actual);
 💡 Currently, the input contents are trimmed in case if the input is too big to be shown in a humanly readable manner to the test output. In case of large files, it might be best to log those files (or parts that interest you) separately before using this test assertion.
 
 ### Customization
-The test assertion also expose several options to tweak the behavior of the JSON comparison.
+The test assertion also exposes several options to tweak the behavior of the JSON comparison.
 
 ```csharp
 using Arcus.Testing;

--- a/docs/preview/02-Features/assertion.md
+++ b/docs/preview/02-Features/assertion.md
@@ -58,7 +58,7 @@ AssertXml.Equal(..., options =>
 ```
 
 ### Loading XML documents yourself
-The XML assertion equalization can be called directly with raw contents - internally it parses to a valid XML structure: `XmlDocument`. It it so happens that you want to compare two XML nodes with different serialization settings, you can load the two nodes separately and do the equalization on the loaded nodes.
+The XML assertion equalization can be called directly with raw contents - internally it parses to a valid XML structure: `XmlDocument`. If you want to compare two XML nodes with different serialization settings, you can load the two nodes separately and do the equalization on the loaded nodes.
 
 💡 It provides you with more options to control how your file should be loaded.
 
@@ -131,7 +131,7 @@ AssertJson.Equal(..., options =>
 ```
 
 ### Loading JSON nodes yourself
-The JSON assertion equalization can be called directly with raw contents - internally it parses to a valid JSON structure: `JsonNode`. It it so happens that you want to compare two JSON nodes with different serialization settings, you can load the two nodes separately and do the equalization on the loaded nodes.
+The JSON assertion equalization can be called directly with raw contents - internally it parses to a valid JSON structure: `JsonNode`. If you want to compare two JSON nodes with different serialization settings, you can load the two nodes separately and do the equalization on the loaded nodes.
 
 💡 It provides you with more options to control how your file should be loaded.
 

--- a/docs/preview/02-Features/assertion.md
+++ b/docs/preview/02-Features/assertion.md
@@ -51,7 +51,7 @@ AssertXml.Equal(..., options =>
     // Default: Ignore.
     options.Order = AssertXmlOrder.Include;
 
-    // Sets the maximum characters of the expected and actual inputs should be written to the test output.
+    // Sets the maximum characters of the expected and actual inputs that should be written to the test output.
     // Default: 500 characters.
     options.MaxInputCharacters = 1000;
 });
@@ -124,7 +124,7 @@ AssertJson.Equal(..., options =>
     // Default: Ignore.
     options.Order = AssertJsonOrder.Include;
 
-    // Sets the maximum characters of the expected and actual inputs should be written to the test output.
+    // Sets the maximum characters of the expected and actual inputs that should be written to the test output.
     // Default: 500 characters.
     options.MaxInputCharacters = 1000;
 });

--- a/docs/preview/02-Features/assertion.md
+++ b/docs/preview/02-Features/assertion.md
@@ -36,7 +36,7 @@ AssertXml.Equal(expected, actual);
 💡 Currently, the input contents are trimmed in case if the input is too big to be shown in a humanly readable manner to the test output. In case of large files, it might be best to log those files (or parts that interest you) separately before using this test assertion.
 
 ### Customization
-The test assertion also expose several options to tweak the behavior of the XML comparison.
+The test assertion also exposes several options to tweak the behavior of the XML comparison.
 
 ```csharp
 using Arcus.Testing;

--- a/src/Arcus.Testing.Assert/AssertXslt.cs
+++ b/src/Arcus.Testing.Assert/AssertXslt.cs
@@ -65,7 +65,7 @@ namespace Arcus.Testing
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="transformer"/> or the <paramref name="input"/> is <c>null</c>.</exception>
         /// <exception cref="XsltException">Thrown when the XSLT transformation was not successful.</exception>
         /// <exception cref="XmlException">Thrown when the output could not be successfully loaded into a structured XML document.</exception>
-        public static XmlNode TransformXml(XslCompiledTransform transformer, XmlNode input)
+        public static XmlDocument TransformXml(XslCompiledTransform transformer, XmlNode input)
         {
             return TransformXml(
                 transformer ?? throw new ArgumentNullException(nameof(transformer)), 
@@ -83,7 +83,7 @@ namespace Arcus.Testing
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="transformer"/> or the <paramref name="input"/> is <c>null</c>.</exception>
         /// <exception cref="XsltException">Thrown when the XSLT transformation was not successful.</exception>
         /// <exception cref="XmlException">Thrown when the output could not be successfully loaded into a structured XML document.</exception>
-        public static XmlNode TransformXml(XslCompiledTransform transformer, XmlNode input, XsltArgumentList arguments)
+        public static XmlDocument TransformXml(XslCompiledTransform transformer, XmlNode input, XsltArgumentList arguments)
         {
             if (transformer is null)
             {

--- a/src/Arcus.Testing.Tests.Unit/Assert_/AssertXmlTests.cs
+++ b/src/Arcus.Testing.Tests.Unit/Assert_/AssertXmlTests.cs
@@ -14,6 +14,46 @@ namespace Arcus.Testing.Tests.Unit.Assert_
         private static readonly Faker Bogus = new();
 
         [Property]
+        public void CompareWithDefaultIgnoredOrderOption_WithDifferentOrderInput_Succeeds()
+        {
+            // Arrange
+            TestXml expected = TestXml.Generate();
+            TestXml actual = expected.Copy();
+
+            expected.Shuffle();
+
+            // Act
+            Equal(expected, actual);
+        }
+
+        [Property]
+        public void CompareWithInclude_WithDifferentOrder_FailsWithDescription()
+        {
+            // Arrange
+            TestXml expected = TestXml.Generate();
+            TestXml actual = expected.Copy();
+
+            expected.Shuffle();
+
+            // Act / Assert
+            CompareShouldFail(() => Equal(expected, actual, options => options.Order = AssertXmlOrder.Include));
+        }
+
+        [Property]
+        public void Compare_WithoutAttribute_FailsWithDescription()
+        {
+            // Arrange
+            TestXml expected = TestXml.Generate();
+            TestXml actual = expected.Copy();
+
+            string newName = Bogus.Lorem.Word();
+            actual.ChangeAttributeName(newName);
+
+            // Act / Assert
+            CompareShouldFailWithDifference(expected, actual, "misses an attribute", newName);
+        }
+
+        [Property]
         public void Compare_DiffElementName_FailsWithDescription()
         {
             // Arrange
@@ -24,7 +64,7 @@ namespace Arcus.Testing.Tests.Unit.Assert_
             actual.ChangeElementName(newName);
 
             // Act / Assert
-            CompareShouldFailWithDifference(actual, expected, "different name", "element", newName);
+            CompareShouldFailWithDifference(expected, actual, "different name", "element", newName);
         }
 
         [Fact]
@@ -35,7 +75,7 @@ namespace Arcus.Testing.Tests.Unit.Assert_
             var actual = $"<root>{Bogus.Random.Int()}</root>";
 
             // Act / Assert
-            CompareShouldFailWithDifference(actual, expected, "has a different value at", "while actual");
+            CompareShouldFailWithDifference(expected, actual, "has a different value at", "while actual");
         }
 
         [Property]
@@ -49,7 +89,7 @@ namespace Arcus.Testing.Tests.Unit.Assert_
             actual.ChangeRandomlyElementValue(newValue);
 
             // Act / Assert
-            CompareShouldFailWithDifference(actual, expected, "different value", newValue);
+            CompareShouldFailWithDifference(expected, actual, "different value", newValue);
         }
 
         [Fact]
@@ -60,7 +100,7 @@ namespace Arcus.Testing.Tests.Unit.Assert_
             string actual = $"<ns:root xmlns:ns=\"{Bogus.Internet.Url()}\"/>";
 
             // Act / Assert
-            CompareShouldFailWithDifference(actual, expected, "different namespace");
+            CompareShouldFailWithDifference(expected, actual, "different namespace");
         }
 
         [Property]
@@ -73,7 +113,7 @@ namespace Arcus.Testing.Tests.Unit.Assert_
             actual.InsertElement(TestXml.GenNodeName());
 
             // Act / Assert
-            CompareShouldFailWithDifference(actual, expected, "has", "element(s)", "instead of");
+            CompareShouldFailWithDifference(expected, actual, "has", "element(s)", "instead of");
         }
 
         [Property]
@@ -87,7 +127,8 @@ namespace Arcus.Testing.Tests.Unit.Assert_
             actual.ChangeAttributeName("diff" + newName);
 
             // Act / Assert
-            CompareShouldFailWithDifference(actual, expected, "different name", "attribute", newName);
+            CompareShouldFail(() => Equal(expected, actual, options => options.Order = AssertXmlOrder.Include),
+                "different name", "attribute", newName);
         }
 
         [Property]
@@ -101,7 +142,7 @@ namespace Arcus.Testing.Tests.Unit.Assert_
             actual.ChangeAttributeValue("diff" + newValue);
 
             // Act / Assert
-            CompareShouldFailWithDifference(actual, expected, "different value", "@", newValue);
+            CompareShouldFailWithDifference(expected, actual, "different value", "@", newValue);
         }
 
         [Property]
@@ -114,7 +155,7 @@ namespace Arcus.Testing.Tests.Unit.Assert_
             actual.InsertAttribute(TestXml.GenNodeName());
             
             // Act / Assert
-            CompareShouldFailWithDifference(actual, expected, "has", "attribute(s)", "instead of");
+            CompareShouldFailWithDifference(expected, actual, "has", "attribute(s)", "instead of");
         }
 
         [Property]
@@ -127,7 +168,8 @@ namespace Arcus.Testing.Tests.Unit.Assert_
             actual.ChangeAttributeNamespace(Bogus.Internet.Url());
 
             // Act / Assert
-            CompareShouldFailWithDifference(actual, expected, "different namespace", "@");
+            CompareShouldFail(() => Equal(expected, actual, options => options.Order = AssertXmlOrder.Include),
+                "different namespace", "@");
         }
 
         public static IEnumerable<object[]> SucceedingBeEquivalentCases
@@ -187,102 +229,112 @@ namespace Arcus.Testing.Tests.Unit.Assert_
             {
                 yield return new object[]
                 {
-                    "<items><fork/><knife/><spoon/></items>",
                     "<items><fork/><knife/></items>",
+                    "<items><fork/><knife/><spoon/></items>",
                     "has 3 element(s) instead of 2 at /items"
                 };
                 yield return new object[]
                 {
-                    "<items><fork/><knife/></items>",
                     "<items><fork/><knife/><spoon/></items>",
+                    "<items><fork/><knife/></items>",
                     "2 element(s) instead of 3 at /items/"
                 };
                 yield return new object[]
                 {
+                    "<items><fork/><spoon/><knife/></items>",
                     "<items><fork/><knife/><spoon/></items>",
-                    "<items><fork /><spoon/><knife/></items>",
-                    "has a different name at /items/spoon[1], expected an element: <spoon> while actual an element: <knife>"
+                    "has a different name at /items/spoon, expected an element: <spoon> while actual an element: <knife>",
+                    AssertXmlOrder.Include
                 };
                 yield return new object[]
                 {
-                    "<items><branch/></items>",
                     "<items>2</items>",
+                    "<items><branch/></items>",
                     "has a different value at /items/text(), expected a number: 2 while actual an element: <branch>"
                 };
                 yield return new object[]
                 {
-                    "<tree><branch/></tree>",
                     "<tree>\"oak\"</tree>",
+                    "<tree><branch/></tree>",
                     "as a different value at /tree/text(), expected a string: \"oak\" while actual an element: <branch>"
                 };
                 yield return new object[]
                 {
-                    "<tree><leaves>10</leaves></tree>",
                     "<tree><branches>5</branches><leaves>10</leaves></tree>",
+                    "<tree><leaves>10</leaves></tree>",
                     "has 1 element(s) instead of 2 at /tree/"
                 };
                 yield return new object[]
                 {
-                    "<tree><branches>5</branches><leaves>10</leaves></tree>",
                     "<tree><leaves>10</leaves></tree>",
+                    "<tree><branches>5</branches><leaves>10</leaves></tree>",
                     "has 2 element(s) instead of 1 at /tree/"
                 };
                 yield return new object[]
                 {
-                    "<tree><leaves>5</leaves></tree>",
                     "<tree><leaves>10</leaves></tree>",
+                    "<tree><leaves>5</leaves></tree>",
                     "has a different value at /tree/leaves/text(), expected a number: 10 while actual a number: 5"
                 };
                 yield return new object[]
                 {
-                    "<eyes>\"blue\"</eyes>",
                     "<eyes>2</eyes>",
+                    "<eyes>\"blue\"</eyes>",
                     "has a different value at /eyes/text(), expected a number: 2 while actual a string: \"blue\""
                 };
                 yield return new object[]
                 {
-                    "<id>1</id>",
                     "<id>2</id>",
+                    "<id>1</id>",
                     "has a different value at /id"
                 };
                 yield return new object[]
                 {
-                    "<tree branches=\"10\" />",
                     "<tree branches=\"11\" />",
+                    "<tree branches=\"10\" />",
                     "has a different value at /tree[@branches], expected a number: 11 while actual a number: 10"
                 };
                 yield return new object[]
                 {
-                    "<items meta=\"data\" other=\"19\" />",
                     "<items meta=\"data\" info=\"root\" />",
-                    "has a different name at /items[@info], expected an attribute: info while actual an attribute: other"
+                    "<items meta=\"data\" other=\"19\" />",
+                    "has a different name at /items[@info], expected an attribute: info while actual an attribute: other",
+                    AssertXmlOrder.Include
                 };
                 yield return new object[]
                 {
-                    "<tree><branches branch_1=\"\" branch_2=\"\" branch_3=\"\"/></tree>",
+                    "<items meta=\"data\" info=\"root\" />",
+                    "<items meta=\"data\" other=\"19\" />",
+                    "misses an attribute: info at /items[@info]",
+                    AssertXmlOrder.Ignore
+                };
+                yield return new object[]
+                {
                     "<tree><branches branch_1=\"\" branch_2=\"\"/></tree>",
+                    "<tree><branches branch_1=\"\" branch_2=\"\" branch_3=\"\"/></tree>",
                     "3 attribute(s) instead of 2 at /tree/branches"
                 };
                 yield return new object[]
                 {
-                    "<tree xmlns:ns1=\"https://nature.com\"><ns1:branch/><ns2:branch xmlns:ns2=\"https://diff.com\"/></tree>",
                     "<tree xmlns:ns1=\"https://nature.com\"><ns1:branch/><ns1:branch/></tree>",
+                    "<tree xmlns:ns1=\"https://nature.com\"><ns1:branch/><ns2:branch xmlns:ns2=\"https://diff.com\"/></tree>",
                     "has a different namespace at /tree/branch[1], expected https://nature.com while actual https://diff.com"
                 };
                 yield return new object[]
                 {
-                    "<tree><branch xmlns:ns1=\"https://climate.com\" xmlns:ns2=\"https://earth.com\" ns1:leaf_1=\"\" ns2:leaf_2=\"\"/></tree>",
                     "<tree><branch xmlns:ns1=\"https://climate.com\" ns1:leaf_1=\"\" ns1:leaf_2=\"\"/></tree>",
-                    "has a different namespace at /tree/branch[@leaf_2], expected https://climate.com while actual https://earth.com"
+                    "<tree><branch xmlns:ns1=\"https://climate.com\" xmlns:ns2=\"https://earth.com\" ns1:leaf_1=\"\" ns2:leaf_2=\"\"/></tree>",
+                    "has a different namespace at /tree/branch[@leaf_2], expected https://climate.com while actual https://earth.com",
+                    AssertXmlOrder.Include
                 };
             }
         }
 
         [Theory]
         [MemberData(nameof(FailingBeEquivalentCases))]
-        public void Compare_WithNotEqual_ShouldFailWithDifference(string actualXml, string expectedXml, string expectedDifference)
+        public void Compare_WithNotEqual_ShouldFailWithDifference(string expectedXml, string actualXml, string expectedDifference, AssertXmlOrder? order = null)
         {
-            CompareShouldFailWithDifference(actualXml, expectedXml, expectedDifference);
+            CompareShouldFail(() => Equal(expectedXml, actualXml, options => options.Order = order ?? options.Order), expectedDifference);
         }
 
         [Property]
@@ -302,14 +354,17 @@ namespace Arcus.Testing.Tests.Unit.Assert_
             string[] diffExpectedNames = CreateNodeNames("diff");
             InsertDiffNodes(expected, diffExpectedNames);
 
-            var actual = expected.Copy();
+            TestXml actual = expected.Copy();
 
             string[] diffActualNames = CreateNodeNames("diff-");
             InsertDiffNodes(actual, diffActualNames);
 
             // Act / Assert
-            Equal(expected.ToString(), actual.ToString(), 
-                options => Assert.All(diffActualNames.Concat(diffExpectedNames), name => options.IgnoreNode(name)));
+            Equal(expected, actual, 
+                options => Assert.All(diffActualNames.Concat(diffExpectedNames), name =>
+                {
+                    options.IgnoreNode(name);
+                }));
         }
 
         private void InsertDiffNodes(TestXml xml, string[] names)
@@ -353,26 +408,42 @@ namespace Arcus.Testing.Tests.Unit.Assert_
             Assert.ThrowsAny<AssertionException>(() => Equal(expected, actual));
         }
 
-        private static void CompareShouldFailWithDifference(TestXml actual, TestXml expected, params string[] expectedDifferences)
+        private static void CompareShouldFailWithDifference(TestXml expected, TestXml actual, params string[] expectedDifferences)
         {
-            CompareShouldFailWithDifference(actual.ToString(), expected.ToString(), expectedDifferences);
+            CompareShouldFailWithDifference(expected.ToString(), actual.ToString(), expectedDifferences);
         }
 
-        private static void CompareShouldFailWithDifference(string actualXml, string expectedXml, params string[] expectedDifferences)
+        private static void CompareShouldFailWithDifference(string expectedXml, string actualXml, params string[] expectedDifferences)
         {
-            var exception = Assert.ThrowsAny<AssertionException>(() => Equal(expectedXml, actualXml, options => options.MaxInputCharacters = int.MaxValue));
+            CompareShouldFail(() => Equal(expectedXml, actualXml, options => options.MaxInputCharacters = int.MaxValue), expectedDifferences);
+        }
+
+        private static void CompareShouldFail(Action testCode, params string[] expectedDifferences)
+        {
+            var exception = Assert.ThrowsAny<AssertionException>(testCode);
             Assert.All(expectedDifferences, expectedDifference => Assert.Contains(expectedDifference, exception.Message));
+        }
+
+        private static void Equal(TestXml expected, TestXml actual, Action<AssertXmlOptions> configureOptions = null)
+        {
+            Equal(expected.ToString(), actual.ToString(), configureOptions);
         }
 
         private static void Equal(string expected, string actual, Action<AssertXmlOptions> configureOptions = null)
         {
+            void ConfigureOptions(AssertXmlOptions options)
+            {
+                options.MaxInputCharacters = int.MaxValue;
+                configureOptions?.Invoke(options);
+            }
+
             if (Bogus.Random.Bool())
             {
-                AssertXml.Equal(expected, actual, configureOptions);
+                AssertXml.Equal(expected, actual, ConfigureOptions);
             }
             else
             {
-                AssertXml.Equal(AssertXml.Load(expected), AssertXml.Load(actual), configureOptions);
+                AssertXml.Equal(AssertXml.Load(expected), AssertXml.Load(actual), ConfigureOptions);
             }
         }
 
@@ -382,6 +453,37 @@ namespace Arcus.Testing.Tests.Unit.Assert_
             var exception = Assert.Throws<XmlException>(() => AssertXml.Load(Bogus.Random.String()));
             Assert.Contains(nameof(AssertXml), exception.Message);
             Assert.Contains("XML contents", exception.Message);
+        }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void IgnoreNode_WithoutValue_Fails(string nodeName)
+        {
+            // Arrange
+            var options = new AssertXmlOptions();
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(() => options.IgnoreNode(nodeName));
+        }
+
+        [Fact]
+        public void MaxInputCharacters_WithNegativeValue_Fails()
+        {
+            // Arrange
+            var options = new AssertXmlOptions();
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(() => options.MaxInputCharacters = Bogus.Random.Int(max: -1));
+        }
+
+        [Fact]
+        public void Order_OutsideEnumeration_Fails()
+        {
+            // Arrange
+            var options = new AssertXmlOptions();
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(() => options.Order = (AssertXmlOrder) Bogus.Random.Int(min: 2));
         }
     }
 }

--- a/src/Arcus.Testing.Tests.Unit/Assert_/Fixture/TestXml.cs
+++ b/src/Arcus.Testing.Tests.Unit/Assert_/Fixture/TestXml.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Xml;
 using Bogus;
-using Bogus.DataSets;
 using Xunit;
 
 namespace Arcus.Testing.Tests.Unit.Assert_.Fixture
@@ -202,20 +201,6 @@ namespace Arcus.Testing.Tests.Unit.Assert_.Fixture
         public void InsertAttribute(string name)
         {
             SelectRandomlyElement().Attributes.Append(CreateAttribute(_doc, name));
-        }
-
-        public XmlAttribute RemoveAttribute()
-        {
-            XmlElement element = SelectRandomlyElement();
-            XmlAttribute attribute = Bogus.PickRandom(element.Attributes.OfType<XmlAttribute>());
-
-            element.Attributes.Remove(attribute);
-            return attribute;
-        }
-
-        public XmlAttribute CreateAttribute()
-        {
-            return CreateAttribute(_doc);
         }
 
         private static XmlAttribute CreateAttribute(XmlDocument doc, string name = null)

--- a/src/Arcus.Testing.Tests.Unit/Assert_/Fixture/TestXml.cs
+++ b/src/Arcus.Testing.Tests.Unit/Assert_/Fixture/TestXml.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Xml;
 using Bogus;
+using Bogus.DataSets;
 using Xunit;
 
 namespace Arcus.Testing.Tests.Unit.Assert_.Fixture
@@ -12,7 +13,7 @@ namespace Arcus.Testing.Tests.Unit.Assert_.Fixture
     /// </summary>
     public class TestXml
     {
-        private readonly XmlDocument _doc;
+        private XmlDocument _doc;
         private static readonly Faker Bogus = new();
 
         private TestXml(XmlDocument doc)
@@ -40,7 +41,7 @@ namespace Arcus.Testing.Tests.Unit.Assert_.Fixture
                 }
 
                 XmlElement[] children = 
-                    Bogus.Make(Bogus.Random.Int(1, 10), GenNodeName)
+                    Bogus.Make(Bogus.Random.Int(1, 5), GenNodeName)
                          .Select(name =>
                          {
                              string ns = Bogus.Random.Bool() ? current.NamespaceURI : GenNamespace();
@@ -71,14 +72,14 @@ namespace Arcus.Testing.Tests.Unit.Assert_.Fixture
 
         private static XmlAttribute[] GenAttributes(XmlDocument doc)
         {
-            return Bogus.Make(Bogus.Random.Int(1, 10), () => CreateAttribute(doc)).ToArray();
+            return Bogus.Make(Bogus.Random.Int(5, 10), () => CreateAttribute(doc)).ToArray();
         }
 
         private static string GenPrefix()
         {
             string Gen()
             {
-                return string.Concat(Bogus.PickRandom(Alphabet(), Bogus.Random.Int(1, 5)));
+                return string.Concat(Bogus.PickRandom(Alphabet(), Bogus.Random.Int(4, 6)));
             }
 
             string prefix = Gen();
@@ -203,6 +204,20 @@ namespace Arcus.Testing.Tests.Unit.Assert_.Fixture
             SelectRandomlyElement().Attributes.Append(CreateAttribute(_doc, name));
         }
 
+        public XmlAttribute RemoveAttribute()
+        {
+            XmlElement element = SelectRandomlyElement();
+            XmlAttribute attribute = Bogus.PickRandom(element.Attributes.OfType<XmlAttribute>());
+
+            element.Attributes.Remove(attribute);
+            return attribute;
+        }
+
+        public XmlAttribute CreateAttribute()
+        {
+            return CreateAttribute(_doc);
+        }
+
         private static XmlAttribute CreateAttribute(XmlDocument doc, string name = null)
         {
             if (Bogus.Random.Bool())
@@ -272,12 +287,43 @@ namespace Arcus.Testing.Tests.Unit.Assert_.Fixture
 
         private static XmlElement SelectRandomly(XmlElement node, Func<XmlElement, bool> filter)
         {
-            IEnumerable<XmlElement> elements = node.ChildNodes.OfType<XmlElement>()
-                                                      .Select(n => SelectRandomly(n, filter))
-                                                      .Where(n => filter?.Invoke(n) ?? true)
-                                                      .Concat(filter?.Invoke(node) ?? true ? new[] { node } : Array.Empty<XmlElement>());
-            return Bogus.PickRandom(
-                elements);
+            IEnumerable<XmlElement> elements = 
+                node.ChildNodes.OfType<XmlElement>()
+                    .Select(n => SelectRandomly(n, filter))
+                    .Where(n => filter?.Invoke(n) ?? true)
+                    .Concat(filter?.Invoke(node) ?? true ? new[] { node } : Array.Empty<XmlElement>());
+            
+            return Bogus.PickRandom(elements);
+        }
+
+        public void Shuffle()
+        {
+            XmlNode shuffled = Shuffle(_doc.DocumentElement);
+            
+            var xml = new XmlDocument();
+            xml.LoadXml(shuffled.OuterXml);
+            _doc = xml;
+        }
+
+        private static XmlNode Shuffle(XmlNode node)
+        {
+            if (node is XmlElement element)
+            {
+                var attributes = Bogus.Random.Shuffle(
+                    element.Attributes.OfType<XmlAttribute>()
+                           .Where(a => a.NamespaceURI != "http://www.w3.org/2000/xmlns/")).ToArray();
+                
+                Assert.All(attributes, attr => element.RemoveAttribute(attr.Name));
+
+                foreach (var attr in attributes)
+                {
+                    element.SetAttributeNode(attr);
+                }
+
+                return element;
+            }
+
+            return node;
         }
     }
 }


### PR DESCRIPTION
Makes sure that XML attributes and JSON array values are compared by default without taking the order of their presence into account. To override this, a new option is added to the assertion options.

This is the last feature in the Testing Framework's comparisons that was missing from Arcus.

Closes #101 