### PR TITLE
chore: disable/fix warnings in tests

### DIFF
--- a/src/Arcus.Testing.Tests.Integration/Storage/TemporaryTableTests.cs
+++ b/src/Arcus.Testing.Tests.Integration/Storage/TemporaryTableTests.cs
@@ -214,7 +214,9 @@ namespace Arcus.Testing.Tests.Integration.Storage
                 3 => TableEntityFilter.EntityEqual(e => e.ContainsKey(Bogus.PickRandom(entity.Keys.Where(k =>
                 {
                     return k != nameof(TableEntity.RowKey) && k != nameof(TableEntity.PartitionKey);
-                }))))
+                })))),
+
+                _ => throw new NotSupportedException("[Test:Setup] not-supported yet matching Azure Table entity filter type")
             };
         }
 

--- a/src/Arcus.Testing.Tests.Unit/Logging/InMemoryLogSinkTests.cs
+++ b/src/Arcus.Testing.Tests.Unit/Logging/InMemoryLogSinkTests.cs
@@ -5,6 +5,8 @@ using Serilog.Core;
 using Serilog.Events;
 using Xunit;
 
+#pragma warning disable CS0618 // Serilog dependency is deprecated in implementation, but still tested here.
+
 namespace Arcus.Testing.Tests.Unit.Logging
 {
     [Trait(name: "Category", value: "Unit")]

--- a/src/Arcus.Testing.Tests.Unit/Logging/LoggerSinkConfigurationExtensionsTests.cs
+++ b/src/Arcus.Testing.Tests.Unit/Logging/LoggerSinkConfigurationExtensionsTests.cs
@@ -6,6 +6,8 @@ using Serilog;
 using Serilog.Configuration;
 using Xunit;
 
+#pragma warning disable CS0618 // Serilog dependency is deprecated in implementation, but still tested here.
+
 namespace Arcus.Testing.Tests.Unit.Logging
 {
     public class LoggerSinkConfigurationExtensionsTests


### PR DESCRIPTION
* Disable NuGet Serilog warnings on deprecated tests.
* Add default switch case for table tests.