### PR TITLE
feat: Added dataset parameters to dataflow debug settings and added tests

### DIFF
--- a/docs/preview/02-Features/06-Integration/01-data-factory.mdx
+++ b/docs/preview/02-Features/06-Integration/01-data-factory.mdx
@@ -207,9 +207,9 @@ await session.RunDataFlowAsync(..., options =>
     options.AddDataFlowParameter("<name>", "<value>");
 
     // Adds a dataset parameter to the data flow upon starting.
-    // 👀 Note that the dataset name should be the "Output stream name" (can also be called DataFlow source or sink name) of the source or sink dataset in the DataFlow, rather than the actual DataSet name.
+    // 👀 Note that the source or sink name should be the "Output stream name" of the source or sink dataset in the DataFlow, not the actual DataSet name.
     // For more info: https://learn.microsoft.com/en-us/azure/data-factory/data-flow-source#source-settings
-    options.AddDataSetParameter(“<dataset-name>", “<parameter-name>", “<parameter-value>");
+    options.AddDataSetParameter(“<soure-or-sink-name>", “<parameter-name>", “<parameter-value>");
 
     // Add additional linked services to the debug session.
     // 💡 This can be useful to add, for example, an additional Key vault linked services for certain authentication types of datasets.

--- a/docs/preview/02-Features/06-Integration/01-data-factory.mdx
+++ b/docs/preview/02-Features/06-Integration/01-data-factory.mdx
@@ -206,6 +206,10 @@ await session.RunDataFlowAsync(..., options =>
     // Adds a parameter to the data flow upon starting.
     options.AddDataFlowParameter("<name>", "<value>");
 
+    // Adds a dataset parameter to the data flow upon starting.
+    // Note here that the dataset name should be the "Output stream name" (can also be called DataFlow source or sink name) of the source or sink dataset in the DataFlow, rather than the actual DataSet name.
+    options.AddDataSetParameter("<datasetName>", "<parameterName>", "<parameterValue>");
+
     // Add additional linked services to the debug session.
     // 💡 This can be useful to add, for example, an additional Key vault linked services for certain authentication types of datasets.
     options.AddLinkedService("datafactory_sales_keyvaultLS");

--- a/docs/preview/02-Features/06-Integration/01-data-factory.mdx
+++ b/docs/preview/02-Features/06-Integration/01-data-factory.mdx
@@ -209,7 +209,7 @@ await session.RunDataFlowAsync(..., options =>
     // Adds a dataset parameter to the data flow upon starting.
     // 👀 Note that the dataset name should be the "Output stream name" (can also be called DataFlow source or sink name) of the source or sink dataset in the DataFlow, rather than the actual DataSet name.
     // For more info: https://learn.microsoft.com/en-us/azure/data-factory/data-flow-source#source-settings
-    options.AddDataSetParameter("<datasetName>", "<parameterName>", "<parameterValue>");
+    options.AddDataSetParameter(“<dataset-name>", “<parameter-name>", “<parameter-value>");
 
     // Add additional linked services to the debug session.
     // 💡 This can be useful to add, for example, an additional Key vault linked services for certain authentication types of datasets.

--- a/docs/preview/02-Features/06-Integration/01-data-factory.mdx
+++ b/docs/preview/02-Features/06-Integration/01-data-factory.mdx
@@ -207,7 +207,8 @@ await session.RunDataFlowAsync(..., options =>
     options.AddDataFlowParameter("<name>", "<value>");
 
     // Adds a dataset parameter to the data flow upon starting.
-    // Note here that the dataset name should be the "Output stream name" (can also be called DataFlow source or sink name) of the source or sink dataset in the DataFlow, rather than the actual DataSet name.
+    // 👀 Note that the dataset name should be the "Output stream name" (can also be called DataFlow source or sink name) of the source or sink dataset in the DataFlow, rather than the actual DataSet name.
+    // For more info: https://learn.microsoft.com/en-us/azure/data-factory/data-flow-source#source-settings
     options.AddDataSetParameter("<datasetName>", "<parameterName>", "<parameterValue>");
 
     // Add additional linked services to the debug session.

--- a/src/Arcus.Testing.Integration.DataFactory/TemporaryDataFlowDebugSession.cs
+++ b/src/Arcus.Testing.Integration.DataFactory/TemporaryDataFlowDebugSession.cs
@@ -429,9 +429,8 @@ namespace Arcus.Testing
         /// </summary>
         /// <remarks>
         ///     The <paramref name="sourceOrSinkName"/> should be the "Output stream name" of the source or sink dataset in the DataFlow, not than the actual DataSet name, see <a href="https://learn.microsoft.com/en-us/azure/data-factory/data-flow-source#source-settings" />.
-        /// </remarks>
-        /// <exception cref="ArgumentException">Thrown when the <paramref name="sourceOrSinkName"/> is blank.</exception>
-        /// <exception cref="ArgumentException">Thrown when the <paramref name="parameterName"/> is blank.</exception>
+        /// </remarks>///
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="sourceOrSinkName"/> or the <paramref name="parameterName"/> is blank.</exception>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="parameterValue"/> is null.</exception>
         public RunDataFlowOptions AddDataSetParameter(string sourceOrSinkName, string parameterName, object parameterValue)
         {

--- a/src/Arcus.Testing.Integration.DataFactory/TemporaryDataFlowDebugSession.cs
+++ b/src/Arcus.Testing.Integration.DataFactory/TemporaryDataFlowDebugSession.cs
@@ -428,16 +428,16 @@ namespace Arcus.Testing
         /// Adds a parameter to a DataSet that is part of the targeted DataFlow.
         /// </summary>
         /// <remarks>
-        ///     The <paramref name=“datasetName”/> should be the "Output stream name" of the source or sink dataset in the DataFlow, rather than the actual DataSet name, see <a href="https://learn.microsoft.com/en-us/azure/data-factory/data-flow-source#source-settings” />.
+        ///     The <paramref name="sourceOrSinkName"/> should be the "Output stream name" of the source or sink dataset in the DataFlow, not than the actual DataSet name, see <a href="https://learn.microsoft.com/en-us/azure/data-factory/data-flow-source#source-settings" />.
         /// </remarks>
-        /// <exception cref="ArgumentException">Thrown when the <paramref name="datasetName"/> is blank.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="sourceOrSinkName"/> is blank.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="parameterName"/> is blank.</exception>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="parameterValue"/> is null.</exception>
-        public RunDataFlowOptions AddDataSetParameter(string datasetName, string parameterName, object parameterValue)
+        public RunDataFlowOptions AddDataSetParameter(string sourceOrSinkName, string parameterName, object parameterValue)
         {
-            if (string.IsNullOrWhiteSpace(datasetName))
+            if (string.IsNullOrWhiteSpace(sourceOrSinkName))
             {
-                throw new ArgumentException("DataSet name should not be blank", nameof(datasetName));
+                throw new ArgumentException("Source or Sink name should not be blank", nameof(sourceOrSinkName));
             }
 
             if (string.IsNullOrWhiteSpace(parameterName))
@@ -447,12 +447,12 @@ namespace Arcus.Testing
 
             ArgumentNullException.ThrowIfNull(parameterValue);
 
-            if (!DataSetParameters.ContainsKey(datasetName))
+            if (!DataSetParameters.ContainsKey(sourceOrSinkName))
             {
-                DataSetParameters[datasetName] = new Dictionary<string, object>();
+                DataSetParameters[sourceOrSinkName] = new Dictionary<string, object>();
             }
 
-            DataSetParameters[datasetName].Add(parameterName, parameterValue);
+            DataSetParameters[sourceOrSinkName].Add(parameterName, parameterValue);
             return this;
         }
 

--- a/src/Arcus.Testing.Integration.DataFactory/TemporaryDataFlowDebugSession.cs
+++ b/src/Arcus.Testing.Integration.DataFactory/TemporaryDataFlowDebugSession.cs
@@ -426,9 +426,10 @@ namespace Arcus.Testing
 
         /// <summary>
         /// Adds a parameter to a DataSet that is part of the targeted DataFlow.
-        /// 
-        /// "datasetName" should be the "Output stream name" of the source or sink dataset in the DataFlow, rather than the actual DataSet name.
         /// </summary>
+        /// <remarks>
+        ///     The <paramref name=“datasetName”/> should be the "Output stream name" of the source or sink dataset in the DataFlow, rather than the actual DataSet name, see <a href="https://learn.microsoft.com/en-us/azure/data-factory/data-flow-source#source-settings” />.
+        /// </remarks>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="datasetName"/> is blank.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="parameterName"/> is blank.</exception>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="parameterValue"/> is null.</exception>

--- a/src/Arcus.Testing.Tests.Integration/Integration/DataFactory/Fixture/TemporaryDataFactoryDataFlow.cs
+++ b/src/Arcus.Testing.Tests.Integration/Integration/DataFactory/Fixture/TemporaryDataFactoryDataFlow.cs
@@ -67,6 +67,11 @@ namespace Arcus.Testing.Tests.Integration.Integration.DataFactory.Fixture
         private StorageAccount StorageAccount => _config.GetStorageAccount();
 
         /// <summary>
+        /// Gets the unique name of the temporary DataFlow in Azure DataFactory.
+        /// </summary>
+        public string Name { get; }
+
+        /// <summary>
         /// Gets the unique name of the source of the temporary DataFlow in Azure DataFactory.
         /// This name is the name of the source "step" of the DataFlow, not to be mistaken with the source DataSet name.
         /// </summary>
@@ -102,11 +107,6 @@ namespace Arcus.Testing.Tests.Integration.Integration.DataFactory.Fixture
         /// Gets the unique name of the parameter value of the sink DataSet of the temporary DataFlow in Azure DataFactory.
         /// </summary>
         public string SinkDataSetParameterValue { get; }
-
-        /// <summary>
-        /// Gets the unique name of the temporary DataFlow in Azure DataFactory.
-        /// </summary>
-        public string Name { get; }
 
         /// <summary>
         /// Creates a DataFlow with a CSV source and sink on an Azure DataFactory resource.

--- a/src/Arcus.Testing.Tests.Integration/Integration/DataFactory/Fixture/TemporaryDataFactoryDataFlow.cs
+++ b/src/Arcus.Testing.Tests.Integration/Integration/DataFactory/Fixture/TemporaryDataFactoryDataFlow.cs
@@ -432,7 +432,7 @@ namespace Arcus.Testing.Tests.Integration.Integration.DataFactory.Fixture
             return this;
         }
 
-        internal void ApplyOptions(ref DelimitedTextDataset dataSet, string sourceDataSetName)
+        internal void ApplyOptions(DelimitedTextDataset dataSet, string sourceDataSetName)
         {
             string folderPathExpression = $"@concat('{sourceDataSetName}/', ";
             foreach (var sourceDataSetParametersKey in SourceDataSetParameterKeyValues.Keys)
@@ -449,7 +449,7 @@ namespace Arcus.Testing.Tests.Integration.Integration.DataFactory.Fixture
             }
         }
 
-        internal void AddDataSetParameters(ref DelimitedTextDataset dataSet, IDictionary<string, string> sourceDataSetParameterKeyValues)
+        internal void AddDataSetParameters(DelimitedTextDataset dataSet, IDictionary<string, string> sourceDataSetParameterKeyValues)
         {
             foreach (var parameters in sourceDataSetParameterKeyValues)
             {

--- a/src/Arcus.Testing.Tests.Integration/Integration/DataFactory/Fixture/TemporaryDataFactoryDataFlow.cs
+++ b/src/Arcus.Testing.Tests.Integration/Integration/DataFactory/Fixture/TemporaryDataFactoryDataFlow.cs
@@ -134,33 +134,6 @@ namespace Arcus.Testing.Tests.Integration.Integration.DataFactory.Fixture
             return temp;
         }
 
-        /*
-        /// <summary>
-        /// Creates a DataFlow with a CSV source and sink on an Azure DataFactory resource.
-        /// </summary>
-        public static async Task<TemporaryDataFactoryDataFlow> CreateWithCsvSinkSourceAndDataSetParametersAsync(TestConfig config, ILogger logger, Action<AssertCsvOptions> configureOptions)
-        {
-            var options = new AssertCsvOptions();
-            configureOptions?.Invoke(options);
-
-            var temp = new TemporaryDataFactoryDataFlow(DataFlowDataType.Csv, config, logger);
-            try
-            {
-                await temp.AddSourceBlobContainerAsync();
-                await temp.AddLinkedServiceAsync();
-                await temp.AddCsvSourceWithDataSetParameterAsync(options);
-                await temp.AddCsvSinkAsyncWithDataSetParameterAsync(options);
-                await temp.AddDataFlowAsync();
-            }
-            catch
-            {
-                await temp.DisposeAsync();
-                throw;
-            }
-
-            return temp;
-        }*/
-
         /// <summary>
         /// Creates a DataFlow with a JSON source and sink on an Azure DataFactory resource.
         /// </summary>

--- a/src/Arcus.Testing.Tests.Integration/Integration/DataFactory/Fixture/TemporaryDataFactoryDataFlow.cs
+++ b/src/Arcus.Testing.Tests.Integration/Integration/DataFactory/Fixture/TemporaryDataFactoryDataFlow.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
+using System.Linq;
 using Arcus.Testing.Tests.Integration.Storage.Configuration;
 using Azure;
 using Azure.Core;
@@ -11,7 +12,6 @@ using Azure.ResourceManager.DataFactory.Models;
 using Azure.ResourceManager.DataFactory;
 using Microsoft.Extensions.Logging;
 using Azure.Core.Expressions.DataFactory;
-using System.Linq;
 
 namespace Arcus.Testing.Tests.Integration.Integration.DataFactory.Fixture
 {

--- a/src/Arcus.Testing.Tests.Integration/Integration/DataFactory/Fixture/TemporaryDataFactoryDataFlow.cs
+++ b/src/Arcus.Testing.Tests.Integration/Integration/DataFactory/Fixture/TemporaryDataFactoryDataFlow.cs
@@ -92,7 +92,7 @@ namespace Arcus.Testing.Tests.Integration.Integration.DataFactory.Fixture
         /// <summary>
         /// Creates a DataFlow with a CSV source and sink on an Azure DataFactory resource.
         /// </summary>
-        public static async Task<TemporaryDataFactoryDataFlow> CreateWithCsvSinkSourceAsync(TestConfig config, ILogger logger, Action<AssertCsvOptions> configureOptions, Action<TempDataFlowOptions> tempDataFlowOptions)
+        public static async Task<TemporaryDataFactoryDataFlow> CreateWithCsvSinkSourceAsync(TestConfig config, ILogger logger, Action<AssertCsvOptions> configureOptions, Action<TempDataFlowOptions> tempDataFlowOptions = null)
         {
             var options = new AssertCsvOptions();
             configureOptions?.Invoke(options);
@@ -186,7 +186,7 @@ namespace Arcus.Testing.Tests.Integration.Integration.DataFactory.Fixture
                 }
             };
 
-            dataFlowOptions?.Source.ApplyOptions(sourceProperties, SourceDataSetName, dataFlowOptions?.Source.SourceDataSetParameterKeyValues);
+            dataFlowOptions?.Source.ApplyOptions(sourceProperties, SourceDataSetName);
 
             await _sourceDataset.UpdateAsync(WaitUntil.Completed, new DataFactoryDatasetData(sourceProperties));
         }
@@ -231,7 +231,7 @@ namespace Arcus.Testing.Tests.Integration.Integration.DataFactory.Fixture
                 }
             };
 
-            dataFlowOptions?.Sink.ApplyOptions(sinkProperties, SinkDataSetName, dataFlowOptions?.Sink.SinkDataSetParameterKeyValues);
+            dataFlowOptions?.Sink.ApplyOptions(sinkProperties, SinkDataSetName);
 
             await _sinkDataset.UpdateAsync(WaitUntil.Completed, new DataFactoryDatasetData(sinkProperties));
         }
@@ -424,7 +424,7 @@ namespace Arcus.Testing.Tests.Integration.Integration.DataFactory.Fixture
             return this;
         }
 
-        internal void ApplyOptions(DelimitedTextDataset dataSet, string sourceDataSetName, IDictionary<string, string> sourceDataSetParameterKeyValues)
+        internal void ApplyOptions(DelimitedTextDataset dataSet, string sourceDataSetName)
         {
             string folderPathExpression = $"@concat('{sourceDataSetName}/', ";
             foreach (var sourceDataSetParametersKey in SourceDataSetParameterKeyValues.Keys)
@@ -440,7 +440,7 @@ namespace Arcus.Testing.Tests.Integration.Integration.DataFactory.Fixture
                 dataSet.DataLocation.FolderPath = DataFactoryElement<string>.FromExpression(folderPathExpression);
             }
 
-            foreach (var parameters in sourceDataSetParameterKeyValues)
+            foreach (var parameters in SourceDataSetParameterKeyValues)
             {
                 dataSet.Parameters.Add(parameters.Key, new EntityParameterSpecification(EntityParameterType.String));
             }
@@ -463,7 +463,7 @@ namespace Arcus.Testing.Tests.Integration.Integration.DataFactory.Fixture
             return this;
         }
 
-        internal void ApplyOptions(DelimitedTextDataset dataSet, string sinkDataSetName, IDictionary<string, string> sinkDataSetParameterKeyValues)
+        internal void ApplyOptions(DelimitedTextDataset dataSet, string sinkDataSetName)
         {
             string folderPathExpression = $"@concat('{sinkDataSetName}/', ";
             foreach (var sinkDataSetParametersKey in SinkDataSetParameterKeyValues.Keys)
@@ -479,7 +479,7 @@ namespace Arcus.Testing.Tests.Integration.Integration.DataFactory.Fixture
                 dataSet.DataLocation.FolderPath = DataFactoryElement<string>.FromExpression(folderPathExpression);
             }
 
-            foreach (var parameters in sinkDataSetParameterKeyValues)
+            foreach (var parameters in SinkDataSetParameterKeyValues)
             {
                 dataSet.Parameters.Add(parameters.Key, new EntityParameterSpecification(EntityParameterType.String));
             }

--- a/src/Arcus.Testing.Tests.Integration/Integration/DataFactory/Fixture/TemporaryDataFactoryDataFlow.cs
+++ b/src/Arcus.Testing.Tests.Integration/Integration/DataFactory/Fixture/TemporaryDataFactoryDataFlow.cs
@@ -55,7 +55,6 @@ namespace Arcus.Testing.Tests.Integration.Integration.DataFactory.Fixture
             SinkName = RandomizeWith("sinkName");
             SinkDataSetName = RandomizeWith("sinkDataSet");
             SourceDataSetName = RandomizeWith("sourceDataSet");
-            SinkDataSetParameterValue = RandomizeWith("sinkDataSetParameterValue");
         }
 
         private string SubscriptionId => _config["Arcus:SubscriptionId"];
