### PR TITLE
chore: stabelize unit tests

### DIFF
--- a/src/Arcus.Testing.Tests.Unit/Assert_/AssertXmlTests.cs
+++ b/src/Arcus.Testing.Tests.Unit/Assert_/AssertXmlTests.cs
@@ -71,7 +71,7 @@ namespace Arcus.Testing.Tests.Unit.Assert_
             var expected = TestXml.Generate();
             TestXml actual = expected.Copy();
 
-            string newName = TestXml.GenNodeName();
+            string newName = TestXml.GenNodeName() + Guid.NewGuid().ToString("N");
             actual.ChangeElementName(newName);
 
             // Act / Assert
@@ -163,7 +163,7 @@ namespace Arcus.Testing.Tests.Unit.Assert_
             var expected = TestXml.Generate();
             TestXml actual = expected.Copy();
             
-            actual.InsertAttribute(TestXml.GenNodeName());
+            actual.InsertAttribute(TestXml.GenNodeName() + Guid.NewGuid().ToString("N"));
             
             // Act / Assert
             CompareShouldFailWithDifference(expected, actual, "has", "attribute(s)", "instead of");

--- a/src/Arcus.Testing.Tests.Unit/Core/PollTests.cs
+++ b/src/Arcus.Testing.Tests.Unit/Core/PollTests.cs
@@ -84,24 +84,23 @@ namespace Arcus.Testing.Tests.Unit.Core
             await Assert.ThrowsAsync<TimeoutException>(() => Poll.UntilAvailableAsync(async () => await AlwaysFailsAsync(), MinTimeFrame));
         }
 
-        [Fact(Skip = "Unreliable on build server")]
-        public async Task Poll_WithUntilPredicate_SucceedsAfterThirdTime()
+        [Fact]
+        public async Task Poll_WithUntilPredicate_Succeeds()
         {
             // Arrange
             var stopwatch = Stopwatch.StartNew();
+            TimeSpan timeout = TimeSpan.FromMilliseconds(100);
+            TimeSpan interval = TimeSpan.FromMilliseconds(10);
 
-            int index = 0;
-            TimeSpan timeout = TimeSpan.FromSeconds(1);
-            TimeSpan interval = TimeSpan.FromMilliseconds(200);
-            
             // Act
-            await Poll.Target(() => Task.FromResult(++index))
-                      .Until(result => result >= 3)
-                      .Every(interval)
-                      .Timeout(timeout);
+            await FailsByResultAsync(async () =>
+                await Poll.Target(AlwaysSucceedsResult)
+                          .Until(_ => false)
+                          .Every(interval)
+                          .Timeout(timeout));
 
             // Assert
-            Assert.True(interval + interval <= stopwatch.Elapsed, "stopwatch should at least run until two intervals");
+            Assert.True(stopwatch.Elapsed >= timeout, "stopwatch should at least run until two intervals");
         }
 
         [Fact]

--- a/src/Arcus.Testing.Tests.Unit/Core/PollTests.cs
+++ b/src/Arcus.Testing.Tests.Unit/Core/PollTests.cs
@@ -11,7 +11,7 @@ namespace Arcus.Testing.Tests.Unit.Core
 {
     public class PollTests
     {
-        private readonly TimeSpan _500ms = TimeSpan.FromMilliseconds(500), _10ms = TimeSpan.FromMilliseconds(10);
+        private readonly TimeSpan _1s = TimeSpan.FromSeconds(1), _10ms = TimeSpan.FromMilliseconds(10);
         private readonly object _expectedResult = Bogus.PickRandom((object) Bogus.Random.Int(), Bogus.Random.AlphaNumeric(10));
 
         private static readonly Faker Bogus = new();
@@ -151,7 +151,7 @@ namespace Arcus.Testing.Tests.Unit.Core
 
         private void MinTimeFrame(PollOptions options)
         {
-            options.Timeout = _500ms;
+            options.Timeout = _1s;
             options.Interval = _10ms;
         }
 
@@ -258,7 +258,7 @@ namespace Arcus.Testing.Tests.Unit.Core
             this Poll<TResult, TException> poll)
             where TException : Exception
         {
-            return poll.Every(TimeSpan.FromMilliseconds(10)).Timeout(TimeSpan.FromMilliseconds(100));
+            return poll.Every(TimeSpan.FromMilliseconds(10)).Timeout(TimeSpan.FromSeconds(1));
         }
     }
 


### PR DESCRIPTION
Stabelizes unit tests by making sure that unique/diff values are indeed unique and giving the poll tests a bit more playroom in terms of retrying.

Closes #159 
Closes #153 