### PR TITLE
fix: compare csv ints w/ spaces as text

### DIFF
--- a/src/Arcus.Testing.Assert/AssertCsv.cs
+++ b/src/Arcus.Testing.Assert/AssertCsv.cs
@@ -507,9 +507,14 @@ namespace Arcus.Testing
         internal CsvDifference(CsvDifferenceKind kind, string expected, string actual, int rowNumber)
         {
             _kind = kind;
-            _expected = expected ?? throw new ArgumentNullException(nameof(expected));
-            _actual = actual ?? throw new ArgumentNullException(nameof(actual));
+            _expected = QuoteValueWithSpaces(expected ?? throw new ArgumentNullException(nameof(expected)));
+            _actual = QuoteValueWithSpaces(actual ?? throw new ArgumentNullException(nameof(actual)));
             _rowNumber = rowNumber;
+        }
+
+        private static string QuoteValueWithSpaces(string value)
+        {
+            return value.Contains(' ') ? $"\"{value}\"" : value;
         }
 
         /// <summary>
@@ -845,20 +850,16 @@ namespace Arcus.Testing
             }
 
             const NumberStyles style = NumberStyles.Float | NumberStyles.AllowThousands;
-            if (float.TryParse(Value, style, _culture, out float expectedValue)
+            const char blankSpace = ' ';
+            
+            if (!Value.Contains(blankSpace) && !other.Value.Contains(blankSpace) 
+                && float.TryParse(Value, style, _culture, out float expectedValue)
                 && float.TryParse(other.Value, style, _culture, out float actualValue))
             {
-                if (!expectedValue.Equals(actualValue))
-                {
-                    return false;
-                }
-            }
-            else if (Value != other.Value)
-            {
-                return false;
+                return expectedValue.Equals(actualValue);
             }
 
-            return true;
+            return Value == other.Value;
         }
 
         /// <summary>

--- a/src/Arcus.Testing.Assert/AssertCsv.cs
+++ b/src/Arcus.Testing.Assert/AssertCsv.cs
@@ -514,7 +514,9 @@ namespace Arcus.Testing
 
         private static string QuoteValueUponSpaces(string value)
         {
-            return value.Contains(' ') ? $"\"{value}\"" : value;
+            return value.Contains(' ') 
+                   && !value.StartsWith('"')
+                   && !value.EndsWith('"') ? $"\"{value}\"" : value;
         }
 
         /// <summary>
@@ -851,8 +853,9 @@ namespace Arcus.Testing
 
             const NumberStyles style = NumberStyles.Float | NumberStyles.AllowThousands;
             const char blankSpace = ' ';
-            
-            if (!Value.Contains(blankSpace) && !other.Value.Contains(blankSpace) 
+            bool containsSpaces = Value.Contains(blankSpace) || other.Value.Contains(blankSpace);
+
+            if (!containsSpaces 
                 && float.TryParse(Value, style, _culture, out float expectedValue)
                 && float.TryParse(other.Value, style, _culture, out float actualValue))
             {

--- a/src/Arcus.Testing.Assert/AssertCsv.cs
+++ b/src/Arcus.Testing.Assert/AssertCsv.cs
@@ -507,12 +507,12 @@ namespace Arcus.Testing
         internal CsvDifference(CsvDifferenceKind kind, string expected, string actual, int rowNumber)
         {
             _kind = kind;
-            _expected = QuoteValueWithSpaces(expected ?? throw new ArgumentNullException(nameof(expected)));
-            _actual = QuoteValueWithSpaces(actual ?? throw new ArgumentNullException(nameof(actual)));
+            _expected = QuoteValueUponSpaces(expected ?? throw new ArgumentNullException(nameof(expected)));
+            _actual = QuoteValueUponSpaces(actual ?? throw new ArgumentNullException(nameof(actual)));
             _rowNumber = rowNumber;
         }
 
-        private static string QuoteValueWithSpaces(string value)
+        private static string QuoteValueUponSpaces(string value)
         {
             return value.Contains(' ') ? $"\"{value}\"" : value;
         }

--- a/src/Arcus.Testing.Tests.Unit/Assert_/AssertCsvTests.cs
+++ b/src/Arcus.Testing.Tests.Unit/Assert_/AssertCsvTests.cs
@@ -125,6 +125,46 @@ namespace Arcus.Testing.Tests.Unit.Assert_
         }
 
         [Property]
+        public void CompareWithInteger_WithSameTrailingSpaces_StillSucceedsByHandlingLikeText()
+        {
+            // Arrange
+            TestCsv expected = TestCsv.Generate();
+            TestCsv actual = expected.Copy();
+
+            (int row, int col) = expected.GetRandomCellIndex();
+            string value = Bogus.Random.Int().ToString();
+
+            string spaces = RandomSpaces();
+            expected.ChangeCellValue(row, col, value + spaces);
+            actual.ChangeCellValue(row, col, value + spaces);
+
+            // Act / Assert
+            EqualCsv(expected, actual, opt => opt.CultureInfo = CultureInfo.InvariantCulture);
+        }
+
+        [Property]
+        public void CompareWithInteger_WithDiffTrailingSpaces_FailsSinceHandledLikeText()
+        {
+            // Arrange
+            TestCsv expected = TestCsv.Generate();
+            TestCsv actual = expected.Copy();
+
+            (int row, int col) = expected.GetRandomCellIndex();
+            string value = Bogus.Random.Int().ToString();
+
+            expected.ChangeCellValue(row, col, value + RandomSpaces(1, 5));
+            actual.ChangeCellValue(row, col, value + RandomSpaces(6, 10));
+
+            // Act / Assert
+            CompareShouldFailWithDescription(expected, actual, "different", "value", value);
+        }
+
+        private static string RandomSpaces(int min = 1, int max = 20)
+        {
+            return string.Concat(Bogus.Make(Bogus.Random.Int(min, max), () => " "));
+        }
+
+        [Property]
         public void CompareWithIgnoreRowOrder_WithDifferentCellValue_FailsWithDescription()
         {
             // Arrange


### PR DESCRIPTION
Adds an additional condition to the Assert CSV that makes sure that any text value with spaces is always considered text.

Follow-up: #115 