@@ -89,11 +88,6 @@ namespace Arcus.Testing.Tests.Integration.Integration.DataFactory.Fixture
         /// Gets the unique name of the source DataSet of the temporary DataFlow in Azure DataFactory.
         /// </summary>
         public string SinkDataSetName { get; }
-
-        /// <summary>
-        /// Gets the unique name of the parameter value of the sink DataSet of the temporary DataFlow in Azure DataFactory.
-        /// </summary>
-        public string SinkDataSetParameterValue { get; }
 
         /// <summary>
         /// Creates a DataFlow with a CSV source and sink on an Azure DataFactory resource.
@@ -192,8 +186,7 @@ namespace Arcus.Testing.Tests.Integration.Integration.DataFactory.Fixture
                 }
             };
 
-            dataFlowOptions?.Source.ApplyOptions(ref sourceProperties, SourceDataSetName);
-            dataFlowOptions?.Source.AddDataSetParameters(ref sourceProperties, dataFlowOptions?.Source.SourceDataSetParameterKeyValues);
+            dataFlowOptions?.Source.ApplyOptions(sourceProperties, SourceDataSetName, dataFlowOptions?.Source.SourceDataSetParameterKeyValues);
 
             await _sourceDataset.UpdateAsync(WaitUntil.Completed, new DataFactoryDatasetData(sourceProperties));
         }
