### PR TITLE
chore: deprecate serilog functionality

### DIFF
--- a/src/Arcus.Testing.Logging.Core/Arcus.Testing.Logging.Core.csproj
+++ b/src/Arcus.Testing.Logging.Core/Arcus.Testing.Logging.Core.csproj
@@ -7,28 +7,17 @@
     <Company>Arcus</Company>
     <Description>Provides logging capabilities during Arcus testing</Description>
     <Copyright>Copyright (c) Arcus</Copyright>
-    <PackageProjectUrl>https://github.com/arcus-azure/arcus.testing</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/arcus-azure/arcus.testing</RepositoryUrl>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
-    <PackageIcon>icon.png</PackageIcon>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
-    <RepositoryType>Git</RepositoryType>
-    <PackageTags>Azure;Testing</PackageTags>
-    <PackageId>Arcus.Testing.Logging.Core</PackageId>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
-    <None Include="..\..\LICENSE" Pack="true" PackagePath="\" />
-    <None Include="..\..\docs\static\img\icon.png" Pack="true" PackagePath="\"/>
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="[6.0.0,9.0.0)" />
+    
+    <!-- TODO: Serilog will be removed in v2.0 -->
     <PackageReference Include="Serilog" Version="2.10.0" />
+    <!-- TODO: Serilog will be removed in v2.0-->
   </ItemGroup>
 
 </Project>

--- a/src/Arcus.Testing.Logging.Core/InMemoryLogSink.cs
+++ b/src/Arcus.Testing.Logging.Core/InMemoryLogSink.cs
@@ -10,6 +10,7 @@ namespace Arcus.Testing
     /// <summary>
     /// Represents a logging sink that collects the emitted log events in-memory.
     /// </summary>
