### PR TITLE
docs: use `main` branch to show code-coverage in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Arcus - Testing
 [![Build Status](https://dev.azure.com/codit/Arcus/_apis/build/status/Commit%20builds/CI%20-%20Arcus.Testing?branchName=main)](https://dev.azure.com/codit/Arcus/_build/latest?definitionId=804&branchName=main)
 [![NuGet Version](https://img.shields.io/nuget/v/Arcus.Testing.Logging.Xunit)](https://www.nuget.org/packages/Arcus.Testing.Logging.Xunit/)
-![Azure DevOps coverage](https://img.shields.io/azure-devops/coverage/codit/Arcus/804)
+![Azure DevOps coverage (branch)](https://img.shields.io/azure-devops/coverage/codit/arcus/804/main)
 
 Reusable testing components for Arcus repo's.
 


### PR DESCRIPTION
We should use the `main` branch only to show the code coverage information in the `README.md` file.