@@ -238,8 +231,7 @@ namespace Arcus.Testing.Tests.Integration.Integration.DataFactory.Fixture
                 }
             };
 
-            dataFlowOptions?.Sink.ApplyOptions(ref sinkProperties, SinkDataSetName);
-            dataFlowOptions?.Sink.AddDataSetParameters(ref sinkProperties, dataFlowOptions?.Sink.SinkDataSetParameterKeyValues);
+            dataFlowOptions?.Sink.ApplyOptions(sinkProperties, SinkDataSetName, dataFlowOptions?.Sink.SinkDataSetParameterKeyValues);
 
             await _sinkDataset.UpdateAsync(WaitUntil.Completed, new DataFactoryDatasetData(sinkProperties));
         }
@@ -432,7 +424,7 @@ namespace Arcus.Testing.Tests.Integration.Integration.DataFactory.Fixture
             return this;
         }
 
-        internal void ApplyOptions(DelimitedTextDataset dataSet, string sourceDataSetName)
+        internal void ApplyOptions(DelimitedTextDataset dataSet, string sourceDataSetName, IDictionary<string, string> sourceDataSetParameterKeyValues)
         {
             string folderPathExpression = $"@concat('{sourceDataSetName}/', ";
             foreach (var sourceDataSetParametersKey in SourceDataSetParameterKeyValues.Keys)
@@ -447,10 +439,7 @@ namespace Arcus.Testing.Tests.Integration.Integration.DataFactory.Fixture
             {
                 dataSet.DataLocation.FolderPath = DataFactoryElement<string>.FromExpression(folderPathExpression);
             }
-        }
 
