### PR TITLE
chore: deploy storage test resources

### DIFF
--- a/build/ci-build.yml
+++ b/build/ci-build.yml
@@ -79,7 +79,7 @@ stages:
     condition: succeeded()
     jobs:
       - template: templates/integration-tests.yml
-        inputs:
+        parameters:
           azureServiceConnection: '${{ parameters.azureServiceConnection }}'
 
   - stage: ReleaseToMyget

--- a/build/ci-build.yml
+++ b/build/ci-build.yml
@@ -18,6 +18,10 @@ parameters:
   - name: 'Package.Version.ManualTrigger'
     type: string
     default: 'preview'
+  - name: azureServiceConnection
+    displayName: 'Azure service connection'
+    type: string
+    default: 'Azure Codit-Arcus Service Principal'
 
 resources:
   repositories:
@@ -67,54 +71,16 @@ stages:
     dependsOn: Build
     condition: succeeded()
     jobs:
-      - job: UnitTests
-        displayName: 'Run unit tests'
-        pool:
-          vmImage: '$(Vm.Image)'
-        steps:
-          - task: DownloadPipelineArtifact@2
-            displayName: 'Download build artifacts'
-            inputs:
-              artifact: 'Build'
-              path: '$(Build.SourcesDirectory)'
-          - task: UseDotNet@2
-            displayName: 'Import .NET SDK ($(DotNet.Sdk.VersionBC))'
-            inputs:
-              packageType: 'sdk'
-              version: '$(DotNet.Sdk.VersionBC)'
-          - template: test/run-unit-tests.yml@templates
-            parameters:
-              dotnetSdkVersion: '$(DotNet.Sdk.Version)'
-              projectName: '$(Project).Tests.Unit'
-              includePreviewVersions: $(DotNet.Sdk.IncludePreviewVersions)
+      - template: templates/unit-tests.yml
 
   - stage: IntegrationTests
     displayName: Integration Tests
     dependsOn: Build
     condition: succeeded()
     jobs:
-      - job: IntegrationTests
-        displayName: 'Run integration tests'
-        pool:
-          vmImage: '$(Vm.Image)'
-        steps:
-          - task: DownloadPipelineArtifact@2
-            displayName: 'Download build artifacts'
-            inputs:
-              artifact: 'Build'
-              path: '$(Build.SourcesDirectory)'
-          - task: UseDotNet@2
-            displayName: 'Import .NET SDK ($(DotNet.Sdk.VersionBC))'
-            inputs:
-              packageType: 'sdk'
-              version: '$(DotNet.Sdk.VersionBC)'
-          - template: test/run-integration-tests.yml@templates
-            parameters:
-              dotnetSdkVersion: '$(DotNet.Sdk.Version)'
-              projectName: '$(Project).Tests.Integration'
-              category: 'Integration'
-              includePreviewVersions: $(DotNet.Sdk.IncludePreviewVersions)
-
+      - template: templates/integration-tests.yml
+        inputs:
+          azureServiceConnection: '${{ parameters.azureServiceConnection }}'
 
   - stage: ReleaseToMyget
     displayName: 'Release to MyGet'

--- a/build/deploy-test-resources.yml
+++ b/build/deploy-test-resources.yml
@@ -48,4 +48,4 @@ stages:
                   --parameters resourceGroupName=${{ parameters.resourceGroupName }} `
                   --parameters storageAccountName=${{ variables['Arcus.Testing.StorageAccount.Name'] }} `
                   --parameters keyVaultName=${{ variables['Arcus.Testing.KeyVault.Name'] }} `
-                  --parameters servicePrincipal_objectId=$objectId `
+                  --parameters servicePrincipal_objectId=$objectId

--- a/build/deploy-test-resources.yml
+++ b/build/deploy-test-resources.yml
@@ -46,4 +46,3 @@ stages:
                   --parameters location=westeurope `
                   --parameters resourceGroupName=${{ parameters.resourceGroupName }} `
                   --parameters storageAccountName=${{ variables['Arcus.Testing.StorageAccount.Name'] }}
-

