### PR TITLE
chore: super rare blob name matching

### DIFF
--- a/src/Arcus.Testing.Tests.Integration/Storage/TemporaryBlobContainerTests.cs
+++ b/src/Arcus.Testing.Tests.Integration/Storage/TemporaryBlobContainerTests.cs
@@ -194,10 +194,10 @@ namespace Arcus.Testing.Tests.Integration.Storage
             return Bogus.Random.Int(1, 4) switch
             {
                 1 => Bogus.Random.Bool() ? NameEqual(name) : NameEqual(RandomCase(name), StringComparison.OrdinalIgnoreCase),
-                2 => Bogus.Random.Bool() ? NameStartsWith(name[..5]) : NameStartsWith(RandomCase(name[..5]), StringComparison.OrdinalIgnoreCase),
-                3 => Bogus.Random.Bool() ? NameEndsWith(name[^5..]) : NameEndsWith(RandomCase(name[^5..]), StringComparison.OrdinalIgnoreCase),
-                4 => Bogus.Random.Bool() ? NameContains(name[5..10]) : NameContains(RandomCase(name[5..10]), StringComparison.OrdinalIgnoreCase),
-                _ => throw new ArgumentOutOfRangeException()
+                2 => Bogus.Random.Bool() ? NameStartsWith(name[..10]) : NameStartsWith(RandomCase(name[..10]), StringComparison.OrdinalIgnoreCase),
+                3 => Bogus.Random.Bool() ? NameEndsWith(name[^10..]) : NameEndsWith(RandomCase(name[^10..]), StringComparison.OrdinalIgnoreCase),
+                4 => Bogus.Random.Bool() ? NameContains(name[1..10]) : NameContains(RandomCase(name[1..10]), StringComparison.OrdinalIgnoreCase),
+                _ => throw new InvalidOperationException($"Unsupported '{nameof(BlobNameFilter)}' method, please provide one in the switch expression")
             };
         }
 


### PR DESCRIPTION
When a random `BlobNameFilter` is created to match against a blob, only the first 5 characters were sometimes taken, but since the blob names start with `blob...`, the chance that the appending GUID starts with the same character is rather big.

This PR makes this a bit more stable by taking a bigger portion of the name to match.