### PR TITLE
chore: manual package upgrade

### DIFF
--- a/src/Arcus.Testing.Core/Arcus.Testing.Core.csproj
+++ b/src/Arcus.Testing.Core/Arcus.Testing.Core.csproj
@@ -27,8 +27,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="[8.0.0,9.0.0)" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="[8.0.0,9.0.0)" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="[8.0.0,10.0.0)" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="[8.0.0,10.0.0)" />
     <PackageReference Include="Polly" Version="8.3.1" />
   </ItemGroup>
 

--- a/src/Arcus.Testing.Integration.DataFactory/Arcus.Testing.Integration.DataFactory.csproj
+++ b/src/Arcus.Testing.Integration.DataFactory/Arcus.Testing.Integration.DataFactory.csproj
@@ -27,9 +27,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="[1.12.0,2.0.0)" />
+    <PackageReference Include="Azure.Identity" Version="[1.13.1,2.0.0)" />
     <PackageReference Include="Azure.ResourceManager.DataFactory" Version="[1.2.0,2.0.0)" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="[8.0.0,9.0.0)" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="[8.0.0,10.0.0)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Arcus.Testing.Logging.Core/Arcus.Testing.Logging.Core.csproj
+++ b/src/Arcus.Testing.Logging.Core/Arcus.Testing.Logging.Core.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="[6.0.0,9.0.0)" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="[8.0.0,10.0.0)" />
     
     <!-- TODO: Serilog will be removed in v2.0 -->
     <PackageReference Include="Serilog" Version="2.10.0" />

--- a/src/Arcus.Testing.Logging.Xunit/Arcus.Testing.Logging.Xunit.csproj
+++ b/src/Arcus.Testing.Logging.Xunit/Arcus.Testing.Logging.Xunit.csproj
@@ -27,7 +27,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="xunit.abstractions" Version="2.0.1" />
+    <PackageReference Include="xunit.abstractions" Version="2.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Arcus.Testing.Security.Providers.InMemory/Arcus.Testing.Security.Providers.InMemory.csproj
+++ b/src/Arcus.Testing.Security.Providers.InMemory/Arcus.Testing.Security.Providers.InMemory.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>net8.0;net6.0;netstandard2.1</TargetFrameworks>
@@ -26,7 +26,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' != 'netstandard2.1'">
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="(8.0.0,10.0.0]" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">

--- a/src/Arcus.Testing.Security.Providers.InMemory/Arcus.Testing.Security.Providers.InMemory.csproj
+++ b/src/Arcus.Testing.Security.Providers.InMemory/Arcus.Testing.Security.Providers.InMemory.csproj
@@ -26,7 +26,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' != 'netstandard2.1'">
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="(8.0.0,10.0.0]" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="[8.0.0,10.0.0)" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">

--- a/src/Arcus.Testing.Storage.Blob/Arcus.Testing.Storage.Blob.csproj
+++ b/src/Arcus.Testing.Storage.Blob/Arcus.Testing.Storage.Blob.csproj
@@ -27,7 +27,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="[1.12.0,2.0.0)" />
+    <PackageReference Include="Azure.Identity" Version="[1.13.1,2.0.0)" />
     <PackageReference Include="Azure.Storage.Blobs" Version="[12.20.0,13.0.0)" />
   </ItemGroup>
 

--- a/src/Arcus.Testing.Storage.Cosmos/Arcus.Testing.Storage.Cosmos.csproj
+++ b/src/Arcus.Testing.Storage.Cosmos/Arcus.Testing.Storage.Cosmos.csproj
@@ -27,7 +27,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="[1.12.0,2.0.0)" />
+    <PackageReference Include="Azure.Identity" Version="[1.13.1,2.0.0)" />
     <PackageReference Include="Azure.ResourceManager.CosmosDB" Version="[1.3.2,2.0.0)" />
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="[3.43.0,4.0.0)" />
     <PackageReference Include="MongoDB.Driver" Version="[2.28.0,3.0.0)" />