+    [Obsolete("Arcus.Testing.Logging.Core will stop supporting Serilog by default, please implement Serilog sinks yourself as this sink will be removed in v2.0")]
     public class InMemoryLogSink : ILogEventSink
     {
         private readonly ConcurrentQueue<LogEvent> _logEmits = new ConcurrentQueue<LogEvent>();

--- a/src/Arcus.Testing.Logging.MSTest/Extensions/ILoggerBuilderExtensions.cs
+++ b/src/Arcus.Testing.Logging.MSTest/Extensions/ILoggerBuilderExtensions.cs
@@ -12,22 +12,15 @@ namespace Microsoft.Extensions.Logging
     public static class ILoggerBuilderExtensions
     {
         /// <summary>
-        /// Adds an the logging messages from the given xUnit <paramref name="testContext"/> as a provider to the <paramref name="builder"/>.
+        /// Adds the logging messages from the given xUnit <paramref name="testContext"/> as a provider to the <paramref name="builder"/>.
         /// </summary>
         /// <param name="builder">The logging builder to add the NUnit logging test messages to.</param>
         /// <param name="testContext">The MSTest writer to write custom test output.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="builder"/> or the <paramref name="testContext"/> is <c>null</c>.</exception>
         public static ILoggingBuilder AddMSTestLogging(this ILoggingBuilder builder, TestContext testContext)
         {
-            if (builder is null)
-            {
-                throw new ArgumentNullException(nameof(builder));
-            }
-
-            if (testContext is null)
-            {
-                throw new ArgumentNullException(nameof(testContext));
-            }
+            ArgumentNullException.ThrowIfNull(builder);
+            ArgumentNullException.ThrowIfNull(testContext);
 
             var logger = new MSTestLogger(testContext);
             var provider = new CustomLoggerProvider(logger);

--- a/src/Arcus.Testing.Logging.MSTest/Extensions/LoggerSinkConfigurationExtensions.cs
+++ b/src/Arcus.Testing.Logging.MSTest/Extensions/LoggerSinkConfigurationExtensions.cs
@@ -16,6 +16,7 @@ namespace Serilog.Configuration
         /// <param name="config">The Serilog sink configuration where the NUnit test logging will be added.</param>
         /// <param name="testContext">The MSTest test writer to write custom test output.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="config"/> or <paramref name="testContext"/> is <c>null</c>.</exception>
+        [Obsolete("Arcus.Testing.Logging.MSTest will stop supporting Serilog by default, please implement Serilog sinks yourself as this extension will be removed in v2.0")]
         public static LoggerConfiguration MSTestLogging(this LoggerSinkConfiguration config, TestContext testContext)
         {
             if (config is null)

--- a/src/Arcus.Testing.Logging.MSTest/MSTestLogEventSink.cs
+++ b/src/Arcus.Testing.Logging.MSTest/MSTestLogEventSink.cs
@@ -8,6 +8,7 @@ namespace Arcus.Testing
     /// <summary>
     /// <see cref="ILogEventSink"/> representation of an <see cref="MSTestLogger"/> instance.
     /// </summary>
+    [Obsolete("Arcus.Testing.Logging.MSTest will stop supporting Serilog by default, please implement Serilog sinks yourself as this sink will be removed in v2.0")]
     public class MSTestLogEventSink : ILogEventSink
     {
         private readonly TestContext _context;

--- a/src/Arcus.Testing.Logging.NUnit/Extensions/ILoggerBuilderExtensions.cs
+++ b/src/Arcus.Testing.Logging.NUnit/Extensions/ILoggerBuilderExtensions.cs
@@ -12,22 +12,15 @@ namespace Microsoft.Extensions.Logging
     public static class ILoggerBuilderExtensions
     {
         /// <summary>
-        /// Adds an the logging messages from the given xUnit <paramref name="outputWriter"/> as a provider to the <paramref name="builder"/>.
+        /// Adds the logging messages from the given xUnit <paramref name="outputWriter"/> as a provider to the <paramref name="builder"/>.
         /// </summary>
         /// <param name="builder">The logging builder to add the NUnit logging test messages to.</param>
         /// <param name="outputWriter">The NUnit test writer to write custom test output.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="builder"/> or the <paramref name="outputWriter"/> is <c>null</c>.</exception>
         public static ILoggingBuilder AddNUnitTestLogging(this ILoggingBuilder builder, TextWriter outputWriter)
         {
-            if (builder is null)
-            {
-                throw new ArgumentNullException(nameof(builder));
-            }
-
-            if (outputWriter is null)
-            {
-                throw new ArgumentNullException(nameof(outputWriter));
-            }
+            ArgumentNullException.ThrowIfNull(builder);
+            ArgumentNullException.ThrowIfNull(outputWriter);
 
             var logger = new NUnitTestLogger(outputWriter);
             var provider = new CustomLoggerProvider(logger);
@@ -36,7 +29,7 @@ namespace Microsoft.Extensions.Logging
         }
 
         /// <summary>
-        /// Adds an the logging messages from the given xUnit <paramref name="outputWriter"/> as a provider to the <paramref name="builder"/>.
+        /// Adds the logging messages from the given xUnit <paramref name="outputWriter"/> as a provider to the <paramref name="builder"/>.
         /// </summary>
         /// <param name="builder">The logging builder to add the NUnit logging test messages to.</param>
         /// <param name="outputWriter">The NUnit test writer to write custom test output.</param>
@@ -44,15 +37,8 @@ namespace Microsoft.Extensions.Logging
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="builder"/>, <paramref name="outputWriter"/> or the <paramref name="errorWriter"/> is <c>null</c>.</exception>
         public static ILoggingBuilder AddNUnitTestLogging(this ILoggingBuilder builder, TextWriter outputWriter, TextWriter errorWriter)
         {
-            if (builder is null)
-            {
-                throw new ArgumentNullException(nameof(builder));
-            }
-
-            if (outputWriter is null)
-            {
-                throw new ArgumentNullException(nameof(outputWriter));
-            }
+            ArgumentNullException.ThrowIfNull(builder);
+            ArgumentNullException.ThrowIfNull(outputWriter);
 
             var logger = new NUnitTestLogger(outputWriter, errorWriter);
             var provider = new CustomLoggerProvider(logger);

--- a/src/Arcus.Testing.Logging.NUnit/Extensions/LoggerSinkConfigurationExtensions.cs
+++ b/src/Arcus.Testing.Logging.NUnit/Extensions/LoggerSinkConfigurationExtensions.cs
@@ -16,6 +16,7 @@ namespace Serilog.Configuration
         /// <param name="config">The Serilog sink configuration where the NUnit test logging will be added.</param>
         /// <param name="outputWriter">The NUnit test writer to write custom test output.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="config"/> or <paramref name="outputWriter"/> is <c>null</c>.</exception>
+        [Obsolete("Arcus.Testing.Logging.NUnit will stop supporting Serilog by default, please implement Serilog sinks yourself as this extension will be removed in v2.0")]
         public static LoggerConfiguration NUnitTestLogging(this LoggerSinkConfiguration config, TextWriter outputWriter)
         {
             if (config is null)
@@ -38,6 +39,7 @@ namespace Serilog.Configuration
         /// <param name="outputWriter">The NUnit test writer to write custom test output.</param>
         /// <param name="errorWriter">The NUnit test writer to write custom test errors.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="config"/>, <paramref name="outputWriter"/> or the <paramref name="errorWriter"/> is <c>null</c>.</exception>
+        [Obsolete("Arcus.Testing.Logging.NUnit will stop supporting Serilog by default, please implement Serilog sinks yourself as this extension will be removed in v2.0")]
         public static LoggerConfiguration NUnitTestLogging(this LoggerSinkConfiguration config, TextWriter outputWriter, TextWriter errorWriter)
         {
             if (config is null)

--- a/src/Arcus.Testing.Logging.NUnit/NUnitTestLogEventSink.cs
+++ b/src/Arcus.Testing.Logging.NUnit/NUnitTestLogEventSink.cs
@@ -8,6 +8,7 @@ namespace Arcus.Testing
     /// <summary>
     /// <see cref="ILogEventSink"/> representation of an <see cref="NUnitTestLogger"/> instance.
     /// </summary>
+    [Obsolete("Arcus.Testing.Logging.NUnit will stop supporting Serilog by default, please implement Serilog sinks yourself as this sink will be removed in v2.0")]
     public class NUnitTestLogEventSink : ILogEventSink
     {
         private readonly TextWriter _outputWriter, _errorWriter;

--- a/src/Arcus.Testing.Logging.Xunit/Extensions/ILoggerBuilderExtensions.cs
+++ b/src/Arcus.Testing.Logging.Xunit/Extensions/ILoggerBuilderExtensions.cs
@@ -12,22 +12,15 @@ namespace Microsoft.Extensions.Logging
     public static class ILoggerBuilderExtensions
     {
         /// <summary>
-        /// Adds an the logging messages from the given xUnit <paramref name="outputWriter"/> as a provider to the <paramref name="builder"/>.
+        /// Adds the logging messages from the given xUnit <paramref name="outputWriter"/> as a provider to the <paramref name="builder"/>.
         /// </summary>
         /// <param name="builder">The logging builder to add the xUnit logging test messages to.</param>
         /// <param name="outputWriter">The xUnit test logger used across the test suite.</param>
         /// <exception cref="ArgumentNullException">Thrown when either the <paramref name="builder"/> or the <paramref name="outputWriter"/> is <c>null</c>.</exception>
         public static ILoggingBuilder AddXunitTestLogging(this ILoggingBuilder builder, ITestOutputHelper outputWriter)
         {
-            if (builder is null)
-            {
-                throw new ArgumentNullException(nameof(builder));
-            }
-
-            if (outputWriter is null)
-            {
-                throw new ArgumentNullException(nameof(outputWriter));
-            }
+            ArgumentNullException.ThrowIfNull(builder);
+            ArgumentNullException.ThrowIfNull(outputWriter);
 
             var logger = new XunitTestLogger(outputWriter);
             var provider = new CustomLoggerProvider(logger);

--- a/src/Arcus.Testing.Logging.Xunit/Extensions/LoggerSinkConfigurationExtensions.cs
+++ b/src/Arcus.Testing.Logging.Xunit/Extensions/LoggerSinkConfigurationExtensions.cs
@@ -16,6 +16,7 @@ namespace Serilog.Configuration
         /// <param name="config">The Serilog sink configuration where the xUnit test logging will be added.</param>
         /// <param name="outputWriter">The xUnit test output writer to write custom test output.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="config"/> or <paramref name="outputWriter"/> is <c>null</c>.</exception>
+        [Obsolete("Arcus.Testing.Logging.Xunit will stop supporting Serilog by default, please implement Serilog sinks yourself as this extension will be removed in v2.0")]
         public static LoggerConfiguration XunitTestLogging(
             this LoggerSinkConfiguration config, 
             ITestOutputHelper outputWriter)

--- a/src/Arcus.Testing.Logging.Xunit/XunitTestLogEventSink.cs
+++ b/src/Arcus.Testing.Logging.Xunit/XunitTestLogEventSink.cs
@@ -8,6 +8,7 @@ namespace Arcus.Testing
     /// <summary>
     /// <see cref="ILogEventSink"/> representation of an <see cref="ITestOutputHelper"/> instance.
     /// </summary>
+    [Obsolete("Arcus.Testing.Logging.Xunit will stop supporting Serilog by default, please implement Serilog sinks yourself as this sink will be removed in v2.0")]
     public class XunitLogEventSink : ILogEventSink
     {
         private readonly ITestOutputHelper _outputWriter;


### PR DESCRIPTION
Deprecate Serilog functionality as we should not force people to use Serilog by default.

Relates to #212 