--- a/build/deploy-test-resources.yml
+++ b/build/deploy-test-resources.yml
@@ -43,7 +43,7 @@ stages:
                 $deployOutput = az deployment sub create `
                   --location westeurope `
                   --template-file ./build/templates/test-resources.bicep `
-                  --parmeters location=westeurope `
+                  --parameters location=westeurope `
                   --parameters resourceGroupName=${{ parameters.resourceGroupName }} `
                   --parameters storageAccountName=${{ variables['Arcus.Testing.StorageAccount.Name'] }}
 

--- a/build/deploy-test-resources.yml
+++ b/build/deploy-test-resources.yml
@@ -1,0 +1,48 @@
+name: Arcus Testing - Deploy test resources
+
+trigger: none
+pr: none
+
+parameters:
+  - name: azureServiceConnection
+    displayName: 'Azure service connection'
+    type: string
+    default: 'Azure Codit-Arcus Service Principal'
+  - name: resourceGroupName
+    displayName: 'Resource group name'
+    default: arcus-testing-dev-we-rg
+
+variables:
+  - template: ./variables/build.yml
+
+resources:
+  repositories:
+    - repository: templates
+      type: github
+      name: arcus-azure/azure-devops-templates
+      endpoint: arcus-azure
+
+stages:
+  - stage: Deploy
+    jobs:
+      - job: DeployBicep
+        displayName: 'Deploy test resources'
+        pool:
+          vmImage: $(Vm.Image)
+        steps:
+          - task: AzureCLI@2
+            env:
+              SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+            inputs:
+              azureSubscription: '${{ parameters.azureServiceConnection }}'
+              addSpnToEnvironment: true
+              scriptType: 'pscore'
+              scriptLocation: 'inlineScript'
+              inlineScript: |
+                $deployOutput = az deployment sub create `
+                  --location westeurope `
+                  --template-file ./build/templates/test-resources.bicep `
+                  --parmeters location=westeurope `
+                  --parameters resourceGroupName=${{ parameters.resourceGroupName }} `
+                  --parameters storageAccountName=${{ variables['Arcus.Testing.StorageAccount.Name'] }} `
+

--- a/build/deploy-test-resources.yml
+++ b/build/deploy-test-resources.yml
@@ -66,5 +66,6 @@ stages:
               scriptType: 'pscore'
               scriptLocation: 'inlineScript'
               inlineScript: |
-                Install-Module -Name Pester -Force -SkipPublisherCheck -MaximumVersion 5.1.1
+                Install-Module -Name Az -Force -AllowClobber -SkipPublisherCheck
+                Install-Module -Name Pester -Force -SkipPublisherCheck
                 Invoke-Pester -Script "./build/templates/smoke-tests.ps1" -OutputFile "./pester.test.results.xml" -OutputFormat 'NUnitXML' -EnableExit

--- a/build/deploy-test-resources.yml
+++ b/build/deploy-test-resources.yml
@@ -69,3 +69,9 @@ stages:
                 Install-Module -Name Az -Force -AllowClobber -SkipPublisherCheck
                 Install-Module -Name Pester -Force -SkipPublisherCheck
                 Invoke-Pester -Script "./build/templates/smoke-tests.ps1" -OutputFile "./pester.test.results.xml" -OutputFormat 'NUnitXML' -EnableExit
+          - task: PublishTestResults@2
+            displayName: 'Publish test results'
+            inputs:
+              testResultsFormat: 'NUnit'
+              testResultsFiles: '**/pester.test.results.xml'
+              failTaskOnFailedTests: true

--- a/build/deploy-test-resources.yml
+++ b/build/deploy-test-resources.yml
@@ -40,9 +40,12 @@ stages:
               scriptType: 'pscore'
               scriptLocation: 'inlineScript'
               inlineScript: |
+                $objectId = (az ad sp show --id $env:servicePrincipalId | ConvertFrom-Json).id
                 $deployOutput = az deployment sub create `
                   --location westeurope `
                   --template-file ./build/templates/test-resources.bicep `
                   --parameters location=westeurope `
                   --parameters resourceGroupName=${{ parameters.resourceGroupName }} `
-                  --parameters storageAccountName=${{ variables['Arcus.Testing.StorageAccount.Name'] }}
+                  --parameters storageAccountName=${{ variables['Arcus.Testing.StorageAccount.Name'] }} `
+                  --parameters keyVaultName=${{ variables['Arcus.Testing.KeyVault.Name'] }} `
+                  --parameters servicePrincipal_objectId=$objectId `

