### PR TITLE
docs: use correct example package for NuGet badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Arcus - Testing
 [![Build Status](https://dev.azure.com/codit/Arcus/_apis/build/status/Commit%20builds/CI%20-%20Arcus.Testing?branchName=main)](https://dev.azure.com/codit/Arcus/_build/latest?definitionId=804&branchName=main)
-[![NuGet Badge](https://buildstats.info/nuget/Arcus.Testing.Logging?includePreReleases=true)](https://www.nuget.org/packages/Arcus.Testing.Logging/)
+[![NuGet Badge](https://buildstats.info/nuget/Arcus.Testing.Logging.Xunit?includePreReleases=true)](https://www.nuget.org/packages/Arcus.Testing.Logging/)
 [![codecov](https://codecov.io/gh/arcus-azure/arcus.testing/graph/badge.svg?token=GIXXJO815Q)](https://codecov.io/gh/arcus-azure/arcus.testing)
 
 Reusable testing components for Arcus repo's.


### PR DESCRIPTION
We should use the correct example NuGet package in the README, otherwise the NuGet package does not show the most recent package version.