### PR TITLE
chore: only publish code coverage comment when building on PR

### DIFF
--- a/build/templates/publish-coverage.yml
+++ b/build/templates/publish-coverage.yml
@@ -28,6 +28,7 @@ jobs:
           publishCodeCoverageResults: true
 
       - script: sudo apt install gh
+        condition: eq(variables['Build.Reason'], 'PullRequest')
         displayName: 'Install GitHub CLI'
 
       - powershell: |
@@ -96,3 +97,4 @@ jobs:
           GITHUB_TOKEN: $(GITHUB_TOKEN)
           PR_NUMBER: $(System.PullRequest.PullRequestNumber)
         displayName: 'Publish code coverage summary on GitHub'
+        condition: eq(variables['Build.Reason'], 'PullRequest')

--- a/src/Arcus.Testing.Tests.Unit/Core/PollTests.cs
+++ b/src/Arcus.Testing.Tests.Unit/Core/PollTests.cs
@@ -11,7 +11,7 @@ namespace Arcus.Testing.Tests.Unit.Core
 {
     public class PollTests
     {
-        private readonly TimeSpan _2s = TimeSpan.FromSeconds(2), _100ms = TimeSpan.FromMilliseconds(100);
+        private readonly TimeSpan _3s = TimeSpan.FromSeconds(3), _100ms = TimeSpan.FromMilliseconds(100);
         private readonly object _expectedResult = Bogus.PickRandom((object) Bogus.Random.Int(), Bogus.Random.AlphaNumeric(10));
 
         private static readonly Faker Bogus = new();
@@ -151,7 +151,7 @@ namespace Arcus.Testing.Tests.Unit.Core
 
         private void ReasonableTimeFrame(PollOptions options)
         {
-            options.Timeout = _2s;
+            options.Timeout = _3s;
             options.Interval = _100ms;
         }
 
@@ -276,7 +276,7 @@ namespace Arcus.Testing.Tests.Unit.Core
             this Poll<TResult, TException> poll)
             where TException : Exception
         {
-            return poll.Every(TimeSpan.FromMilliseconds(100)).Timeout(TimeSpan.FromSeconds(2));
+            return poll.Every(TimeSpan.FromMilliseconds(100)).Timeout(TimeSpan.FromSeconds(3));
         }
 
         public static Poll<TResult, TException> LowestTimeFrame<TResult, TException>(


### PR DESCRIPTION
Forgot to add a condition to the steps related to publishing to a PR to only run when triggered by a PR; otherwise, runs on `main` will fail.

Follow-up of #170 