### PR TITLE
fix: add unit tests dependencies to release

### DIFF
--- a/build/nuget-release.yml
+++ b/build/nuget-release.yml
@@ -105,7 +105,9 @@ stages:
 
   - stage: Release
     displayName: 'Release to NuGet.org'
-    dependsOn: IntegrationTests
+    dependsOn:
+      - UnitTests
+      - IntegrationTests
     condition: succeeded()
     jobs:
       - job: PushToNuGet


### PR DESCRIPTION
Seemed like the unit tests were not yet part of the requirements in the release pipeline.
Fixed that here.