### PR TITLE
feat: add adoptation improvements on core functionality

### DIFF
--- a/docs/preview/02-Features/core.md
+++ b/docs/preview/02-Features/core.md
@@ -59,7 +59,8 @@ byte[] img = root.ReadFileBytesByName("file.png");
 ResourceDirectory sub = root.WithSubDirectory("resources");
 
 string txt = sub.ReadFileTextByName("file.txt");
-byte[] img = sub.ReadFileBytesByName("file.png");
+byte[] img = sub.ReadFileBytesByPattern("*.png");
+
 
 // FileNotFoundException: 
 //    Cannot retrieve 'file.txt' file contents in test resource directory 'resources' because it does not exists,
@@ -122,6 +123,21 @@ var config = TestConfig.Create(options =>
     options.AddOptionalJsonFile("configuration.Dev.json");
 });
 ```
+
+It can also be used as a base for your custom configuration, by inheriting from the `TestConfig`:
+
+```csharp
+public class MyTestConfig : TestConfig
+{
+    // Uses default 'appsettings.json' and 'appsettings.local.json' as local alternative.
+    // Same as doing `TestConfig.Create()`
+    public MyTestConfig()
+
+    public MyTestConfig() : base(options => options.UseMainJsonFile("configuration.json")) { }
+}
+```
+
+💡 The added benefit from having your own instance of the test configuration, is that you are free to add project-specific properties and methods, without exposing Arcus functionality directly to your tests.
 
 ## Polling
 Writing integration tests interacts by definition with external resources. These resources might not always be available at the time the test needs them. Because of this, polling until the target resource is available is a common practice. An example is polling for a health endpoint until the application response 'healthy'.

--- a/src/Arcus.Testing.Core/DisposableCollection.cs
+++ b/src/Arcus.Testing.Core/DisposableCollection.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -89,6 +90,24 @@ namespace Arcus.Testing
         }
 
         /// <summary>
+        /// Adds a range of <paramref name="disposables"/> to this collection which will get disposed when this collection gets disposed.
+        /// </summary>
+        /// <param name="disposables">The disposable instances to add to the collection.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="disposables"/> or any of its elements are <c>null</c>.</exception>
+        public void AddRange(IEnumerable<IAsyncDisposable> disposables)
+        {
+            if (disposables is null)
+            {
+                throw new ArgumentNullException(nameof(disposables));
+            }
+
+            foreach (IAsyncDisposable disposable in disposables)
+            {
+                Add(disposable);
+            }
+        }
+
+        /// <summary>
         /// Adds a <paramref name="disposable"/> to this collection which will get disposed when this collection gets disposed.
         /// </summary>
         /// <param name="disposable">The disposable instance to add to the collection.</param>
@@ -101,6 +120,24 @@ namespace Arcus.Testing
             }
 
             Add(AsyncDisposable.Create(disposable));
+        }
+
+        /// <summary>
+        /// Adds a range of <paramref name="disposables"/> to this collection which will get disposed when this collection gets disposed.
+        /// </summary>
+        /// <param name="disposables">The disposable instances to add to the collection.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="disposables"/> or any of its elements are <c>null</c>.</exception>
+        public void AddRange(IEnumerable<IDisposable> disposables)
+        {
+            if (disposables is null)
+            {
+                throw new ArgumentNullException(nameof(disposables));
+            }
+
+            foreach (IDisposable disposable in disposables)
+            {
+                Add(disposable);
+            }
         }
 
         /// <summary>

--- a/src/Arcus.Testing.Tests.Integration/Core/Fixture/CustomTestConfig.cs
+++ b/src/Arcus.Testing.Tests.Integration/Core/Fixture/CustomTestConfig.cs
@@ -1,0 +1,21 @@
+﻿using System;
+
+namespace Arcus.Testing.Tests.Integration.Core.Fixture
+{
+    internal class CustomTestConfig : TestConfig
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CustomTestConfig" /> class.
+        /// </summary>
+        public CustomTestConfig()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CustomTestConfig" /> class.
+        /// </summary>
+        public CustomTestConfig(Action<TestConfigOptions> configureOptions) : base(configureOptions)
+        {
+        }
+    }
+}

--- a/src/Arcus.Testing.Tests.Integration/Core/ResourceDirectoryTests.cs
+++ b/src/Arcus.Testing.Tests.Integration/Core/ResourceDirectoryTests.cs
@@ -23,8 +23,7 @@ namespace Arcus.Testing.Tests.Integration.Core
             ResourceDirectory subDir = WithSubDirectories(Root, tempSubDir);
 
             // Act / Assert
-            Assert.Equal(tempFile.Contents, subDir.ReadFileBytesByName(tempFile.Name));
-            Assert.Equal(tempFile.Text, subDir.ReadFileTextByName(tempFile.Name));
+            AssertContainsFile(tempFile, subDir);
         }
 
         [Fact]
@@ -35,8 +34,7 @@ namespace Arcus.Testing.Tests.Integration.Core
             string unknownFileName = Bogus.Lorem.Word();
 
             // Act / Assert
-            AssertFileNotFound(() => Root.ReadFileTextByName(unknownFileName), unknownFileName);
-            AssertFileNotFound(() => Root.ReadFileBytesByName(unknownFileName), unknownFileName);
+            AssertFileNotFound(unknownFileName, Root);
         }
 
         [Fact]
@@ -46,8 +44,7 @@ namespace Arcus.Testing.Tests.Integration.Core
             using var tempFile = TemporaryFile.GenerateAt(Root.Path);
 
             // Act / Assert
-            Assert.Equal(tempFile.Contents, Root.ReadFileBytesByName(tempFile.Name));
-            Assert.Equal(tempFile.Text, Root.ReadFileTextByName(tempFile.Name));
+            AssertContainsFile(tempFile, Root);
         }
 
         [Fact]
@@ -57,8 +54,7 @@ namespace Arcus.Testing.Tests.Integration.Core
             string unknownFileName = Bogus.Lorem.Word();
 
             // Act / Assert
-            AssertFileNotFound(() => Root.ReadFileTextByName(unknownFileName), unknownFileName);
-            AssertFileNotFound(() => Root.ReadFileBytesByName(unknownFileName), unknownFileName);
+            AssertFileNotFound(unknownFileName, Root);
         }
 
         [Fact]
@@ -87,6 +83,22 @@ namespace Arcus.Testing.Tests.Integration.Core
 
             // Act / Assert
             AssertDirNotFound(() => Root.WithSubDirectory(unknownSubDirName), unknownSubDirName);
+        }
+
+        private static void AssertContainsFile(TemporaryFile expectedFile, ResourceDirectory directory)
+        {
+            Assert.Equal(expectedFile.Contents, directory.ReadFileBytesByName(expectedFile.Name));
+            Assert.Equal(expectedFile.Contents, directory.ReadFileBytesByPattern(expectedFile.Name[..^1] + "?"));
+            Assert.Equal(expectedFile.Text, directory.ReadFileTextByName(expectedFile.Name));
+            Assert.Equal(expectedFile.Text, directory.ReadFileTextByPattern(expectedFile.Name[..5] + "*"));
+        }
+
+        private static void AssertFileNotFound(string input, ResourceDirectory directory)
+        {
+            AssertFileNotFound(() => directory.ReadFileTextByName(input), input);
+            AssertFileNotFound(() => directory.ReadFileBytesByName(input), input);
+            AssertFileNotFound(() => directory.ReadFileTextByPattern(input), input);
+            AssertFileNotFound(() => directory.ReadFileBytesByPattern(input), input);
         }
 
         private static void AssertFileNotFound(Action dirAction, params string[] errorParts)

--- a/src/Arcus.Testing.Tests.Integration/Core/ResourceDirectoryTests.cs
+++ b/src/Arcus.Testing.Tests.Integration/Core/ResourceDirectoryTests.cs
@@ -27,6 +27,20 @@ namespace Arcus.Testing.Tests.Integration.Core
         }
 
         [Fact]
+        public void FileContentsFromSubDirectory_FromManyMatchingFiles_FailsWithNotFound()
+        {
+            // Arrange
+            using var tempSubDir = TemporaryDirectory.GenerateAt(Root.Path);
+            using var tempFile1 = TemporaryFile.GenerateAt(tempSubDir.Path);
+            using var tempFile2 = TemporaryFile.GenerateAt(tempSubDir.Path);
+
+            ResourceDirectory subDir = WithSubDirectories(Root, tempSubDir);
+
+            // Act / Assert
+            AssertFileNotFound("*", subDir);
+        }
+
+        [Fact]
         public void FileContentsFromSubDirectory_FromUnknownFile_FailsWithNotFound()
         {
             // Arrange

--- a/src/Arcus.Testing.Tests.Unit/Assert_/AssertXmlTests.cs
+++ b/src/Arcus.Testing.Tests.Unit/Assert_/AssertXmlTests.cs
@@ -96,7 +96,7 @@ namespace Arcus.Testing.Tests.Unit.Assert_
             var expected = TestXml.Generate();
             TestXml actual = expected.Copy();
 
-            string newValue = Bogus.Random.AlphaNumeric(Bogus.Random.Int(1, 10));
+            string newValue = Bogus.Random.AlphaNumeric(Bogus.Random.Int(10, 20));
             actual.ChangeRandomlyElementValue(newValue);
 
             // Act / Assert

--- a/src/Arcus.Testing.Tests.Unit/Core/DisposableCollectionTests.cs
+++ b/src/Arcus.Testing.Tests.Unit/Core/DisposableCollectionTests.cs
@@ -79,11 +79,25 @@ namespace Arcus.Testing.Tests.Unit.Core
             switch (disposable)
             {
                 case IAsyncDisposable d:
-                    collection.Add(d);
+                    if (Bogus.Random.Bool())
+                    {
+                        collection.Add(d); 
+                    }
+                    else
+                    {
+                        collection.AddRange(new[] { d });
+                    }
                     break;
 
                 case IDisposable d:
-                    collection.Add(d);
+                    if (Bogus.Random.Bool())
+                    {
+                        collection.Add(d); 
+                    }
+                    else
+                    {
+                        collection.AddRange(new[] { d });
+                    }
                     break;
             }
         }


### PR DESCRIPTION
Adds some improvements to the core library that were all related to improved adoptation - were found when trying to include into Invictus test suite.

* Provide a `DisposableCollection.AddRange` method to add multiple disposable instances at once, this is especially useful when you deal with many of the same test fixture - like several temporary environment variables.
* Provide a `ReadFileText/BytesByPattern` method to pass in a search pattern to find a resource file instead of obligated for the full name - lessens the dependanbility on the test suite to know the exact names when it can just pass in `*.xslt` in a certain folder.
* Make the `TestConfig` open for extensibility by accepting child implementations by using the `TestConfig` as a base parent class - this helps when you want project-specific properties in your test config without the hassle of having to implement the `IConfiguration` yourself.