### PR TITLE
test: add dataflow run result blank input tests

### DIFF
--- a/src/Arcus.Testing.Tests.Unit/Integration/DataFactory/DataFlowRunResultAsCsvTests.cs
+++ b/src/Arcus.Testing.Tests.Unit/Integration/DataFactory/DataFlowRunResultAsCsvTests.cs
@@ -158,7 +158,7 @@ namespace Arcus.Testing.Tests.Unit.Integration.DataFactory
             ShouldFailToGetDataAsCsv(input);
         }
 
-        private CsvException ShouldFailToGetDataAsCsv(string input)
+        private static CsvException ShouldFailToGetDataAsCsv(string input)
         {
             // Arrange
             DataFlowRunResult result = CreateRunResult(input);
@@ -167,7 +167,7 @@ namespace Arcus.Testing.Tests.Unit.Integration.DataFactory
             return Assert.ThrowsAny<CsvException>(() => result.GetDataAsCsv());
         }
 
-        private void ShouldContain(string actual, params string[] expected)
+        private static void ShouldContain(string actual, params string[] expected)
         {
             Assert.All(expected, str => Assert.Contains(str, actual, StringComparison.OrdinalIgnoreCase));
         }

--- a/src/Arcus.Testing.Tests.Unit/Integration/DataFactory/DataFlowRunResultAsJsonTests.cs
+++ b/src/Arcus.Testing.Tests.Unit/Integration/DataFactory/DataFlowRunResultAsJsonTests.cs
@@ -240,12 +240,29 @@ namespace Arcus.Testing.Tests.Unit.Integration.DataFactory
         {
             // Arrange
             var preview = DataPreview.Create(headersTxt, dataTxt);
-            DataFlowRunResult result = CreateRunResult(preview);
 
             // Act / Assert
-            var exception = Assert.ThrowsAny<JsonException>(() => result.GetDataAsJson());
+            var exception = ShouldFailToGetDataAsJson(preview.ToString());
             Assert.Contains("cannot load", exception.Message, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("only supports limited", exception.Message, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData(" ")]
+        [InlineData("   ")]
+        public void GetDataAsCsv_WithBlankInput_Fails(string input)
+        { 
+            ShouldFailToGetDataAsJson(input);
+        }
+
+        private static JsonException ShouldFailToGetDataAsJson(string input)
+        {
+            // Arrange
+            DataFlowRunResult result = CreateRunResult(input);
+
+            // Act / Assert
+            return Assert.ThrowsAny<JsonException>(() => result.GetDataAsJson());
         }
 
         private static DataFlowRunResult CreateRunResult(DataPreview preview)


### PR DESCRIPTION
Add blank input unit tests to the DataFlow JSON result.

Follow-up #176 