--- a/src/Arcus.Testing.Storage.Table/Arcus.Testing.Storage.Table.csproj
+++ b/src/Arcus.Testing.Storage.Table/Arcus.Testing.Storage.Table.csproj
@@ -27,7 +27,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="[1.12.1,2.0.0)" />
+    <PackageReference Include="Azure.Identity" Version="[1.13.1,2.0.0)" />
     <PackageReference Include="Azure.Data.Tables" Version="[12.9.1,13.0.0)" />
   </ItemGroup>
 

--- a/src/Arcus.Testing.Tests.Core/Arcus.Testing.Tests.Core.csproj
+++ b/src/Arcus.Testing.Tests.Core/Arcus.Testing.Tests.Core.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Bogus" Version="29.0.2" />
-    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="Bogus" Version="35.6.1" />
+    <PackageReference Include="xunit" Version="2.9.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Arcus.Testing.Tests.Integration/Arcus.Testing.Tests.Integration.csproj
+++ b/src/Arcus.Testing.Tests.Integration/Arcus.Testing.Tests.Integration.csproj
@@ -6,19 +6,21 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Bogus" Version="29.0.2" />
+    <PackageReference Include="Bogus" Version="35.6.1" />
     <PackageReference Include="coverlet.collector" Version="6.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Guard.Net" Version="3.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.9.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Arcus.Testing.Tests.Integration/Core/Fixture/TemporaryDirectory.cs
+++ b/src/Arcus.Testing.Tests.Integration/Core/Fixture/TemporaryDirectory.cs
@@ -2,7 +2,6 @@
 using System.IO;
 using System.Linq;
 using Bogus;
