### PR TITLE
chore: add all related options to assert failure messge

### DIFF
--- a/src/Arcus.Testing.Assert/AssertCsv.cs
+++ b/src/Arcus.Testing.Assert/AssertCsv.cs
@@ -739,7 +739,7 @@ namespace Arcus.Testing
                     $"Options: {Environment.NewLine}" +
                     $"\t- separator: {options.Separator}{Environment.NewLine}" +
                     $"\t- escape: {options.Escape}{Environment.NewLine}" +
-                    $"\t- quote: \"";
+                    $"\t- quote: {options.Quote}";
 
                 throw new CsvException(
                     ReportBuilder.ForMethod(LoadMethodName, "cannot correctly load the CSV contents as not all rows in the CSV table has the same amount of columns")

--- a/src/Arcus.Testing.Assert/AssertJson.cs
+++ b/src/Arcus.Testing.Assert/AssertJson.cs
@@ -160,9 +160,16 @@ namespace Arcus.Testing
                 string expectedJson = expected?.ToString() ?? "null";
                 string actualJson = actual?.ToString() ?? "null";
 
+                string optionsDescription =
+                    $"Options: {Environment.NewLine}" +
+                    $"\t- node order {options.Order}" +
+                    $"\t- ignored node names: [{string.Join(", ", options.IgnoredNodeNames)}]{Environment.NewLine}";
+
                 throw new EqualAssertionException(
                     ReportBuilder.ForMethod(EqualMethodName, "expected and actual JSON contents do not match")
                                  .AppendLine(diff.ToString())
+                                 .AppendLine()
+                                 .AppendLine(optionsDescription)
                                  .AppendDiff(expectedJson, actualJson, options.MaxInputCharacters)
                                  .ToString());
             }

--- a/src/Arcus.Testing.Assert/AssertXml.cs
+++ b/src/Arcus.Testing.Assert/AssertXml.cs
@@ -174,9 +174,16 @@ namespace Arcus.Testing
                 string expectedXml = ReadXml(expected);
                 string actualXml = ReadXml(actual);
 
+                string optionsDescription =
+                    $"Options: {Environment.NewLine}" +
+                    $"\t- attribute order: {options.Order}{Environment.NewLine}" +
+                    $"\t- ignored node (local) names: [{string.Join(", ", options.IgnoredNodeNames)}]{Environment.NewLine}";
+
                 throw new EqualAssertionException(
                     ReportBuilder.ForMethod(EqualMethodName, "expected and actual XML documents do not match")
                                  .AppendLine(diff.ToString())
+                                 .AppendLine()
+                                 .AppendLine(optionsDescription)
                                  .AppendDiff(expectedXml, actualXml, options.MaxInputCharacters)
                                  .ToString());
             }


### PR DESCRIPTION
Saw that not all assertion failures include the related available options in their failure message. Having the options there can help with pinpointing the problem.