### PR TITLE
feat: introduce reusable polling mechanism

### DIFF
--- a/src/Arcus.Testing.Core/Poll.cs
+++ b/src/Arcus.Testing.Core/Poll.cs
@@ -1,0 +1,396 @@
+﻿using System;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using Polly;
+using Polly.Retry;
+
+namespace Arcus.Testing
+{
+    /// <summary>
+    /// Represents a polling operation that will run until the target is available.
+    /// </summary>
+    /// <typeparam name="TException">The type of exception that is expected to be thrown by the target.</typeparam>
+    public class Poll<TException> : Poll<int, TException> where TException : Exception
+    {
+        internal Poll(Func<Task> getTargetWithoutResultAsync, PollOptions options) : base(() => getTargetWithoutResultAsync().ContinueWith(_ => 0), options)
+        {
+        }
+    }
+
+    /// <summary>
+    /// Represents a polling operation that will run until the target is available.
+    /// </summary>
+    /// <typeparam name="TResult">The type of result for which the target has to be polled.</typeparam>
+    /// <typeparam name="TException">The type of exception that is expected to be thrown by the target.</typeparam>
+    public class Poll<TResult, TException> where TException : Exception
+    {
+        private readonly Func<Task<TResult>> _getTargetWithResultAsync;
+        private readonly PollOptions _options;
+        private readonly Collection<Func<TResult, bool>> _untilTargets = new();
+
+        internal Poll(Func<Task<TResult>> getTargetWithResultAsync, PollOptions options)
+        {
+            _getTargetWithResultAsync = getTargetWithResultAsync;
+            _options = options;
+        }
+
+        /// <summary>
+        /// Adds a predicate to determine when the polling operation should stop.
+        /// </summary>
+        /// <remarks>This operation can be called multiple times, until filters will be aggregated.</remarks>
+        /// <param name="untilTarget">
+        ///     The custom function to determine the state of the current target, returns [false] when the target is unavailable; [true] otherwise.
+        /// </param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="untilTarget"/> is <c>null</c>.</exception>
+        public Poll<TResult, TException> Until(Func<TResult, bool> untilTarget)
+        {
+            if (untilTarget is null)
+            {
+                throw new ArgumentNullException(nameof(untilTarget));
+            }
+
+            _untilTargets.Add(untilTarget);
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the interval between each poll operation.
+        /// </summary>
+        /// <param name="interval">The interval between each polling operation to the target.</param>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when the <paramref name="interval"/>"> represents a negative time frame.</exception>
+        public Poll<TResult, TException> Every(TimeSpan interval)
+        {
+            _options.Interval = interval;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the time frame in which the polling operation has to succeed.
+        /// </summary>
+        /// <param name="timeout">The time frame in which the entire polling should succeed.</param>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when the <paramref name="timeout"/>"> represents a negative or zero time frame.</exception>
+        public Poll<TResult, TException> Timeout(TimeSpan timeout)
+        {
+            _options.Timeout = timeout;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the message that describes the failure of the polling operation.
+        /// </summary>
+        /// <param name="errorMessage">
+        ///     The message that will be used as the final failure message of the <see cref="TimeoutException"/> when the polling operation fails to succeed within the configured time frame.
+        /// </param>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="errorMessage"/> is blank.</exception>
+        public Poll<TResult, TException> FailWith(string errorMessage)
+        {
+            _options.FailureMessage = errorMessage;
+            return this;
+        }
+
+        /// <summary>
+        /// Gets the awaiter used to await this <see cref="Poll{TResult,TException}"/>.
+        /// </summary>
+        public TaskAwaiter<TResult> GetAwaiter()
+        {
+            return StartAsync().GetAwaiter();
+        }
+
+        /// <summary>
+        /// Starts the polling operation with the previously configured options.
+        /// </summary>
+        /// <exception cref="TimeoutException">Thrown when the target remains unavailable after within the configured time frame.</exception>
+        public async Task<TResult> StartAsync()
+        {
+            var exceptions = new Collection<Exception>();
+            var results = new Collection<TResult>();
+
+            AsyncRetryPolicy<TResult> retryPolicy =
+                Policy.HandleResult((TResult r) =>
+                      {
+                          results.Add(r);
+                          return _untilTargets.Count > 0 && _untilTargets.Any(untilTarget => untilTarget(r));
+                      }).Or<TException>(ex =>
+                      {
+                          exceptions.Add(ex);
+                          return true;
+                      })
+                      .WaitAndRetryForeverAsync(_ => _options.Interval);
+
+            PolicyResult<TResult> target =
+                await Policy.TimeoutAsync(_options.Timeout)
+                            .WrapAsync(retryPolicy)
+                            .ExecuteAndCaptureAsync(_getTargetWithResultAsync);
+
+            if (target.Outcome is OutcomeType.Failure)
+            {
+                string resultDescription = results.Count > 0 ? $" (last result: {results[^1]})" : string.Empty;
+                throw new TimeoutException(_options.FailureMessage + resultDescription, exceptions.LastOrDefault() ?? target.FinalException);
+            }
+
+            return target.Result;
+        }
+    }
+
+    /// <summary>
+    /// Represents the available user-configurable options for the <see cref="Poll"/> operation.
+    /// </summary>
+    public class PollOptions
+    {
+        private TimeSpan _interval = TimeSpan.FromSeconds(1);
+        private TimeSpan _timeout = TimeSpan.FromSeconds(30);
+        private string _failureMessage = "operation did not succeed within the given time frame";
+
+        /// <summary>
+        /// Gets the default set of polling options.
+        /// </summary>
+        internal static PollOptions Default { get; } = new();
+
+        /// <summary>
+        /// Gets or sets the interval between each poll operation.
+        /// </summary>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when the <paramref name="value"/>"> represents a negative time frame.</exception>
+        public TimeSpan Interval
+        {
+            get => _interval;
+            set
+            {
+                if (value < TimeSpan.Zero)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(value), "Interval between polling operations cannot be negative");
+                }
+
+                _interval = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the time frame in which the polling operation has to succeed.
+        /// </summary>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when the <paramref name="value"/>"> represents a negative time frame.</exception>
+        public TimeSpan Timeout
+        {
+            get => _timeout;
+            set
+            {
+                if (value <= TimeSpan.Zero)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(value), "Timeout of polling operation cannot be negative or zero");
+                }
+
+                _timeout = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the message that describes the failure of the polling operation.
+        /// </summary>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="value"/> is blank.</exception>
+        public string FailureMessage
+        {
+            get => $"{nameof(Poll)}: {_failureMessage} (interval: {_interval:g}, timeout: {_timeout:g})";
+            set
+            {
+                if (string.IsNullOrWhiteSpace(value))
+                {
+                    throw new ArgumentException("Failure message for polling operation cannot be blank");
+                }
+
+                _failureMessage = value;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Represents a polling operation that will run until the target is available.
+    /// </summary>
+    public static class Poll
+    {
+        /// <summary>
+        /// Polls the given <paramref name="getTargetWithoutResultAsync"/> until it stops throwing exceptions.
+        /// </summary>
+        /// <param name="getTargetWithoutResultAsync">The custom function that interacts with the possible unavailable target.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="getTargetWithoutResultAsync"/> is <c>null</c>.</exception>
+        /// <exception cref="TimeoutException">Thrown when the target was not available (meaning: did not throw any exceptions) in the configured time frame.</exception>
+        public static Task UntilAvailableAsync(Func<Task> getTargetWithoutResultAsync)
+        {
+            return UntilAvailableAsync<Exception>(
+                getTargetWithoutResultAsync ?? throw new ArgumentNullException(nameof(getTargetWithoutResultAsync)),
+                configureOptions: null);
+        }
+
+        /// <summary>
+        /// Polls the given <paramref name="getTargetWithoutResultAsync"/> until it stops throwing exceptions.
+        /// </summary>
+        /// <typeparam name="TException">The type of exception that is expected to be thrown by the <paramref name="getTargetWithoutResultAsync"/>.</typeparam>
+        /// <param name="getTargetWithoutResultAsync">The custom function that interacts with the possible unavailable target.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="getTargetWithoutResultAsync"/> is <c>null</c>.</exception>
+        /// <exception cref="TimeoutException">Thrown when the target was not available (meaning: did not throw any exceptions) in the configured time frame.</exception>
+        public static Task UntilAvailableAsync<TException>(Func<Task> getTargetWithoutResultAsync)
+            where TException : Exception
+        {
+            return UntilAvailableAsync<TException>(
+                getTargetWithoutResultAsync ?? throw new ArgumentNullException(nameof(getTargetWithoutResultAsync)),
+                configureOptions: null);
+        }
+
+        /// <summary>
+        /// Polls the given <paramref name="getTargetWithoutResultAsync"/> until it stops throwing exceptions.
+        /// </summary>
+        /// <param name="getTargetWithoutResultAsync">The custom function that interacts with the possible unavailable target.</param>
+        /// <param name="configureOptions">The additional options to manipulate the polling behavior.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="getTargetWithoutResultAsync"/> is <c>null</c>.</exception>
+        /// <exception cref="TimeoutException">Thrown when the target was not available (meaning: did not throw any exceptions) in the configured time frame.</exception>
+        public static Task UntilAvailableAsync(Func<Task> getTargetWithoutResultAsync, Action<PollOptions> configureOptions)
+        {
+            return UntilAvailableAsync<Exception>(getTargetWithoutResultAsync, configureOptions);
+        }
+
+        /// <summary>
+        /// Polls the given <paramref name="getTargetWithoutResultAsync"/> until it stops throwing exceptions.
+        /// </summary>
+        /// <typeparam name="TException">The type of exception that is expected to be thrown by the <paramref name="getTargetWithoutResultAsync"/>.</typeparam>
+        /// <param name="getTargetWithoutResultAsync">The custom function that interacts with the possible unavailable target.</param>
+        /// <param name="configureOptions">The additional options to manipulate the polling behavior.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="getTargetWithoutResultAsync"/> is <c>null</c>.</exception>
+        /// <exception cref="TimeoutException">Thrown when the target was not available (meaning: did not throw any exceptions) in the configured time frame.</exception>
+        public static Task UntilAvailableAsync<TException>(Func<Task> getTargetWithoutResultAsync, Action<PollOptions> configureOptions)
+            where TException : Exception
+        {
+            if (getTargetWithoutResultAsync is null)
+            {
+                throw new ArgumentNullException(nameof(getTargetWithoutResultAsync));
+            }
+
+            var options = new PollOptions();
+            configureOptions?.Invoke(options);
+
+            return new Poll<TException>(getTargetWithoutResultAsync, options).StartAsync();
+        }
+
+        /// <summary>
+        /// Polls the given <paramref name="getTargetWithResultAsync"/> until it stops throwing exceptions.
+        /// </summary>
+        /// <typeparam name="TResult">The type of result for which the target has to be polled.</typeparam>
+        /// <param name="getTargetWithResultAsync">The custom function that interacts with the necessary possible unavailable target.</param>
+        /// <returns>The result of the interaction with the target.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="getTargetWithResultAsync"/> is <c>null</c>.</exception>
+        /// <exception cref="TimeoutException">Thrown when the target was not available (meaning: did not throw any exceptions) in the configured time frame.</exception>
+        public static Task<TResult> UntilAvailableAsync<TResult>(Func<Task<TResult>> getTargetWithResultAsync)
+        {
+            return UntilAvailableAsync<TResult, Exception>(
+                getTargetWithResultAsync ?? throw new ArgumentNullException(nameof(getTargetWithResultAsync)),
+                configureOptions: null);
+        }
+
+        /// <summary>
+        /// Polls the given <paramref name="getTargetWithResultAsync"/> until it stops throwing exceptions.
+        /// </summary>
+        /// <typeparam name="TResult">The type of result for which the target has to be polled.</typeparam>
+        /// <param name="getTargetWithResultAsync">The custom function that interacts with the necessary possible unavailable target.</param>
+        /// <param name="configureOptions">The additional options to manipulate the polling behavior.</param>
+        /// <returns>The result of the interaction with the target.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="getTargetWithResultAsync"/> is <c>null</c>.</exception>
+        /// <exception cref="TimeoutException">Thrown when the target was not available (meaning: did not throw any exceptions) in the configured time frame.</exception>
+        public static Task<TResult> UntilAvailableAsync<TResult>(Func<Task<TResult>> getTargetWithResultAsync, Action<PollOptions> configureOptions)
+        {
+            return UntilAvailableAsync<TResult, Exception>(
+                getTargetWithResultAsync ?? throw new ArgumentNullException(nameof(getTargetWithResultAsync)),
+                configureOptions);
+        }
+
+        /// <summary>
+        /// Polls the given <paramref name="getTargetWithResultAsync"/> until it stops throwing exceptions.
+        /// </summary>
+        /// <typeparam name="TResult">The type of result for which the target has to be polled.</typeparam>
+        /// <typeparam name="TException">The type of exceptions the target can throw.</typeparam>
+        /// <param name="getTargetWithResultAsync">The custom function that interacts with the necessary possible unavailable target.</param>
+        /// <returns>The result of the interaction with the target.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="getTargetWithResultAsync"/> is <c>null</c>.</exception>
+        /// <exception cref="TimeoutException">Thrown when the target was not available (meaning: did not throw any exceptions) in the configured time frame.</exception>
+        public static Task<TResult> UntilAvailableAsync<TResult, TException>(Func<Task<TResult>> getTargetWithResultAsync)
+            where TException : Exception
+        {
+            return UntilAvailableAsync<TResult, TException>(getTargetWithResultAsync, configureOptions: null);
+        }
+
+        /// <summary>
+        /// Polls the given <paramref name="getTargetWithResultAsync"/> until it stops throwing exceptions.
+        /// </summary>
+        /// <typeparam name="TResult">The type of result for which the target has to be polled.</typeparam>
+        /// <typeparam name="TException">The type of exceptions the target can throw.</typeparam>
+        /// <param name="getTargetWithResultAsync">The custom function that interacts with the necessary possible unavailable target.</param>
+        /// <param name="configureOptions">The additional options to manipulate the polling behavior.</param>
+        /// <returns>The result of the interaction with the target.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="getTargetWithResultAsync"/> is <c>null</c>.</exception>
+        /// <exception cref="TimeoutException">Thrown when the target was not available (meaning: did not throw any exceptions) in the configured time frame.</exception>
+        public static Task<TResult> UntilAvailableAsync<TResult, TException>(Func<Task<TResult>> getTargetWithResultAsync, Action<PollOptions> configureOptions)
+            where TException : Exception
+        {
+            var options = new PollOptions();
+            configureOptions?.Invoke(options);
+
+            return new Poll<TResult, TException>(
+                getTargetWithResultAsync ?? throw new ArgumentNullException(nameof(getTargetWithResultAsync)),
+                options).StartAsync();
+        }
+
+        /// <summary>
+        /// Creates a polling operation that will run the <paramref name="getTargetWithoutResultAsync"/> until it stops throwing exceptions.
+        /// </summary>
+        /// <param name="getTargetWithoutResultAsync">The custom function that interacts with the necessary possible unavailable target.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="getTargetWithoutResultAsync"/> is <c>null</c>.</exception>
+        /// <exception cref="TimeoutException">Thrown when the target was not available (meaning: did not throw any exceptions) in the configured time frame.</exception>
+        public static Poll<Exception> Target(Func<Task> getTargetWithoutResultAsync)
+        {
+            return Target<Exception>(getTargetWithoutResultAsync);
+        }
+
+        /// <summary>
+        /// Creates a polling operation that will run the <paramref name="getTargetWithResultAsync"/> until it stops throwing exceptions.
+        /// </summary>
+        /// <typeparam name="TResult">The type of result for which the target has to be polled.</typeparam>
+        /// <param name="getTargetWithResultAsync">The custom function that interacts with the necessary possible unavailable target.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="getTargetWithResultAsync"/> is <c>null</c>.</exception>
+        /// <exception cref="TimeoutException">Thrown when the target was not available (meaning: did not throw any exceptions) in the configured time frame.</exception>
+        public static Poll<TResult, Exception> Target<TResult>(Func<Task<TResult>> getTargetWithResultAsync)
+        {
+            return Target<TResult, Exception>(getTargetWithResultAsync);
+        }
+
+        /// <summary>
+        /// Creates a polling operation that will run the <paramref name="getTargetWithoutResultAsync"/> until it stops throwing exceptions.
+        /// </summary>
+        /// <typeparam name="TException">The type of exceptions the target can throw.</typeparam>
+        /// <param name="getTargetWithoutResultAsync">The custom function that interacts with the necessary possible unavailable target.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="getTargetWithoutResultAsync"/> is <c>null</c>.</exception>
+        /// <exception cref="TimeoutException">Thrown when the target was not available (meaning: did not throw any exceptions) in the configured time frame.</exception>
+        public static Poll<TException> Target<TException>(Func<Task> getTargetWithoutResultAsync)
+            where TException : Exception
+        {
+            return new Poll<TException>(
+                getTargetWithoutResultAsync ?? throw new ArgumentNullException(nameof(getTargetWithoutResultAsync)),
+                PollOptions.Default);
+        }
+
+        /// <summary>
+        /// Creates a polling operation that will run the <paramref name="getTargetWithResultAsync"/> until a given condition is met.
+        /// </summary>
+        /// <typeparam name="TResult">The type of result for which the target has to be polled.</typeparam>
+        /// <typeparam name="TException">The type of exceptions the target can throw.</typeparam>
+        /// <param name="getTargetWithResultAsync">The custom function that interacts with the necessary possible unavailable target.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="getTargetWithResultAsync"/> is <c>null</c>.</exception>
+        /// <exception cref="TimeoutException">
+        ///     Thrown when the target was not available (meaning: did not throw any exceptions and the configured condition is met) in the configured time frame.
+        /// </exception>
+        public static Poll<TResult, TException> Target<TResult, TException>(Func<Task<TResult>> getTargetWithResultAsync)
+            where TException : Exception
+        {
+            return new Poll<TResult, TException>(
+                getTargetWithResultAsync ?? throw new ArgumentNullException(nameof(getTargetWithResultAsync)),
+                PollOptions.Default);
+        }
+    }
+}

--- a/src/Arcus.Testing.Tests.Unit/Core/PollTests.cs
+++ b/src/Arcus.Testing.Tests.Unit/Core/PollTests.cs
@@ -8,12 +8,11 @@ using Xunit;
 
 namespace Arcus.Testing.Tests.Unit.Core
 {
-    public class PollTests : IAsyncLifetime
+    public class PollTests
     {
         private readonly TimeSpan _100ms = TimeSpan.FromMilliseconds(100), _10ms = TimeSpan.FromMilliseconds(10);
         private readonly object _expectedResult = Bogus.PickRandom((object) Bogus.Random.Int(), Bogus.Random.AlphaNumeric(10));
 
-        private static int Index;
         private static readonly Faker Bogus = new();
 
         [Fact]
@@ -122,13 +121,15 @@ namespace Arcus.Testing.Tests.Unit.Core
         private static Task AlwaysSucceedsAsync() => Task.CompletedTask;
         private Task<object> AlwaysSucceedsResultAsync() => Task.FromResult(_expectedResult);
 
-        private static async Task SometimesSucceedsAsync()
+        private int __index;
+        private async Task SometimesSucceedsAsync()
         {
-            if (++Index < 3)
+            if (++__index < 3)
             {
                 throw new TestPollException("Sabotage polling!");
             }
 
+            __index = 0;
             await Task.CompletedTask;
         }
 
@@ -167,21 +168,6 @@ namespace Arcus.Testing.Tests.Unit.Core
             Assert.Equal(typeof(TException), exception.InnerException.GetType());
 
             return exception;
-        }
-
-        /// <summary>
-        /// Called immediately after the class has been created, before it is used.
-        /// </summary>
-        public Task InitializeAsync() => Task.CompletedTask;
-
-        /// <summary>
-        /// Called when an object is no longer needed. Called just before <see cref="M:System.IDisposable.Dispose" />
-        /// if the class also implements that.
-        /// </summary>
-        public Task DisposeAsync()
-        {
-            Index = 0;
-            return Task.CompletedTask;
         }
 
         [Fact]

--- a/src/Arcus.Testing.Tests.Unit/Core/PollTests.cs
+++ b/src/Arcus.Testing.Tests.Unit/Core/PollTests.cs
@@ -1,0 +1,236 @@
+﻿using System;
+using System.IO;
+using System.Threading.Tasks;
+using Bogus;
+using Bogus.Extensions;
+using Polly.Timeout;
+using Xunit;
+
+namespace Arcus.Testing.Tests.Unit.Core
+{
+    public class PollTests : IAsyncLifetime
+    {
+        private readonly TimeSpan _100ms = TimeSpan.FromMilliseconds(100), _10ms = TimeSpan.FromMilliseconds(10);
+        private readonly object _expectedResult = Bogus.PickRandom((object) Bogus.Random.Int(), Bogus.Random.AlphaNumeric(10));
+
+        private static int Index;
+        private static readonly Faker Bogus = new();
+
+        [Fact]
+        public async Task Poll_WithTargetAvailableWithinTimeFrame_SucceedsByContinuing()
+        {
+            await Poll.UntilAvailableAsync(AlwaysSucceedsAsync);
+            await Poll.UntilAvailableAsync(SometimesSucceedsAsync, MinTimeFrame);
+            await Poll.UntilAvailableAsync<InvalidOperationException>(AlwaysSucceedsAsync);
+            await Poll.UntilAvailableAsync<TestPollException>(SometimesSucceedsAsync, MinTimeFrame);
+
+            await Poll.Target(AlwaysSucceedsAsync);
+            await Poll.Target(SometimesSucceedsAsync).MinTimeFrame();
+            await Poll.Target<ArrayTypeMismatchException>(AlwaysSucceedsAsync);
+            await Poll.Target<TestPollException>(SometimesSucceedsAsync).MinTimeFrame();
+
+            await GetsResultAsync(() => Poll.UntilAvailableAsync(AlwaysSucceedsResultAsync));
+            await GetsResultAsync(() => Poll.UntilAvailableAsync(SometimesSucceedsResultAsync, MinTimeFrame));
+            await GetsResultAsync(() => Poll.UntilAvailableAsync<object, AggregateException>(AlwaysSucceedsResultAsync));
+            await GetsResultAsync(() => Poll.UntilAvailableAsync<object, TestPollException>(SometimesSucceedsResultAsync, MinTimeFrame));
+
+            await GetsResultAsync(async () => await Poll.Target(AlwaysSucceedsResultAsync));
+            await GetsResultAsync(async () => await Poll.Target(SometimesSucceedsResultAsync).MinTimeFrame());
+            await GetsResultAsync(async () => await Poll.Target<object, DllNotFoundException>(AlwaysSucceedsResultAsync));
+            await GetsResultAsync(async () => await Poll.Target<object, TestPollException>(SometimesSucceedsResultAsync).MinTimeFrame());
+        }
+
+        [Fact]
+        public async Task Poll_WithTargetRemainsUnavailableWithinTimeFrame_FailsWithDescription()
+        {
+            await FailsByExceptionAsync(() => Poll.UntilAvailableAsync(AlwaysFailsAsync, MinTimeFrame));
+            await FailsByExceptionAsync(() => Poll.UntilAvailableAsync(AlwaysFailsResultAsync, MinTimeFrame));
+            await FailsByExceptionAsync(() => Poll.UntilAvailableAsync<TestPollException>(AlwaysFailsAsync, MinTimeFrame));
+            await FailsByExceptionAsync(() => Poll.UntilAvailableAsync<object, TestPollException>(AlwaysFailsResultAsync, MinTimeFrame));
+
+            await FailsByExceptionAsync(async () => await Poll.Target(AlwaysFailsAsync).MinTimeFrame());
+            await FailsByExceptionAsync(async () => await Poll.Target(AlwaysFailsResultAsync).Until(AlwaysTrue).MinTimeFrame());
+            await FailsByExceptionAsync(async () => await Poll.Target<TestPollException>(AlwaysFailsAsync).MinTimeFrame());
+            await FailsByExceptionAsync(async () => await Poll.Target<object, TestPollException>(AlwaysFailsResultAsync).Until(AlwaysTrue).MinTimeFrame());
+        }
+
+        [Fact]
+        public async Task Poll_WithDiffExceptionThanUnavailableTarget_FailsDirectlyWithDescription()
+        {
+            await FailsByExceptionAsync(() => Poll.UntilAvailableAsync<InvalidOperationException>(AlwaysFailsAsync, MinTimeFrame));
+            await FailsByExceptionAsync(() => Poll.UntilAvailableAsync<object, FileNotFoundException>(AlwaysFailsResultAsync, MinTimeFrame));
+
+            await FailsByExceptionAsync(async () => await Poll.Target<AggregateException>(AlwaysFailsAsync).MinTimeFrame());
+            await FailsByExceptionAsync(async () => await Poll.Target<object, ApplicationException>(AlwaysFailsResultAsync).MinTimeFrame());
+        }
+
+        [Fact]
+        public async Task Poll_WithNegativeUntilTargetPredicate_FailsWithDescription()
+        {
+            // Arrange
+            string expected = Bogus.Lorem.Sentence();
+
+            // Act / Assert
+            await FailsByResultAsync(async () =>
+                await Poll.Target(AlwaysSucceedsResultAsync)
+                          .MinTimeFrame()
+                          .Until(AlwaysTrue)
+                          .Until(AlwaysFalse)
+                          .Until(AlwaysTrue)
+                          .FailWith(expected), errorParts: expected);
+            
+            await FailsByResultAsync(async () => 
+                await Poll.Target<object, TestPollException>(AlwaysSucceedsResultAsync)
+                          .MinTimeFrame()
+                          .Until(AlwaysTrue)
+                          .Until(AlwaysFalse)
+                          .Until(AlwaysTrue)
+                          .FailWith(expected), errorParts: expected);
+        }
+
+        [Fact]
+        public async Task Poll_WithCustomFailureMessage_FailsWithGivenMessage()
+        {
+            // Arrange
+            string expected = Bogus.Lorem.Sentence();
+
+            await FailsByExceptionAsync(() => Poll.UntilAvailableAsync(AlwaysFailsAsync, WithMessage(expected)), expected);
+            await FailsByExceptionAsync(() => Poll.UntilAvailableAsync(AlwaysFailsResultAsync, WithMessage(expected)), expected);
+            await FailsByExceptionAsync(() => Poll.UntilAvailableAsync<InvalidOperationException>(AlwaysFailsAsync, WithMessage(expected)), expected);
+            await FailsByExceptionAsync(() => Poll.UntilAvailableAsync<object, AggregateException>(AlwaysFailsResultAsync, WithMessage(expected)), expected);
+        }
+
+        private Action<PollOptions> WithMessage(string message)
+        {
+            return options =>
+            {
+                options.FailureMessage = message;
+                MinTimeFrame(options);
+            };
+        }
+
+        private void MinTimeFrame(PollOptions options)
+        {
+            options.Timeout = _100ms;
+            options.Interval = _10ms;
+        }
+
+        private static bool AlwaysTrue(object result) => true;
+        private static bool AlwaysFalse(object result) => false;
+        private static Task AlwaysFailsAsync() => throw new TestPollException();
+        private static Task<object> AlwaysFailsResultAsync() => throw new TestPollException();
+        private static Task AlwaysSucceedsAsync() => Task.CompletedTask;
+        private Task<object> AlwaysSucceedsResultAsync() => Task.FromResult(_expectedResult);
+
+        private static async Task SometimesSucceedsAsync()
+        {
+            if (++Index < 3)
+            {
+                throw new TestPollException("Sabotage polling!");
+            }
+
+            await Task.CompletedTask;
+        }
+
+        private async Task<object> SometimesSucceedsResultAsync()
+        {
+            await SometimesSucceedsAsync();
+            return _expectedResult;
+        }
+
+        private async Task GetsResultAsync(Func<Task<object>> pollAsync)
+        {
+            object actualResult = await pollAsync();
+            Assert.Equal(_expectedResult, actualResult);
+        }
+
+        private static async Task FailsByResultAsync(Func<Task<object>> pollAsync, params string[] errorParts)
+        {
+            TimeoutException exception = await ShouldFailAsync<TimeoutRejectedException>(pollAsync, errorParts);
+            Assert.Contains("last result", exception.Message);
+        }
+
+        private static async Task FailsByExceptionAsync(Func<Task> pollAsync, params string[] errorParts)
+        {
+            await ShouldFailAsync<TestPollException>(pollAsync, errorParts);
+        }
+
+        private static async Task<TimeoutException> ShouldFailAsync<TException>(Func<Task> pollAsync, params string[] errorParts)
+        {
+            var exception = await Assert.ThrowsAsync<TimeoutException>(pollAsync);
+            Assert.Contains(nameof(Poll), exception.Message);
+
+            var parts = errorParts.Length == 0 ? new[] { "not succeed", "time frame" } : errorParts;
+            Assert.All(parts, part => Assert.Contains(part, exception.Message));
+
+            Assert.NotNull(exception.InnerException);
+            Assert.Equal(typeof(TException), exception.InnerException.GetType());
+
+            return exception;
+        }
+
+        /// <summary>
+        /// Called immediately after the class has been created, before it is used.
+        /// </summary>
+        public Task InitializeAsync() => Task.CompletedTask;
+
+        /// <summary>
+        /// Called when an object is no longer needed. Called just before <see cref="M:System.IDisposable.Dispose" />
+        /// if the class also implements that.
+        /// </summary>
+        public Task DisposeAsync()
+        {
+            Index = 0;
+            return Task.CompletedTask;
+        }
+
+        [Fact]
+        public void Set_NegativeInterval_Fails()
+        {
+            // Arrange
+            var options = new PollOptions();
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(() => options.Interval = Bogus.Date.Timespan().Negate());
+        }
+
+        [Fact]
+        public void Set_NegativeOrZeroTimeout_Fails()
+        {
+            // Arrange
+            var options = new PollOptions();
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(() => options.Timeout = Bogus.Date.Timespan().Negate().OrDefault(Bogus));
+        }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void Set_BlankFailureMessage_Fails(string blank)
+        {
+            // Arrange
+            var options = new PollOptions();
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(() => options.FailureMessage = blank);
+        }
+    }
+
+    public static class PollExtensions
+    {
+        public static Poll<TResult, TException> MinTimeFrame<TResult, TException>(
+            this Poll<TResult, TException> poll)
+            where TException : Exception
+        {
+            return poll.Every(TimeSpan.FromMilliseconds(10)).Timeout(TimeSpan.FromMilliseconds(100));
+        }
+    }
+
+    [Serializable]
+    public class TestPollException : Exception
+    {
+        public TestPollException() : base("Test poll exception") { }
+        public TestPollException(string message) : base(message) { }
+        public TestPollException(string message, Exception innerException) : base(message, innerException) { }
+    }
+}


### PR DESCRIPTION
Introduce reusable `Poll`ing mechanism as an assertion-like safeguard before interacting with external resources, or as an assertion by itself.

Closes #113