-using GuardNet;
 
 namespace Arcus.Testing.Tests.Integration.Core.Fixture
 {
@@ -16,10 +15,6 @@ namespace Arcus.Testing.Tests.Integration.Core.Fixture
 
         private TemporaryDirectory(DirectoryInfo dir, string[] subDirNames)
         {
-            Guard.NotNull(dir, nameof(dir));
-            Guard.NotNull(subDirNames, nameof(subDirNames));
-            Guard.NotAny(subDirNames, nameof(subDirNames));
-
             _dir = dir;
             SubDirNames = subDirNames;
         }
@@ -39,8 +34,6 @@ namespace Arcus.Testing.Tests.Integration.Core.Fixture
         /// </summary>
         public static TemporaryDirectory GenerateAt(DirectoryInfo root)
         {
-            Guard.NotNull(root, nameof(root));
-
             string[] subDirNames = Bogus.Lorem.Words();
             string path = System.IO.Path.Combine(subDirNames.Prepend(root.FullName).ToArray());
             DirectoryInfo sub = Directory.CreateDirectory(path);

--- a/src/Arcus.Testing.Tests.Integration/Core/Fixture/TemporaryFile.cs
+++ b/src/Arcus.Testing.Tests.Integration/Core/Fixture/TemporaryFile.cs
@@ -2,7 +2,6 @@
 using System.IO;
 using System.Text;
 using Bogus;
-using GuardNet;
 
 namespace Arcus.Testing.Tests.Integration.Core.Fixture
 {
@@ -16,9 +15,6 @@ namespace Arcus.Testing.Tests.Integration.Core.Fixture
 
         private TemporaryFile(FileInfo file, byte[] fileContents)
         {
-            Guard.NotNull(file, nameof(file));
-            Guard.NotNull(fileContents, nameof(fileContents));
-
             _file = file;
             Contents = fileContents;
         }
@@ -43,8 +39,6 @@ namespace Arcus.Testing.Tests.Integration.Core.Fixture
         /// </summary>
         public static TemporaryFile GenerateAt(DirectoryInfo directory)
         {
-            Guard.NotNull(directory, nameof(directory));
-
             string fileName = Bogus.System.FileName();
             byte[] fileContents = Bogus.Random.Bytes(Bogus.Random.Int(10, 20));
 
@@ -56,10 +50,6 @@ namespace Arcus.Testing.Tests.Integration.Core.Fixture
         /// </summary>
         public static TemporaryFile CreateAt(DirectoryInfo directory, string fileName, byte[] fileContents)
         {
-            Guard.NotNull(directory, nameof(directory));
-            Guard.NotNullOrWhitespace(fileName, nameof(fileContents));
-            Guard.NotNull(fileContents, nameof(fileContents));
-
             string filePath = Path.Combine(directory.FullName, fileName);
             File.WriteAllBytes(filePath, fileContents);
 

--- a/src/Arcus.Testing.Tests.Integration/Core/Fixture/TemporaryFile.cs
+++ b/src/Arcus.Testing.Tests.Integration/Core/Fixture/TemporaryFile.cs
@@ -15,6 +15,8 @@ namespace Arcus.Testing.Tests.Integration.Core.Fixture
 
         private TemporaryFile(FileInfo file, byte[] fileContents)
         {
+            ArgumentNullException.ThrowIfNull(file);
+
             _file = file;
             Contents = fileContents;
         }
@@ -39,6 +41,8 @@ namespace Arcus.Testing.Tests.Integration.Core.Fixture
         /// </summary>
         public static TemporaryFile GenerateAt(DirectoryInfo directory)
         {
+            ArgumentNullException.ThrowIfNull(directory);
+
             string fileName = Bogus.System.FileName();
             byte[] fileContents = Bogus.Random.Bytes(Bogus.Random.Int(10, 20));
 
@@ -50,6 +54,8 @@ namespace Arcus.Testing.Tests.Integration.Core.Fixture
         /// </summary>
         public static TemporaryFile CreateAt(DirectoryInfo directory, string fileName, byte[] fileContents)
         {
+            ArgumentNullException.ThrowIfNull(directory);
+
             string filePath = Path.Combine(directory.FullName, fileName);
             File.WriteAllBytes(filePath, fileContents);
 

--- a/src/Arcus.Testing.Tests.Integration/Core/Fixture/TemporaryFileEdit.cs
+++ b/src/Arcus.Testing.Tests.Integration/Core/Fixture/TemporaryFileEdit.cs
@@ -13,6 +13,8 @@ namespace Arcus.Testing.Tests.Integration.Core.Fixture
 
         private TemporaryFileEdit(FileInfo file, string originalContents)
         {
+            ArgumentNullException.ThrowIfNull(file);
+
             _file = file;
             _originalContents = originalContents;
         }

--- a/src/Arcus.Testing.Tests.Integration/Core/Fixture/TemporaryFileEdit.cs
+++ b/src/Arcus.Testing.Tests.Integration/Core/Fixture/TemporaryFileEdit.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.IO;
-using GuardNet;
 
 namespace Arcus.Testing.Tests.Integration.Core.Fixture
 {
@@ -14,9 +13,6 @@ namespace Arcus.Testing.Tests.Integration.Core.Fixture
 
         private TemporaryFileEdit(FileInfo file, string originalContents)
         {
-            Guard.NotNull(file, nameof(file));
-            Guard.NotNull(originalContents, nameof(originalContents));
-
             _file = file;
             _originalContents = originalContents;
         }
@@ -26,9 +22,6 @@ namespace Arcus.Testing.Tests.Integration.Core.Fixture
         /// </summary>
         public static TemporaryFileEdit At(FileInfo file, Func<string, string> editContents)
         {
-            Guard.NotNull(file, nameof(file));
-            Guard.NotNull(editContents, nameof(editContents));
-
             string originalContents = File.ReadAllText(file.FullName);
             string editedContents = editContents(originalContents);
 

--- a/src/Arcus.Testing.Tests.Unit/Arcus.Testing.Tests.Unit.csproj
+++ b/src/Arcus.Testing.Tests.Unit/Arcus.Testing.Tests.Unit.csproj
@@ -6,18 +6,21 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Bogus" Version="29.0.2" />
+    <PackageReference Include="Bogus" Version="35.6.1" />
     <PackageReference Include="coverlet.collector" Version="6.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="FsCheck.Xunit" Version="2.16.6" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
-    <PackageReference Include="Moq" Version="4.14.5" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.4.3" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.6.4" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
* Use v10.0.0 now as upperbound package version for Microsoft package to allow easier support for the most recent v9.x package.
* Use the most recent Az.Identity package to remove (some of the) security vulnerabilities in transient packages.
* Upgrade the tests projects to the most recent versions to proof support for the most recent test packages. 