### PR TITLE
chore: add code coverage reporting

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -31,6 +31,7 @@ jobs:
     - name: Coverlet coverage unit test
       run: dotnet test --framework net8.0 -p:coverletOutput=coverage.json -p:CollectCoverage=true -p:CoverletOutputFormat=\"opencover,json\" -p:ExcludeByAttribute=\"Obsolete,GeneratedCodeAttribute,CompilerGeneratedAttribute\" -p:Exclude=\"[Arcus.Testing.Tests.*]*\" src/Arcus.Testing.Tests.Unit/Arcus.Testing.Tests.Unit.csproj
 
-    - name: Codecov
-      uses: codecov/codecov-action@v3.1.1
-      if: always()
+    - name: Upload coverage reports to Codecov
+      uses: codecov/codecov-action@v4.0.1
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -1,0 +1,36 @@
+name: "Code Coverage"
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ main ]
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'csharp' ]
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+    - uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: '8.0.x'
+        dotnet-quality: 'preview'
+
+    - name: Coverlet coverage unit test
+      run: dotnet test --framework net8.0 -p:coverletOutput=coverage.json -p:CollectCoverage=true -p:CoverletOutputFormat=\"opencover,json\" -p:ExcludeByAttribute=\"Obsolete,GeneratedCodeAttribute,CompilerGeneratedAttribute\" -p:Exclude=\"[Arcus.Testing.Tests.*]*\" src/Arcus.Testing.Tests.Unit/Arcus.Testing.Tests.Unit.csproj
+
+    - name: Codecov
+      uses: codecov/codecov-action@v3.1.1
+      if: always()

--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
 # Arcus - Testing
 [![Build Status](https://dev.azure.com/codit/Arcus/_apis/build/status/Commit%20builds/CI%20-%20Arcus.Testing?branchName=main)](https://dev.azure.com/codit/Arcus/_build/latest?definitionId=804&branchName=main)
 [![NuGet Badge](https://buildstats.info/nuget/Arcus.Testing.Logging?includePreReleases=true)](https://www.nuget.org/packages/Arcus.Testing.Logging/)
+[![codecov](https://codecov.io/gh/arcus-azure/arcus.testing/graph/badge.svg?token=GIXXJO815Q)](https://codecov.io/gh/arcus-azure/arcus.testing)
 
 Reusable testing components for Arcus repo's.
 
 ![Arcus](https://raw.githubusercontent.com/arcus-azure/arcus/master/media/arcus.png)
 
 # Documentation
-All documentation can be found on [here](https://testing.arcus-azure.net/).
+All documentation can be found [here](https://testing.arcus-azure.net/).
 
 # License Information
 This is licensed under The MIT License (MIT). Which means that you can use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the web application. But you always need to state that Codit is the original author of this web application.


### PR DESCRIPTION
Adds code coverage reporting to the repository that reports to Coverlet and shows the coverage percentage in the repo's root `README.md` with a badge.