### PR TITLE
chore: fix codecov path

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,2 @@
+fixes:
+  - "/home/runner/work/::"


### PR DESCRIPTION
Fixes the (new?) GitHub path in the CodeCov configuration.