### PR TITLE
chore: don't treat nuget warnings as errors

### DIFF
--- a/src/Arcus.Testing.Assert/Arcus.Testing.Assert.csproj
+++ b/src/Arcus.Testing.Assert/Arcus.Testing.Assert.csproj
@@ -18,6 +18,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Arcus.Testing.Core/Arcus.Testing.Core.csproj
+++ b/src/Arcus.Testing.Core/Arcus.Testing.Core.csproj
@@ -18,6 +18,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Arcus.Testing.Integration.DataFactory/Arcus.Testing.Integration.DataFactory.csproj
+++ b/src/Arcus.Testing.Integration.DataFactory/Arcus.Testing.Integration.DataFactory.csproj
@@ -18,6 +18,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Arcus.Testing.Logging.Core/Arcus.Testing.Logging.Core.csproj
+++ b/src/Arcus.Testing.Logging.Core/Arcus.Testing.Logging.Core.csproj
@@ -10,6 +10,7 @@
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Arcus.Testing.Logging.MSTest/Arcus.Testing.Logging.MSTest.csproj
+++ b/src/Arcus.Testing.Logging.MSTest/Arcus.Testing.Logging.MSTest.csproj
@@ -18,6 +18,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Arcus.Testing.Logging.NUnit/Arcus.Testing.Logging.NUnit.csproj
+++ b/src/Arcus.Testing.Logging.NUnit/Arcus.Testing.Logging.NUnit.csproj
@@ -18,6 +18,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Arcus.Testing.Logging.Xunit/Arcus.Testing.Logging.Xunit.csproj
+++ b/src/Arcus.Testing.Logging.Xunit/Arcus.Testing.Logging.Xunit.csproj
@@ -18,6 +18,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Arcus.Testing.Messaging.Pumps.EventHubs/Arcus.Testing.Messaging.Pumps.EventHubs.csproj
+++ b/src/Arcus.Testing.Messaging.Pumps.EventHubs/Arcus.Testing.Messaging.Pumps.EventHubs.csproj
@@ -17,6 +17,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Arcus.Testing.Messaging.Pumps.ServiceBus/Arcus.Testing.Messaging.Pumps.ServiceBus.csproj
+++ b/src/Arcus.Testing.Messaging.Pumps.ServiceBus/Arcus.Testing.Messaging.Pumps.ServiceBus.csproj
@@ -17,6 +17,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Arcus.Testing.Security.Providers.InMemory/Arcus.Testing.Security.Providers.InMemory.csproj
+++ b/src/Arcus.Testing.Security.Providers.InMemory/Arcus.Testing.Security.Providers.InMemory.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>net8.0;net6.0;netstandard2.1</TargetFrameworks>
@@ -17,6 +17,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Arcus.Testing.Storage.Blob/Arcus.Testing.Storage.Blob.csproj
+++ b/src/Arcus.Testing.Storage.Blob/Arcus.Testing.Storage.Blob.csproj
@@ -18,6 +18,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Arcus.Testing.Storage.Cosmos/Arcus.Testing.Storage.Cosmos.csproj
+++ b/src/Arcus.Testing.Storage.Cosmos/Arcus.Testing.Storage.Cosmos.csproj
@@ -18,6 +18,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Arcus.Testing.Storage.Table/Arcus.Testing.Storage.Table.csproj
+++ b/src/Arcus.Testing.Storage.Table/Arcus.Testing.Storage.Table.csproj
@@ -18,6 +18,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Don't let a NuGet audit warning (could be vulnerability low - critical) fail the compilation, as we do not have the budget to hotfix every NuGet warnings as quickly as possible. 