--- a/build/deploy-test-resources.yml
+++ b/build/deploy-test-resources.yml
@@ -45,5 +45,5 @@ stages:
                   --template-file ./build/templates/test-resources.bicep `
                   --parmeters location=westeurope `
                   --parameters resourceGroupName=${{ parameters.resourceGroupName }} `
-                  --parameters storageAccountName=${{ variables['Arcus.Testing.StorageAccount.Name'] }} `
+                  --parameters storageAccountName=${{ variables['Arcus.Testing.StorageAccount.Name'] }}
 

--- a/build/deploy-test-resources.yml
+++ b/build/deploy-test-resources.yml
@@ -32,8 +32,6 @@ stages:
           vmImage: $(Vm.Image)
         steps:
           - task: AzureCLI@2
-            env:
-              SYSTEM_ACCESSTOKEN: $(System.AccessToken)
             inputs:
               azureSubscription: '${{ parameters.azureServiceConnection }}'
               addSpnToEnvironment: true
@@ -49,3 +47,24 @@ stages:
                   --parameters storageAccountName=${{ variables['Arcus.Testing.StorageAccount.Name'] }} `
                   --parameters keyVaultName=${{ variables['Arcus.Testing.KeyVault.Name'] }} `
                   --parameters servicePrincipal_objectId=$objectId
+
+  - stage: SmokeTests
+    dependsOn: Deploy
+    condition: succeeded()
+    jobs:
+      - job: RunSmokeTests
+        displayName: 'Run smoke tests'
+        pool:
+          vmImage: $(Vm.Image)
+        steps:
+          - task: AzureCLI@2
+            env:
+              resourceGroupName: ${{ parameters.resourceGroupName }}
+            inputs:
+              azureSubscription: '${{ parameters.azureServiceConnection }}'
+              addSpnToEnvironment: true
+              scriptType: 'pscore'
+              scriptLocation: 'inlineScript'
+              inlineScript: |
+                Install-Module -Name Pester -Force -SkipPublisherCheck -MaximumVersion 5.1.1
+                Invoke-Pester -Script "./build/templates/smoke-tests.ps1" -OutputFile "./pester.test.results.xml" -OutputFormat 'NUnitXML' -EnableExit

--- a/build/deploy-test-resources.yml
+++ b/build/deploy-test-resources.yml
@@ -14,6 +14,7 @@ parameters:
 
 variables:
   - template: ./variables/build.yml
+  - template: ./variables/test.yml
 
 resources:
   repositories:

--- a/build/deploy-test-resources.yml
+++ b/build/deploy-test-resources.yml
@@ -60,6 +60,7 @@ stages:
           - task: AzureCLI@2
             env:
               resourceGroupName: ${{ parameters.resourceGroupName }}
+              storageAccountName: $(Arcus.Testing.StorageAccount.Name)
             inputs:
               azureSubscription: '${{ parameters.azureServiceConnection }}'
               addSpnToEnvironment: true

--- a/build/nuget-release.yml
+++ b/build/nuget-release.yml
@@ -6,6 +6,10 @@ pr: none
 parameters:
   - name: 'Package.Version'
     type: 'string'
+  - name: azureServiceConnection
+    displayName: 'Azure service connection'
+    type: string
+    default: 'Azure Codit-Arcus Service Principal'
 
 resources:
   repositories:
@@ -55,53 +59,16 @@ stages:
     dependsOn: Build
     condition: succeeded()
     jobs:
