### PR TITLE
chore: streamline readme w/ other repo's

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,25 +6,8 @@ Reusable testing components for Arcus repo's.
 
 ![Arcus](https://raw.githubusercontent.com/arcus-azure/arcus/master/media/arcus.png)
 
-# Installation
-Easy to install it via NuGet:
-
-- **Logging**
-```shell
-PM > Install-Package Arcus.Testing.Logging
-```
-
-- **In-memory secret store**
-```shell
-PM > Install-Package Arcus.Testing.Security.Providers.InMemory
-```
-
-For a more thorough overview, we recommend reading our [documentation](/docs/index.md).
-
-# Features
-
-* [Logging](/docs/features/logging.md): provides reusable logging components during testing.
-* [In-memory secret provider](/docs/features/inmemory-secret-provider.md): provides an secret provider with in-memory secrets during testing. 
+# Documentation
+All documentation can be found on [here](https://testing.arcus-azure.net/).
 
 # License Information
 This is licensed under The MIT License (MIT). Which means that you can use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the web application. But you always need to state that Codit is the original author of this web application.


### PR DESCRIPTION
Streamline the current `README.md` with the other Arcus repositories now that it can be used outside the internal Arcus ecosystem (points to the documentation site instead of placing the installation sections directly in the `README.md`).