### PR TITLE
chore: add net6.0 support for assertion library

### DIFF
--- a/src/Arcus.Testing.Assert/Arcus.Testing.Assert.csproj
+++ b/src/Arcus.Testing.Assert/Arcus.Testing.Assert.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <RootNamespace>Arcus.Testing</RootNamespace>
     <Authors>Arcus</Authors>
     <Company>Arcus</Company>

--- a/src/Arcus.Testing.Assert/AssertCsv.cs
+++ b/src/Arcus.Testing.Assert/AssertCsv.cs
@@ -397,8 +397,8 @@ namespace Arcus.Testing
             
             if (options.ColumnOrder is AssertCsvOrder.Ignore)
             {
-                expectedHeaders = expectedHeaders.Order().ToArray();
-                actualHeaders = actualHeaders.Order().ToArray();
+                expectedHeaders = expectedHeaders.OrderBy(h => h).ToArray();
+                actualHeaders = actualHeaders.OrderBy(h => h).ToArray();
             }
 
             for (var i = 0; i < expectedHeaders.Count; i++)
@@ -775,8 +775,9 @@ namespace Arcus.Testing
                 return true;
             }
 
-            if (float.TryParse(Value, _culture, out float expectedValue)
-                && float.TryParse(other.Value, _culture, out float actualValue))
+            const NumberStyles style = NumberStyles.Float | NumberStyles.AllowThousands;
+            if (float.TryParse(Value, style, _culture, out float expectedValue)
+                && float.TryParse(other.Value, style, _culture, out float actualValue))
             {
                 if (!expectedValue.Equals(actualValue))
                 {

--- a/src/Arcus.Testing.Core/Arcus.Testing.Core.csproj
+++ b/src/Arcus.Testing.Core/Arcus.Testing.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <RootNamespace>Arcus.Testing</RootNamespace>
     <Authors>Arcus</Authors>
     <Company>Arcus</Company>

--- a/src/Arcus.Testing.Tests.Unit/Arcus.Testing.Tests.Unit.csproj
+++ b/src/Arcus.Testing.Tests.Unit/Arcus.Testing.Tests.Unit.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/Arcus.Testing.Tests.Unit/Assert_/AssertJsonTests.cs
+++ b/src/Arcus.Testing.Tests.Unit/Assert_/AssertJsonTests.cs
@@ -63,7 +63,7 @@ namespace Arcus.Testing.Tests.Unit.Assert_
             actual.InsertProperty(newName);
 
             // Act / Assert
-            CompareShouldFailWithDifference(actual, expected, "misses property", newName);
+            CompareShouldFailWithDifference(expected, actual, "misses property", newName);
         }
 
         [Property]
@@ -124,7 +124,7 @@ namespace Arcus.Testing.Tests.Unit.Assert_
                 {
                     "{ \"items\": 2 }",
                     "{ \"items\": [] }",
-                    "has an array: [] instead of a number: 2 at $.items"
+                    "different type at $.items, expected a number: 2 while actual an array: []"
                 };
                 yield return new object[]
                 {
@@ -148,7 +148,7 @@ namespace Arcus.Testing.Tests.Unit.Assert_
                 {
                     "{ \"tree\": \"oak\" }",
                     "{ \"tree\": { } }",
-                    "has an object: {} instead of a string: oak at $.tree"
+                    "different type at $.tree, expected a string: oak while actual an object: {}"
                 };
                 yield return new object[]
                 {
@@ -166,25 +166,25 @@ namespace Arcus.Testing.Tests.Unit.Assert_
                 {
                     "{ \"tree\": { \"leaves\": 10} }",
                     "{ \"tree\": { \"leaves\": 5 } }",
-                    "has a different value at $.tree.leaves"
+                    "different value at $.tree.leaves, expected a number: 10 while actual a number: 5"
                 };
                 yield return new object[]
                 {
                     "{ \"eyes\": [] }",
                     "{ \"eyes\": \"blue\" }",
-                    "has a string: blue instead of an array: [] at $.eyes"
+                    "different type at $.eyes, expected an array: [] while actual a string: blue"
                 };
                 yield return new object[]
                 {
                     "{ \"eyes\": 2 }",
                     "{ \"eyes\": \"blue\" }",
-                    "has a string: blue instead of a number: 2 at $.eyes"
+                    "at $.eyes, expected a number: 2 while actual a string: blue"
                 };
                 yield return new object[]
                 {
                     "{ \"id\": 2 }",
                     "{ \"id\": 1 }",
-                    "has a different value at $.id"
+                    "different value at $.id, expected a number: 2 while actual a number: 1"
                 };
                 yield return new object[]
                 {
@@ -272,13 +272,13 @@ namespace Arcus.Testing.Tests.Unit.Assert_
                 {
                     "{ \"id\": 2 }",
                     "\"null\"",
-                    "has a string: null instead of an object: {\"id\":2} at $"
+                    "different type at $, expected an object: {\"id\":2} while actual a string: null"
                 };
                 yield return new object[]
                 {
                     "\"null\"",
                     "{ \"id\": 1 }",
-                    "has an object: {\"id\":1} instead of a string: null at $"
+                    "different type at $, expected a string: null while actual an object: {\"id\":1}"
                 };
                 yield return new object[]
                 {
@@ -290,7 +290,7 @@ namespace Arcus.Testing.Tests.Unit.Assert_
                 {
                     "{ \"items\": 2 }",
                     "{ \"items\": [] }",
-                    "has an array: [] instead of a number: 2 at $.items"
+                    "different type at $.items, expected a number: 2 while actual an array: []"
                 };
                 yield return new object[]
                 {
@@ -308,7 +308,7 @@ namespace Arcus.Testing.Tests.Unit.Assert_
                 {
                     "{ \"tree\": \"oak\" }",
                     "{ \"tree\": { } }",
-                    "has an object: {} instead of a string: oak at $.tree"
+                    "different type at $.tree, expected a string: oak while actual an object: {}"
                 };
                 yield return new object[]
                 {
@@ -320,25 +320,25 @@ namespace Arcus.Testing.Tests.Unit.Assert_
                 {
                     "{ \"tree\": { \"leaves\": 10} }",
                     "{ \"tree\": { \"leaves\": 5 } }",
-                    "has a different value at $.tree.leaves"
+                    "different value at $.tree.leaves, expected a number: 10 while actual a number: 5"
                 };
                 yield return new object[]
                 {
                     "{ \"eyes\": [] }",
                     "{ \"eyes\": \"blue\" }",
-                    "has a string: blue instead of an array: [] at $.eyes"
+                    "different type at $.eyes, expected an array: [] while actual a string: blue"
                 };
                 yield return new object[]
                 {
                     "{ \"eyes\": 2 }",
                     "{ \"eyes\": \"blue\" }",
-                    "has a string: blue instead of a number: 2 at $.eyes"
+                    "at $.eyes, expected a number: 2 while actual a string: blue"
                 };
                 yield return new object[]
                 {
                     "{ \"id\": 2 }",
                     "{ \"id\": 1 }",
-                    "has a different value at $.id"
+                    "different value at $.id, expected a number: 2 while actual a number: 1"
                 };
                 yield return new object[]
                 {
@@ -350,7 +350,7 @@ namespace Arcus.Testing.Tests.Unit.Assert_
                 {
                     "{ \"foo\": 1 }",
                     "{ \"foo\": \"test\" }",
-                    "has a string: test instead of a number: 1 at $.foo"
+                    "at $.foo, expected a number: 1 while actual a string: test"
                 };
                 yield return new object[]
                 {

--- a/src/Arcus.Testing.Tests.Unit/Assert_/Fixture/TestCsv.cs
+++ b/src/Arcus.Testing.Tests.Unit/Assert_/Fixture/TestCsv.cs
@@ -31,7 +31,7 @@ namespace Arcus.Testing.Tests.Unit.Assert_.Fixture
     {
         private readonly TestCsvOptions _options;
         private List<List<string>> _columns;
-        private readonly List<List<string>> _invalidrows = new();
+        private readonly List<List<string>> _invalidRows = new();
         private static readonly Faker Bogus = new();
         private bool _shouldShuffleRows;
 
@@ -132,7 +132,7 @@ namespace Arcus.Testing.Tests.Unit.Assert_.Fixture
         /// </summary>
         public void AddInvalidRow()
         {
-            _invalidrows.Add(Bogus.Make(Bogus.Random.Int(11, 20), GenValue).ToList());
+            _invalidRows.Add(Bogus.Make(Bogus.Random.Int(11, 20), GenValue).ToList());
         }
 
         /// <summary>
@@ -222,7 +222,7 @@ namespace Arcus.Testing.Tests.Unit.Assert_.Fixture
         public override string ToString()
         {
             List<List<string>> rows = Transpose(_columns);
-            rows.AddRange(_invalidrows);
+            rows.AddRange(_invalidRows);
 
             if (_shouldShuffleRows)
             {

--- a/src/Arcus.Testing.Tests.Unit/Core/DisposableCollectionTests.cs
+++ b/src/Arcus.Testing.Tests.Unit/Core/DisposableCollectionTests.cs
@@ -93,6 +93,7 @@ namespace Arcus.Testing.Tests.Unit.Core
         public async Task Create_WithoutItems_Succeeds()
         {
             await using DisposableCollection disposables = CreateCollection();
+            Assert.NotNull(disposables);
         }
 
         [Fact]
@@ -120,7 +121,7 @@ namespace Arcus.Testing.Tests.Unit.Core
             var disposables = new DisposableCollection(_logger);
 
             disposables.Options.RetryCount = Bogus.Random.Int(1, 3);
-            disposables.Options.RetryInterval = TimeSpan.FromMicroseconds(Bogus.Random.Int(100, 300));
+            disposables.Options.RetryInterval = TimeSpan.FromMilliseconds(Bogus.Random.Int(100, 300));
 
             return disposables;
         }


### PR DESCRIPTION
Adds .NET 6 support to assertion library, for more eaiser migration.

PR contains changes to make the current functionality work both in .NET 6 & 8. It uses more broadly used functionality instead of .NET 8-specific ones.

Closes #114
Created issue #118 to remove it back.