### PR TITLE
docs: Added information about IgnoreNode using JSON path not supported

### DIFF
--- a/docs/preview/02-Features/02-assertion.md
+++ b/docs/preview/02-Features/02-assertion.md
@@ -129,7 +129,7 @@ AssertJson.Equal(..., options =>
 });
 ```
 
-> 💡 IgnoreNode from a JSON path is currently unsupported by Arcus.Testing. As workaround you can use Newtonsoft.Json library to parse the JSON string and remove the node before using the AssertJson.Equal method.
+> 💡 `IgnoreNode` from a JSON path is currently unsupported by Arcus.Testing. As workaround you can use [Newtonsoft.Json](https://www.newtonsoft.com/json) library to parse the JSON string and remove the node before using the `AssertJson.Equal` method.
 
 ### Loading JSON nodes yourself
 The JSON assertion equalization can be called directly with raw contents - internally it parses to a valid JSON structure: `JsonNode`. If you want to compare two JSON nodes with different serialization settings, you can load the two nodes separately and do the equalization on the loaded nodes.

--- a/docs/preview/02-Features/02-assertion.md
+++ b/docs/preview/02-Features/02-assertion.md
@@ -129,6 +129,8 @@ AssertJson.Equal(..., options =>
 });
 ```
 
+> 💡 IgnoreNode from a JSON path is currently unsupported by Arcus.Testing. As workaround you can use Newtonsoft.Json library to parse the JSON string and remove the node before using the AssertJson.Equal method.
+
 ### Loading JSON nodes yourself
 The JSON assertion equalization can be called directly with raw contents - internally it parses to a valid JSON structure: `JsonNode`. If you want to compare two JSON nodes with different serialization settings, you can load the two nodes separately and do the equalization on the loaded nodes.
 


### PR DESCRIPTION
Relates to [issue #154](https://github.com/arcus-azure/arcus.testing/issues/154)