-        internal void AddDataSetParameters(DelimitedTextDataset dataSet, IDictionary<string, string> sourceDataSetParameterKeyValues)
-        {
             foreach (var parameters in sourceDataSetParameterKeyValues)
             {
                 dataSet.Parameters.Add(parameters.Key, new EntityParameterSpecification(EntityParameterType.String));
@@ -474,7 +463,7 @@ namespace Arcus.Testing.Tests.Integration.Integration.DataFactory.Fixture
             return this;
         }
 
-        internal void ApplyOptions(ref DelimitedTextDataset dataSet, string sinkDataSetName)
+        internal void ApplyOptions(DelimitedTextDataset dataSet, string sinkDataSetName, IDictionary<string, string> sinkDataSetParameterKeyValues)
         {
             string folderPathExpression = $"@concat('{sinkDataSetName}/', ";
             foreach (var sinkDataSetParametersKey in SinkDataSetParameterKeyValues.Keys)
@@ -489,10 +478,7 @@ namespace Arcus.Testing.Tests.Integration.Integration.DataFactory.Fixture
             {
                 dataSet.DataLocation.FolderPath = DataFactoryElement<string>.FromExpression(folderPathExpression);
             }
-        }
 
-        internal void AddDataSetParameters(ref DelimitedTextDataset dataSet, IDictionary<string, string> sinkDataSetParameterKeyValues)
-        {
             foreach (var parameters in sinkDataSetParameterKeyValues)
             {
                 dataSet.Parameters.Add(parameters.Key, new EntityParameterSpecification(EntityParameterType.String));

--- a/src/Arcus.Testing.Tests.Integration/Integration/DataFactory/Fixture/TemporaryDataFactoryDataFlow.cs
+++ b/src/Arcus.Testing.Tests.Integration/Integration/DataFactory/Fixture/TemporaryDataFactoryDataFlow.cs
@@ -443,7 +443,7 @@ namespace Arcus.Testing.Tests.Integration.Integration.DataFactory.Fixture
         /// </summary>
         public IDictionary<string, string> SourceDataSetParameterKeyValues { get; } = new Dictionary<string, string>();
 
-        public TempDataFlowSourceOptions SetSourceDataSetParameterKeyValues(IDictionary<string, string> parameters)
+        public TempDataFlowSourceOptions AddFolderPathParameters(IDictionary<string, string> parameters)
         {
             foreach (var parameter in parameters)
             {
@@ -485,7 +485,7 @@ namespace Arcus.Testing.Tests.Integration.Integration.DataFactory.Fixture
         /// </summary>
         public IDictionary<string, string> SinkDataSetParameterKeyValues { get; } = new Dictionary<string, string>();
 
-        public TempDataFlowSinkOptions SetSinkDataSetParameterKeyValues(IDictionary<string, string> parameters)
+        public TempDataFlowSinkOptions AddFolderPathParameters(IDictionary<string, string> parameters)
         {
             foreach (var parameter in parameters)
             {

--- a/src/Arcus.Testing.Tests.Integration/Integration/DataFactory/RunDataFlowTests.cs
+++ b/src/Arcus.Testing.Tests.Integration/Integration/DataFactory/RunDataFlowTests.cs
@@ -44,7 +44,7 @@ namespace Arcus.Testing.Tests.Integration.Integration.DataFactory
         {
             // Arrange
             await using var dataFlow = await TemporaryDataFactoryDataFlow.CreateWithJsonSinkSourceAsync(docForm, Configuration, Logger);
-            await dataFlow.UploadToSourceAsync(expected!.ToString(), null);
+            await dataFlow.UploadToSourceAsync(expected!.ToString());
 
             // Act
             DataFlowRunResult result = await _session.Value.RunDataFlowAsync(dataFlow.Name, dataFlow.SinkName);
@@ -60,7 +60,7 @@ namespace Arcus.Testing.Tests.Integration.Integration.DataFactory
             await using var dataFlow = await TemporaryDataFactoryDataFlow.CreateWithCsvSinkSourceAsync(Configuration, Logger, ConfigureCsv, null);
 
             string expectedCsv = GenerateCsv();
-            await dataFlow.UploadToSourceAsync(expectedCsv, null);
+            await dataFlow.UploadToSourceAsync(expectedCsv);
 
             // Act
             DataFlowRunResult result = await _session.Value.RunDataFlowAsync(dataFlow.Name, dataFlow.SinkName);

--- a/src/Arcus.Testing.Tests.Integration/Integration/DataFactory/RunDataFlowTests.cs
+++ b/src/Arcus.Testing.Tests.Integration/Integration/DataFactory/RunDataFlowTests.cs
@@ -69,6 +69,26 @@ namespace Arcus.Testing.Tests.Integration.Integration.DataFactory
             AssertCsv.Equal(expected, result.GetDataAsCsv(ConfigureCsv));
         }
 
+        [Fact]
+        public async Task RunDataFlow_WithCsvFileOnSourceAndDataSetParameter_SucceedsByGettingCsvFileOnSinkWithSubPathParameter()
+        {
+            // Arrange
+            await using var dataFlow = await TemporaryDataFactoryDataFlow.CreateWithCsvSinkSourceAndDataSetParameterAsync(Configuration, Logger, ConfigureCsv);
+
+            string expectedCsv = GenerateCsv();
+            await dataFlow.UploadToSourceAsync(expectedCsv, dataFlow.SourceDataSetParameterValue);
+
+            // Act
+            DataFlowRunResult result = await _session.Value.RunDataFlowAsync(
+                dataFlow.Name,
+                dataFlow.SinkName,
+                options => options.AddDataSetParameter(dataFlow.SourceName, dataFlow.SourceDataSetParameterKey, dataFlow.SourceDataSetParameterValue));
+
+            // Assert
+            CsvTable expected = AssertCsv.Load(expectedCsv, ConfigureCsv);
+            AssertCsv.Equal(expected, result.GetDataAsCsv(ConfigureCsv));
+        }
+
         private static string GenerateCsv()
         {
             var input = TestCsv.Generate(ConfigureCsv);

--- a/src/Arcus.Testing.Tests.Integration/Integration/DataFactory/RunDataFlowTests.cs
+++ b/src/Arcus.Testing.Tests.Integration/Integration/DataFactory/RunDataFlowTests.cs
@@ -91,7 +91,7 @@ namespace Arcus.Testing.Tests.Integration.Integration.DataFactory
             });
 
             string expectedCsv = GenerateCsv();
-            await dataFlow.UploadToSourceAsync(expectedCsv, dataFlow.SourceDataSetParameterKeyValues.Select(d => d.Value).ToArray());
+            await dataFlow.UploadToSourceAsync(expectedCsv, sourceDataSetParameterKeyValues.Select(d => d.Value).ToArray());
 
             // Act
             DataFlowRunResult result = await _session.Value.RunDataFlowAsync(

--- a/src/Arcus.Testing.Tests.Integration/Integration/DataFactory/RunDataFlowTests.cs
+++ b/src/Arcus.Testing.Tests.Integration/Integration/DataFactory/RunDataFlowTests.cs
@@ -57,7 +57,7 @@ namespace Arcus.Testing.Tests.Integration.Integration.DataFactory
         public async Task RunDataFlow_WithCsvFileOnSource_SucceedsByGettingCsvFileOnSink()
         {
             // Arrange
-            await using var dataFlow = await TemporaryDataFactoryDataFlow.CreateWithCsvSinkSourceAsync(Configuration, Logger, ConfigureCsv);
+            await using var dataFlow = await TemporaryDataFactoryDataFlow.CreateWithCsvSinkSourceAsync(Configuration, Logger, ConfigureCsv, null);
 
             string expectedCsv = GenerateCsv();
             await dataFlow.UploadToSourceAsync(expectedCsv);

--- a/src/Arcus.Testing.Tests.Integration/Integration/DataFactory/RunDataFlowTests.cs
+++ b/src/Arcus.Testing.Tests.Integration/Integration/DataFactory/RunDataFlowTests.cs
@@ -57,7 +57,7 @@ namespace Arcus.Testing.Tests.Integration.Integration.DataFactory
         public async Task RunDataFlow_WithCsvFileOnSource_SucceedsByGettingCsvFileOnSink()
         {
             // Arrange
-            await using var dataFlow = await TemporaryDataFactoryDataFlow.CreateWithCsvSinkSourceAsync(Configuration, Logger, ConfigureCsv, null);
+            await using var dataFlow = await TemporaryDataFactoryDataFlow.CreateWithCsvSinkSourceAsync(Configuration, Logger, ConfigureCsv);
 
             string expectedCsv = GenerateCsv();
             await dataFlow.UploadToSourceAsync(expectedCsv);

--- a/src/Arcus.Testing.Tests.Integration/Integration/DataFactory/RunDataFlowTests.cs
+++ b/src/Arcus.Testing.Tests.Integration/Integration/DataFactory/RunDataFlowTests.cs
@@ -86,8 +86,8 @@ namespace Arcus.Testing.Tests.Integration.Integration.DataFactory
 
             await using var dataFlow = await TemporaryDataFactoryDataFlow.CreateWithCsvSinkSourceAsync(Configuration, Logger, ConfigureCsv, dataFlowOptions =>
             {
-                dataFlowOptions.Source.SetSourceDataSetParameterKeyValues(sourceDataSetParameterKeyValues);
-                dataFlowOptions.Sink.SetSinkDataSetParameterKeyValues(sinkDataSetParameterKeyValues);
+                dataFlowOptions.Source.AddFolderPathParameters(sourceDataSetParameterKeyValues);
+                dataFlowOptions.Sink.AddFolderPathParameters(sinkDataSetParameterKeyValues);
             });
 
             string expectedCsv = GenerateCsv();

--- a/src/Arcus.Testing.Tests.Integration/Integration/DataFactory/RunDataFlowTests.cs
+++ b/src/Arcus.Testing.Tests.Integration/Integration/DataFactory/RunDataFlowTests.cs
@@ -99,11 +99,11 @@ namespace Arcus.Testing.Tests.Integration.Integration.DataFactory
                 dataFlow.SinkName,
                 options =>
                 {
-                    foreach (var sourceDataSetParameter in dataFlow.SourceDataSetParameterKeyValues)
+                    foreach (var sourceDataSetParameter in sourceDataSetParameterKeyValues)
                     {
                         options.AddDataSetParameter(dataFlow.SourceName, sourceDataSetParameter.Key, sourceDataSetParameter.Value);
                     }
-                    foreach (var sinkDataSetParameter in dataFlow.SinkDataSetParameterKeyValues)
+                    foreach (var sinkDataSetParameter in sinkDataSetParameterKeyValues)
                     {
                         options.AddDataSetParameter(dataFlow.SinkName, sinkDataSetParameter.Key, sinkDataSetParameter.Value);
                     }

--- a/src/Arcus.Testing.Tests.Unit/Integration/DataFactory/RunDataFlowTests.cs
+++ b/src/Arcus.Testing.Tests.Unit/Integration/DataFactory/RunDataFlowTests.cs
@@ -85,39 +85,6 @@ namespace Arcus.Testing.Tests.Unit.Integration.DataFactory
             Assert.ThrowsAny<NotSupportedException>(() => options.AddDataFlowParameter(name, invalidValue));
         }
 
-        [Fact]
-        public void AddDataSetParameter_WithExistingDataSetNameAndNewName_SucceedsByAddingNewParameter()
-        {
-            // Arrange
-            var options = new RunDataFlowOptions();
-            string datasetName = Bogus.Lorem.Word();
-            string name = Bogus.Lorem.Word();
-            string newName = Bogus.Lorem.Word();
-            options.AddDataSetParameter(datasetName, name, Bogus.Random.Guid());
-
-            // Act
-            options.AddDataSetParameter(datasetName, newName, Bogus.Random.Guid());
-
-            // Assert
-            Assert.NotNull(options);
-        }
-
-        [Fact]
-        public void AddDataSetParameter_WithExistingDataSetNameAndExistingName_SucceedsByOverriding()
-        {
-            // Arrange
-            var options = new RunDataFlowOptions();
-            string datasetName = Bogus.Lorem.Word();
-            string name = Bogus.Lorem.Word();
-            options.AddDataSetParameter(datasetName, name, Bogus.Random.Guid());
-
-            // Act
-            options.AddDataSetParameter(datasetName, name, Bogus.Random.Guid());
-
-            // Assert
-            Assert.NotNull(options);
-        }
-
         [Theory]
         [ClassData(typeof(Blanks))]
         public void AddDataSetParameter_WithoutDataSetName_Fails(string dataSetName)

--- a/src/Arcus.Testing.Tests.Unit/Integration/DataFactory/RunDataFlowTests.cs
+++ b/src/Arcus.Testing.Tests.Unit/Integration/DataFactory/RunDataFlowTests.cs
@@ -111,19 +111,6 @@ namespace Arcus.Testing.Tests.Unit.Integration.DataFactory
             Assert.ThrowsAny<ArgumentException>(() => options.AddDataSetParameter(dataSetName, name, value));
         }
 
-        [Fact]
-        public void AddDataSetParameter_WithoutUnsupportedJson_Fails()
-        {
-            // Arrange
-            var options = new RunDataFlowOptions();
-            string dataSetName = Bogus.Lorem.Word();
-            string name = Bogus.Lorem.Word();
-            Type invalidValue = GetType();
-
-            // Act / Assert
-            Assert.ThrowsAny<NotSupportedException>(() => options.AddDataSetParameter(dataSetName, name, invalidValue));
-        }
-
         [Theory]
         [ClassData(typeof(Blanks))]
         public void AddLinkedService_WithoutServiceName_Fails(string serviceName)

--- a/src/Arcus.Testing.Tests.Unit/Integration/DataFactory/RunDataFlowTests.cs
+++ b/src/Arcus.Testing.Tests.Unit/Integration/DataFactory/RunDataFlowTests.cs
@@ -85,6 +85,78 @@ namespace Arcus.Testing.Tests.Unit.Integration.DataFactory
             Assert.ThrowsAny<NotSupportedException>(() => options.AddDataFlowParameter(name, invalidValue));
         }
 
+        [Fact]
+        public void AddDataSetParameter_WithExistingDataSetNameAndNewName_SucceedsByAddingNewParameter()
+        {
+            // Arrange
+            var options = new RunDataFlowOptions();
+            string datasetName = Bogus.Lorem.Word();
+            string name = Bogus.Lorem.Word();
+            string newName = Bogus.Lorem.Word();
+            options.AddDataSetParameter(datasetName, name, Bogus.Random.Guid());
+
+            // Act
+            options.AddDataSetParameter(datasetName, newName, Bogus.Random.Guid());
+
+            // Assert
+            Assert.NotNull(options);
+        }
+
+        [Fact]
+        public void AddDataSetParameter_WithExistingDataSetNameAndExistingName_SucceedsByOverriding()
+        {
+            // Arrange
+            var options = new RunDataFlowOptions();
+            string datasetName = Bogus.Lorem.Word();
+            string name = Bogus.Lorem.Word();
+            options.AddDataSetParameter(datasetName, name, Bogus.Random.Guid());
+
+            // Act
+            options.AddDataSetParameter(datasetName, name, Bogus.Random.Guid());
+
+            // Assert
+            Assert.NotNull(options);
+        }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void AddDataSetParameter_WithoutDataSetName_Fails(string dataSetName)
+        {
+            // Arrange
+            var options = new RunDataFlowOptions();
+            string name = Bogus.Lorem.Word();
+            string value = Bogus.Lorem.Word();
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(() => options.AddDataSetParameter(dataSetName, name, value));
+        }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void AddDataSetParameter_WithoutParameterName_Fails(string name)
+        {
+            // Arrange
+            var options = new RunDataFlowOptions();
+            string dataSetName = Bogus.Lorem.Word();
+            string value = Bogus.Lorem.Word();
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(() => options.AddDataSetParameter(dataSetName, name, value));
+        }
+
+        [Fact]
+        public void AddDataSetParameter_WithoutUnsupportedJson_Fails()
+        {
+            // Arrange
+            var options = new RunDataFlowOptions();
+            string dataSetName = Bogus.Lorem.Word();
+            string name = Bogus.Lorem.Word();
+            Type invalidValue = GetType();
+
+            // Act / Assert
+            Assert.ThrowsAny<NotSupportedException>(() => options.AddDataSetParameter(dataSetName, name, invalidValue));
+        }
+
         [Theory]
         [ClassData(typeof(Blanks))]
         public void AddLinkedService_WithoutServiceName_Fails(string serviceName)


### PR DESCRIPTION
- Added dataset parameters to dataflow debug settings 
    - For information, debugSettings.DatasetParameters is of type BinaryData. Data is basically a JSON representation of a Dictionary<string, Dictionary<string, object>>, where the high level dictionary contains the keys of the dataset names, and the low level dictionary contains the actual dataset parameter keys and values
- Added tests, @stijnmoreels since DataSetParameters property is internal, not sure how I could assert that if a dataset parameter is added to a not empty dictionary of parameters, it is added to the dictionary and not overridden. Any suggestions for this please? Should I expose the RunDataFlowOptions.DataSetParameters via a method?