-      - job: UnitTests
-        displayName: 'Run unit tests'
-        pool:
-          vmImage: '$(Vm.Image)'
-        steps:
-          - task: DownloadPipelineArtifact@2
-            displayName: 'Download build artifacts'
-            inputs:
-              artifact: 'Build'
-              path: '$(Build.SourcesDirectory)'
-          - task: UseDotNet@2
-            displayName: 'Import .NET SDK ($(DotNet.Sdk.VersionBC))'
-            inputs:
-              packageType: 'sdk'
-              version: '$(DotNet.Sdk.VersionBC)'
-          - template: test/run-unit-tests.yml@templates
-            parameters:
-              dotnetSdkVersion: '$(DotNet.Sdk.Version)'
-              projectName: '$(Project).Tests.Unit'
-              includePreviewVersions: $(DotNet.Sdk.IncludePreviewVersions)
-
+      - template: templates/unit-tests.yml
 
   - stage: IntegrationTests
     displayName: Integration Tests
     dependsOn: Build
     condition: succeeded()
     jobs:
-      - job: IntegrationTests
-        displayName: 'Run integration tests'
-        pool:
-          vmImage: '$(Vm.Image)'
-        steps:
-          - task: DownloadPipelineArtifact@2
-            displayName: 'Download build artifacts'
-            inputs:
-              artifact: 'Build'
-              path: '$(Build.SourcesDirectory)'
-          - task: UseDotNet@2
-            displayName: 'Import .NET SDK ($(DotNet.Sdk.VersionBC))'
-            inputs:
-              packageType: 'sdk'
-              version: '$(DotNet.Sdk.VersionBC)'
-          - template: test/run-integration-tests.yml@templates
-            parameters:
-              dotnetSdkVersion: '$(DotNet.Sdk.Version)'
-              projectName: '$(Project).Tests.Integration'
-              includePreviewVersions: $(DotNet.Sdk.IncludePreviewVersions)
+      - template: templates/integration-tests.yml
+        inputs:
+          azureServiceConnection: '${{ parameters.azureServiceConnection }}'
 
   - stage: Release
     displayName: 'Release to NuGet.org'
@@ -124,9 +91,9 @@ stages:
             parameters:
               repositoryName: '$(Repository)'
               releaseNotes: |
