### PR TITLE
test: correct xml/json test inputs

### DIFF
--- a/src/Arcus.Testing.Tests.Unit/Assert_/Fixture/TestXml.cs
+++ b/src/Arcus.Testing.Tests.Unit/Assert_/Fixture/TestXml.cs
@@ -294,15 +294,20 @@ namespace Arcus.Testing.Tests.Unit.Assert_.Fixture
         {
             if (node is XmlElement element)
             {
-                var attributes = Bogus.Random.Shuffle(
+                XmlAttribute[] attributes = Bogus.Random.Shuffle(
                     element.Attributes.OfType<XmlAttribute>()
                            .Where(a => a.NamespaceURI != "http://www.w3.org/2000/xmlns/")).ToArray();
                 
                 Assert.All(attributes, attr => element.RemoveAttribute(attr.Name));
 
-                foreach (var attr in attributes)
+                foreach (XmlAttribute attr in attributes)
                 {
                     element.SetAttributeNode(attr);
+                }
+
+                foreach (XmlElement child in element.ChildNodes.OfType<XmlElement>())
+                {
+                    Shuffle(child);
                 }
 
                 return element;


### PR DESCRIPTION
Corrects the XML inputs of the test assertion to not include `&` and make sure that upon shuffling all the child elements are also shuffled.

In both cases there was a rare instance that a generated value contained an `&` or was 'not enough' shuffled to make the test succeed.

This PR also make sure that there is more logging in both tests so that upon failure, we clearly see the test inputs; this to more quickly spot any future failures.

Follow-up of #101 