### PR TITLE
fix: equalization on JSON `null` node

### DIFF
--- a/src/Arcus.Testing.Assert/AssertJson.cs
+++ b/src/Arcus.Testing.Assert/AssertJson.cs
@@ -430,7 +430,7 @@ namespace Arcus.Testing
         private readonly object _actual, _expected;
 
         internal JsonDifference(JsonDifferenceKind kind, JsonNode expected, JsonNode actual)
-            : this(kind, expected.GetPath(), expected: Describe(expected), actual: Describe(actual))
+            : this(kind, expected?.GetPath() ?? actual?.GetPath() ?? "<not-available>", expected: Describe(expected), actual: Describe(actual))
         {
         }
 
@@ -449,6 +449,11 @@ namespace Arcus.Testing
 
         private static string Describe(JsonNode node)
         {
+            if (node is null)
+            {
+                return "type null";
+            }
+
             string nodeTxt = node.ToJsonString(new JsonSerializerOptions { WriteIndented = false });
 #if NET8_0
 

--- a/src/Arcus.Testing.Tests.Unit/Assert_/AssertJsonTests.cs
+++ b/src/Arcus.Testing.Tests.Unit/Assert_/AssertJsonTests.cs
@@ -214,6 +214,18 @@ namespace Arcus.Testing.Tests.Unit.Assert_
                     "{\"Products\":[1,2,3]}",
                     "has a different type at $.Products",
                 };
+                yield return new object[]
+                {
+                    "{\"Products\": null }",
+                    "{\"Products\":{\"id\":3}}",
+                    "has a different type at $.Products"
+                };
+                yield return new object[]
+                {
+                    "null",
+                    "{ \"Products\": [] }",
+                    "expected JSON is null"
+                };
             }
         }
 


### PR DESCRIPTION
For some obscure reason, Microsoft decided that the `JsonNode` representing a JSON `null` value, should be represented with a C# `null` value. Because of this, one looses context and also has to deal with `null` checks everywhere. Bad design decision of Microsoft, but something that we forgot to handle in special cases.

Fixes that here.