-                Install the $(Project) packages that you need via NuGet, for instance [$(Project).Logging](https://www.nuget.org/packages/$(Project).Logging/$(Build.BuildNumber)):
+                Install the $(Project) packages that you need via NuGet, for instance [$(Project).Logging](https://www.nuget.org/packages/$(Project).Logging.Xunit/$(Build.BuildNumber)):
                 ```shell
-                PM > Install-Package $(Project).Logging --Version $(Build.BuildNumber)
+                PM > Install-Package $(Project).Logging.Xunit --Version $(Build.BuildNumber)
                 ```
                 For a complete list of all $(Project) packages see the [documentation](https://github.com/arcus-azure/arcus.testing/blob/master/docs/index.md).
                 ## What's new?

--- a/build/nuget-release.yml
+++ b/build/nuget-release.yml
@@ -67,7 +67,7 @@ stages:
     condition: succeeded()
     jobs:
       - template: templates/integration-tests.yml
-        inputs:
+        parameters:
           azureServiceConnection: '${{ parameters.azureServiceConnection }}'
 
   - stage: Release

--- a/build/templates/integration-tests.yml
+++ b/build/templates/integration-tests.yml
@@ -1,0 +1,44 @@
+parameters:
+  azureServiceConnection: ''
+
+jobs:
+  - job: IntegrationTests
+    displayName: 'Run integration tests'
+    pool:
+      vmImage: '$(Vm.Image)'
+    steps:
+      - task: DownloadPipelineArtifact@2
+        displayName: 'Download build artifacts'
+        inputs:
+          artifact: 'Build'
+          path: '$(Build.SourcesDirectory)'
+
+      - task: UseDotNet@2
+        displayName: 'Import .NET SDK ($(DotNet.Sdk.VersionBC))'
+        inputs:
+          packageType: 'sdk'
+          version: '$(DotNet.Sdk.VersionBC)'
+
+      - task: AzureCLI@2
+        displayName: 'Import secrets from Azure Key Vault'
+        env:
+          ARCUS_KEYVAULT_NAME: $(Arcus.Testing.KeyVault.Name)
+        inputs:
+          azureSubscription: '${{ parameters.azureServiceConnection }}'
+          scriptType: 'pscore'
+          scriptLocation: 'inlineScript'
+          addSpnToEnvironment: true
+          inlineScript: |
+            Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
+            Install-Module -Name Arcus.Scripting.DevOps -AllowClobber
+
+            # TODO: get Key Vault secret and set it as secret pipeline variable.
+            Set-AzDevOpsVariable -Name 'Arcus.Testing.TenantId' -Value $env:tenantId
+            Set-AzDevOpsVariable -Name 'Arcus.Testing.ServicePrincipal.ClientId' -Value $env:servicePrincipalId
+            Set-AzDevOpsVariable -Name 'Arcus.Testing.ServicePrincipal.ClientSecret' -Value $env:servicePrincipalKey
+
+      - template: test/run-integration-tests.yml@templates
+        parameters:
+          dotnetSdkVersion: '$(DotNet.Sdk.Version)'
+          projectName: '$(Project).Tests.Integration'
+          includePreviewVersions: $(DotNet.Sdk.IncludePreviewVersions)

--- a/build/templates/smoke-tests.ps1
+++ b/build/templates/smoke-tests.ps1
@@ -5,7 +5,15 @@ BeforeAll {
 }
 
 Describe 'Storage account' {
-  It 'Service principal has access to storage account' {
+  It 'Service principal can get blob container' {
     Get-AzStorageContainer -ResourceGroupName $env:resourceGroupName
+  }
+  It 'Service principal can create blob container' {
+    $containerName = 'test-container'
+    try {
+      New-AzStorageContainer -ResourceGroupName $env:resourceGroupName -Name $containerName
+    } finally {
+      Remove-AzStorageContainer -ResourceGroupName $env:resourceGroupName -Name $containerName -Force
+    }
   }
 }

--- a/build/templates/smoke-tests.ps1
+++ b/build/templates/smoke-tests.ps1
@@ -6,14 +6,14 @@ BeforeAll {
 
 Describe 'Storage account' {
   It 'Service principal can get blob container' {
-    Get-AzStorageContainer -ResourceGroupName $env:resourceGroupName
+    Get-AzStorageContainer
   }
   It 'Service principal can create blob container' {
     $containerName = 'test-container'
     try {
-      New-AzStorageContainer -ResourceGroupName $env:resourceGroupName -Name $containerName
+      New-AzStorageContainer -Name $containerName
     } finally {
-      Remove-AzStorageContainer -ResourceGroupName $env:resourceGroupName -Name $containerName -Force
+      Remove-AzStorageContainer -Name $containerName -Force
     }
   }
 }

--- a/build/templates/smoke-tests.ps1
+++ b/build/templates/smoke-tests.ps1
@@ -1,9 +1,11 @@
+BeforeAll {
+  $clientSecret = ConvertTo-SecureString $env:servicePrincipalKey -AsPlainText -Force
+  $pscredential = New-Object -TypeName System.Management.Automation.PSCredential($env:servicePrincipalId, $clientSecret)
+  Connect-AzAccount -ServicePrincipal -Tenant $env:tenantId -Credential $pscredential
+}
+
 Describe 'Storage account' {
   BeforeEach {
-    $clientSecret = ConvertTo-SecureString $env:servicePrincipalKey -AsPlainText -Force
-    $pscredential = New-Object -TypeName System.Management.Automation.PSCredential($env:servicePrincipalId, $clientSecret)
-    Connect-AzAccount -ServicePrincipal -Tenant $env:tenantId -Credential $pscredential
-    
     $storageContext = New-AzStorageContext -StorageAccountName $env:storageAccountName -UseConnectedAccount
   }
   It 'Service principal can get blob container' {

--- a/build/templates/smoke-tests.ps1
+++ b/build/templates/smoke-tests.ps1
@@ -1,11 +1,9 @@
-BeforeAll {
-  $clientSecret = ConvertTo-SecureString $env:servicePrincipalKey -AsPlainText -Force
-  $pscredential = New-Object -TypeName System.Management.Automation.PSCredential($env:servicePrincipalId, $clientSecret)
-  Connect-AzAccount -ServicePrincipal -Tenant $env:tenantId -Credential $pscredential
-}
-
 Describe 'Storage account' {
   BeforeEach {
+    $clientSecret = ConvertTo-SecureString $env:servicePrincipalKey -AsPlainText -Force
+    $pscredential = New-Object -TypeName System.Management.Automation.PSCredential($env:servicePrincipalId, $clientSecret)
+    Connect-AzAccount -ServicePrincipal -Tenant $env:tenantId -Credential $pscredential
+    
     $storageContext = New-AzStorageContext -StorageAccountName $env:storageAccountName -UseConnectedAccount
   }
   It 'Service principal can get blob container' {

--- a/build/templates/smoke-tests.ps1
+++ b/build/templates/smoke-tests.ps1
@@ -5,15 +5,18 @@ BeforeAll {
 }
 
 Describe 'Storage account' {
+  BeforeEach {
+    $storageContext = New-AzStorageContext -StorageAccountName $env:storageAccountName -UseConnectedAccount
+  }
   It 'Service principal can get blob container' {
-    Get-AzStorageContainer
+    Get-AzStorageContainer -Context $storageContext
   }
   It 'Service principal can create blob container' {
     $containerName = 'test-container'
     try {
-      New-AzStorageContainer -Name $containerName
+      New-AzStorageContainer -Name $containerName -Context $storageContext
     } finally {
-      Remove-AzStorageContainer -Name $containerName -Force
+      Remove-AzStorageContainer -Name $containerName -Context $storageContext -Force
     }
   }
 }

--- a/build/templates/smoke-tests.ps1
+++ b/build/templates/smoke-tests.ps1
@@ -1,7 +1,7 @@
 BeforeAll {
   $clientSecret = ConvertTo-SecureString $env:servicePrincipalKey -AsPlainText -Force
   $pscredential = New-Object -TypeName System.Management.Automation.PSCredential($env:servicePrincipalId, $clientSecret)
-  Connect-AzAccount -ServicePrincipal -Tenant $env:tenantId -Credential 
+  Connect-AzAccount -ServicePrincipal -Tenant $env:tenantId -Credential $pscredential
 }
 
 Describe 'Storage account' {

--- a/build/templates/smoke-tests.ps1
+++ b/build/templates/smoke-tests.ps1
@@ -1,0 +1,11 @@
+BeforeAll {
+  $clientSecret = ConvertTo-SecureString $env:servicePrincipalKey -AsPlainText -Force
+  $pscredential = New-Object -TypeName System.Management.Automation.PSCredential($env:servicePrincipalId, $clientSecret)
+  Connect-AzAccount -ServicePrincipal -Tenant $env:tenantId -Credential 
+}
+
+Describe 'Storage account' {
+  It 'Service principal has access to storage account' {
+    Get-AzStorageContainer -ResourceGroupName $env:resourceGroupName
+  }
+}

--- a/build/templates/test-resources.bicep
+++ b/build/templates/test-resources.bicep
@@ -1,0 +1,32 @@
+// Define the location for the deployment of the components.
+param location string
+
+// Define the name of the resource group where the components will be deployed.
+param resourceGroupName string
+
+// Define the name of the storage account that will be created.
+param storageAccountName string
+
+targetScope = 'subscription'
+
+module resourceGroup 'br/public:avm/res/resources/resource-group:0.2.3' = {
+  name: 'resourceGroupDeployment'
+  params: {
+    name: resourceGroupName
+    location: location
+  }
+}
+
+resource rg 'Microsoft.Resources/resourceGroups@2021-04-01' existing = {
+  name: resourceGroupName
+}
+
+module storageAccount 'br/public:avm/res/storage/storage-account:0.9.1' = {
+  name: 'storageAccountDeployment'
+  scope: rg
+  params: {
+    name: storageAccountName
+    location: location
+    allowBlobPublicAccess: true
+  }
+}

--- a/build/templates/test-resources.bicep
+++ b/build/templates/test-resources.bicep
@@ -7,6 +7,12 @@ param resourceGroupName string
 // Define the name of the storage account that will be created.
 param storageAccountName string
 
+// Define the name of the key vault where the necessary secrets will be stored to access the deployed test resources.
+param keyVaultName string
+
+// Define the Service Principal ID that needs access full access to the deployed resource group.
+param servicePrincipal_objectId string
+
 targetScope = 'subscription'
 
 module resourceGroup 'br/public:avm/res/resources/resource-group:0.2.3' = {
@@ -28,5 +34,35 @@ module storageAccount 'br/public:avm/res/storage/storage-account:0.9.1' = {
     name: storageAccountName
     location: location
     allowBlobPublicAccess: true
+    roleAssignments: [
+      {
+        principalId: servicePrincipal_objectId
+        roleDefinitionIdOrName: 'Storage Blob Data Contributor'
+      }
+      {
+        principalId: servicePrincipal_objectId
+        roleDefinitionIdOrName: 'Storage Table Data Contributor'
+      }
+    ]
+  }
+}
+
+module vault 'br/public:avm/res/key-vault/vault:0.6.1' = {
+  name: 'vaultDeployment'
+  dependsOn: [
+    resourceGroup
+  ]
+  scope: rg
+  params: {
+    name: keyVaultName
+    location: location
+    roleAssignments: [
+      {
+        principalId: servicePrincipal_objectId
+        roleDefinitionIdOrName: 'Key Vault Secrets officer'
+      }
+    ]
+    secrets: [
+    ]
   }
 }

--- a/build/templates/test-resources.bicep
+++ b/build/templates/test-resources.bicep
@@ -35,6 +35,12 @@ module storageAccount 'br/public:avm/res/storage/storage-account:0.9.1' = {
     location: location
     allowBlobPublicAccess: true
     publicNetworkAccess: 'Enabled'
+    networkAcls: {
+      bypass: 'AzureServices'
+      defaultAction: 'Allow'
+      ipRules: []
+      virtualNetworkRules: []
+    }
     roleAssignments: [
       {
         principalId: servicePrincipal_objectId

--- a/build/templates/test-resources.bicep
+++ b/build/templates/test-resources.bicep
@@ -34,6 +34,7 @@ module storageAccount 'br/public:avm/res/storage/storage-account:0.9.1' = {
     name: storageAccountName
     location: location
     allowBlobPublicAccess: true
+    publicNetworkAccess: 'Enabled'
     roleAssignments: [
       {
         principalId: servicePrincipal_objectId

--- a/build/templates/unit-tests.yml
+++ b/build/templates/unit-tests.yml
@@ -1,0 +1,23 @@
+jobs:
+  - job: UnitTests
+    displayName: 'Run unit tests'
+    pool:
+      vmImage: '$(Vm.Image)'
+    steps:
+      - task: DownloadPipelineArtifact@2
+        displayName: 'Download build artifacts'
+        inputs:
+          artifact: 'Build'
+          path: '$(Build.SourcesDirectory)'
+
+      - task: UseDotNet@2
+        displayName: 'Import .NET SDK ($(DotNet.Sdk.VersionBC))'
+        inputs:
+          packageType: 'sdk'
+          version: '$(DotNet.Sdk.VersionBC)'
+
+      - template: test/run-unit-tests.yml@templates
+        parameters:
+          dotnetSdkVersion: '$(DotNet.Sdk.Version)'
+          projectName: '$(Project).Tests.Unit'
+          includePreviewVersions: $(DotNet.Sdk.IncludePreviewVersions)

--- a/build/variables/test.yml
+++ b/build/variables/test.yml
@@ -1,0 +1,2 @@
+variables:
+  Arcus.Testing.StorageAccount.Name: 'arcustestingstorage'

--- a/build/variables/test.yml
+++ b/build/variables/test.yml
@@ -1,2 +1,3 @@
 variables:
   Arcus.Testing.StorageAccount.Name: 'arcustestingstorage'
+  Arcus.Testing.KeyVault.Name: 'arcus-testing-kv'


### PR DESCRIPTION
As prepartion for the upcoming Arcus.Testing storage functionality, we should make sure that we have a Storage Account in the new tenant to interact with during local/CI testing.

Relates to #93 