### PR TITLE
fix: mark main appsettings testconfig optional

### DIFF
--- a/src/Arcus.Testing.Core/TestConfig.cs
+++ b/src/Arcus.Testing.Core/TestConfig.cs
@@ -86,7 +86,7 @@ namespace Arcus.Testing
             configureOptions?.Invoke(options);
 
             IConfigurationBuilder builder = new ConfigurationBuilder()
-                .AddJsonFile(options.MainJsonPath, optional: false);
+                .AddJsonFile(options.MainJsonPath, optional: true);
 
             foreach (string path in options.OptionalJsonPaths)
             {

--- a/src/Arcus.Testing.Tests.Integration/Core/TestConfigTests.cs
+++ b/src/Arcus.Testing.Tests.Integration/Core/TestConfigTests.cs
@@ -26,21 +26,23 @@ namespace Arcus.Testing.Tests.Integration.Core
         {
             // Arrange
             string mainAppSettingsName = $"{Bogus.Lorem.Word()}.json";
-            string localAppSettingsName = $"{Bogus.Lorem.Word()}.local.json";
-            string key = Bogus.Lorem.Word(), expected = Bogus.Lorem.Word();
-            AddLocalValueToCustomMain(localAppSettingsName, key, expected, mainAppSettingsName);
+            string localAppSettingsName1 = $"{Bogus.Lorem.Word()}.local.json";
+            string localAppSettingsName2 = $"{Bogus.Lorem.Word()}.local.json";
+            string key1 = Bogus.Lorem.Word(), expected1 = Bogus.Lorem.Word();
+            string key2 = Bogus.Lorem.Word(), expected2 = Bogus.Lorem.Word();
+            AddLocalValueToCustomMain(localAppSettingsName1, key1, expected1, mainAppSettingsName);
+            AddLocalValueToCustomMain(localAppSettingsName2, key2, expected2, mainAppSettingsName);
 
             var config = TestConfig.Create(options =>
             {
                 options.UseMainJsonFile(mainAppSettingsName)
-                       .AddOptionalJsonFile(localAppSettingsName);
+                       .AddOptionalJsonFile(localAppSettingsName1)
+                       .AddOptionalJsonFile(localAppSettingsName2);
             });
 
-            // Act
-            string actual = config[key];
-
-            // Assert
-            Assert.Equal(expected, actual);
+            // Act / Assert
+            Assert.Equal(expected1, config[key1]);
+            Assert.Equal(expected2, config[key2]);
         }
 
         private void AddLocalValueToCustomMain(string fileName, string key, string value, string newMainFile)
@@ -194,10 +196,13 @@ namespace Arcus.Testing.Tests.Integration.Core
         }
 
         [Fact]
-        public void CreateCustom_WithoutMainAppSettingsFile_FailsWithNotFound()
+        public void CreateCustom_WithoutMainAppSettingsFile_StillSucceeds()
         {
-            Assert.Throws<FileNotFoundException>(
-                () => TestConfig.Create(opt => opt.UseMainJsonFile(Bogus.System.FileName("json"))));
+            // Arrange
+            var config = TestConfig.Create(opt => opt.UseMainJsonFile(Bogus.System.FileName("json")));
+
+            // Act / Assert
+            AssertNotFound(() => { string _ = config["ignored_key"]; });
         }
 
         [Fact]


### PR DESCRIPTION
Mark the main `appsettings.json` file as optional by-design in the `TestConfig` for more easily access and user-friendliness.

Follow-up of #92 