### PR TITLE
chore: streamline loglevels throughout test fixtures

### DIFF
--- a/src/Arcus.Testing.Core/DisposableCollection.cs
+++ b/src/Arcus.Testing.Core/DisposableCollection.cs
@@ -149,7 +149,7 @@ namespace Arcus.Testing
             AsyncRetryPolicy policy =
                 Policy.Handle<Exception>(ex =>
                       {
-                          _logger.LogError(ex, "Test fixture failed to be tear down, retrying {RetryInterval:g}...", Options.RetryInterval);
+                          _logger.LogError(ex, "[Test:Teardown] Test fixture failed to be tear down: '{Message}', retrying in {RetryInterval:g}...", ex.Message, Options.RetryInterval);
                           return true;
                       })
                       .WaitAndRetryAsync(Options.RetryCount, index => Options.RetryInterval);
@@ -175,7 +175,9 @@ namespace Arcus.Testing
 
             if (exceptions.Count > 1)
             {
-                throw new AggregateException("Some test fixtures failed to tear down correctly", exceptions);
+                throw new AggregateException(
+                    "[Test:Teardown] Some test fixtures failed to tear down correctly, please check the collected exceptions for more information", 
+                    exceptions);
             }
         }
     }

--- a/src/Arcus.Testing.Integration.DataFactory/TemporaryDataFlowDebugSession.cs
+++ b/src/Arcus.Testing.Integration.DataFactory/TemporaryDataFlowDebugSession.cs
@@ -167,7 +167,7 @@ namespace Arcus.Testing
             DataFlowDebugSessionInfo activeSession = await GetActiveDebugSessionOrDefaultAsync(resource, options.ActiveSessionId);
             if (activeSession is not null)
             {
-                logger.LogTrace("[Test:Setup] Re-using Azure DataFactory '{Name}' DataFlow debug session '{SessionId}'", resource.Id.Name, activeSession.SessionId);
+                logger.LogDebug("[Test:Setup] Re-using Azure DataFactory '{Name}' DataFlow debug session '{SessionId}'", resource.Id.Name, activeSession.SessionId);
                 return new TemporaryDataFlowDebugSession(startedByUs: false, activeSession.SessionId ?? throw new InvalidOperationException($"Re-using DataFactory '{resource.Id.Name}' DataFlow debug session did not result in a session ID"), resource, logger);
             }
 
@@ -179,7 +179,7 @@ namespace Arcus.Testing
                 });
 
             Guid sessionId = result.Value.SessionId ?? throw new InvalidOperationException($"Starting DataFactory '{resource.Id.Name}' DataFlow debug session did not result in a session ID");
-            logger.LogTrace("[Test:Setup] Started Azure DataFactory '{Name}' DataFlow debug session '{SessionId}'", resource.Id.Name, sessionId);
+            logger.LogDebug("[Test:Setup] Started Azure DataFactory '{Name}' DataFlow debug session '{SessionId}'", resource.Id.Name, sessionId);
 
             return new TemporaryDataFlowDebugSession(startedByUs: true, sessionId, resource, logger);
         }
@@ -280,7 +280,7 @@ namespace Arcus.Testing
 
             foreach (KeyValuePair<string, BinaryData> parameter in options.DataFlowParameters)
             {
-                _logger.LogTrace("[Test:Setup] Add DataFlow parameter '{Name}' to debug session", parameter.Key);
+                _logger.LogDebug("[Test:Setup] Add DataFlow parameter '{Name}' to debug session", parameter.Key);
                 settings.Parameters[parameter.Key] = parameter.Value;
             }
 
@@ -288,10 +288,7 @@ namespace Arcus.Testing
             {
                 foreach (KeyValuePair<string, object> parameter in datasetParameter.Value)
                 {
-                    _logger.LogTrace("[Test:Setup] Add DataSet parameter '{ParameterName}' for DataSet '{DataSetName}' to debug session",
-                        parameter.Key,
-                        datasetParameter.Key
-                    );
+                    _logger.LogDebug("[Test:Setup] Add DataSet parameter '{ParameterName}' for DataSet '{DataSetName}' to debug session", parameter.Key, datasetParameter.Key);
                 }
             }
 
@@ -338,7 +335,7 @@ namespace Arcus.Testing
 
         private async Task<DataFactoryDatasetResource> AddDataSetAsync(DataFactoryDataFlowDebugPackageContent debug, DataFactoryResource dataFactory, string datasetName)
         {
-            _logger.LogTrace("[Test:Setup] Add DataSet '{DataSetName}' of DataFactory '{DataFactoryName}' to debug session", datasetName, dataFactory.Id.Name);
+            _logger.LogDebug("[Test:Setup] Add DataSet '{DataSetName}' of DataFactory '{DataFactoryName}' to debug session", datasetName, dataFactory.Id.Name);
 
             DataFactoryDatasetResource dataset = await dataFactory.GetDataFactoryDatasetAsync(datasetName);
             debug.Datasets.Add(new DataFactoryDatasetDebugInfo(dataset.Data.Properties) { Name = dataset.Data.Name });
@@ -348,7 +345,7 @@ namespace Arcus.Testing
 
         private async Task AddLinkedServiceAsync(DataFactoryDataFlowDebugPackageContent debug, DataFactoryResource dataFactory, string serviceName)
         {
-            _logger.LogTrace("[Test:Setup] Add LinkedService '{ServiceName}' of DataFactory '{DatFactoryName}' to debug session", serviceName, dataFactory.Id.Name);
+            _logger.LogDebug("[Test:Setup] Add LinkedService '{ServiceName}' of DataFactory '{DatFactoryName}' to debug session", serviceName, dataFactory.Id.Name);
 
             DataFactoryLinkedServiceResource linkedService = await dataFactory.GetDataFactoryLinkedServiceAsync(serviceName);
             debug.LinkedServices.Add(new DataFactoryLinkedServiceDebugInfo(linkedService.Data.Properties) { Name = linkedService.Data.Name });
@@ -356,7 +353,7 @@ namespace Arcus.Testing
 
         private async Task<DataFlowRunResult> GetDataFlowResultAsync(string dataFlowName, string targetSinkName, RunDataFlowOptions options)
         {
-            _logger.LogTrace("[Test] Run DataFlow '{DataFlowName}' until result is available on sink '{SinkName}'", dataFlowName, targetSinkName);
+            _logger.LogInformation("[Test] Run DataFlow '{DataFlowName}' until result is available on sink '{SinkName}'", dataFlowName, targetSinkName);
 
             ArmOperation<DataFactoryDataFlowDebugCommandResult> result =
                 await DataFactory.ExecuteDataFlowDebugSessionCommandAsync(WaitUntil.Completed, new DataFlowDebugCommandContent
@@ -387,7 +384,7 @@ namespace Arcus.Testing
         {
             if (_startedByUs)
             {
-                _logger.LogTrace("[Test:Teardown] Stop Azure DataFactory '{Name}' DataFlow debug session '{SessionId}'", DataFactory.Id.Name, SessionId);
+                _logger.LogDebug("[Test:Teardown] Stop Azure DataFactory '{Name}' DataFlow debug session '{SessionId}'", DataFactory.Id.Name, SessionId);
                 await DataFactory.DeleteDataFlowDebugSessionAsync(new DeleteDataFlowDebugSessionContent { SessionId = SessionId });
             }
 

--- a/src/Arcus.Testing.Storage.Blob/TemporaryBlobContainer.cs
+++ b/src/Arcus.Testing.Storage.Blob/TemporaryBlobContainer.cs
@@ -559,7 +559,7 @@ namespace Arcus.Testing
             {
                 if (options.OnSetup.IsMatched(blob))
                 {
-                    logger.LogTrace("[Test:Setup] Delete Azure Blob file '{BlobName}' from container '{AccountName}/{ContainerName}'", blob.Name, containerClient.AccountName, containerClient.Name);
+                    logger.LogDebug("[Test:Setup] Delete Azure Blob file '{BlobName}' from container '{AccountName}/{ContainerName}'", blob.Name, containerClient.AccountName, containerClient.Name);
                     await containerClient.GetBlobClient(blob.Name).DeleteIfExistsAsync();
                 }
             }
@@ -576,7 +576,7 @@ namespace Arcus.Testing
             {
                 if (options.OnTeardown.IsMatched(blob))
                 {
-                    logger.LogTrace("[Test:Teardown] Delete Azure Blob file '{BlobName}' from container '{AccountName}/{ContainerName}'", blob.Name, containerClient.AccountName, containerClient.Name);
+                    logger.LogDebug("[Test:Teardown] Delete Azure Blob file '{BlobName}' from container '{AccountName}/{ContainerName}'", blob.Name, containerClient.AccountName, containerClient.Name);
                     await containerClient.GetBlobClient(blob.Name).DeleteIfExistsAsync();
                 }
             }

--- a/src/Arcus.Testing.Storage.Cosmos/TemporaryMongoDbCollection.cs
+++ b/src/Arcus.Testing.Storage.Cosmos/TemporaryMongoDbCollection.cs
@@ -357,13 +357,13 @@ namespace Arcus.Testing
 
             if (options.OnSetup.Documents is OnSetupMongoDbCollection.CleanIfExisted)
             {
-                logger.LogTrace("[Test:Setup] Clean all documents in Azure Cosmos MongoDb collection '{DatabaseName}/{CollectionName}'", database.DatabaseNamespace.DatabaseName, collectionName);
+                logger.LogDebug("[Test:Setup] Clean all documents in Azure Cosmos MongoDb collection '{DatabaseName}/{CollectionName}'", database.DatabaseNamespace.DatabaseName, collectionName);
                 await collection.DeleteManyAsync(Builders<BsonDocument>.Filter.Empty);
             }
 
             if (options.OnSetup.Documents is OnSetupMongoDbCollection.CleanIfMatched)
             {
-                logger.LogTrace("[Test:Setup] Clean all matching documents in Azure Cosmos MongoDb collection '{DatabaseName}/{CollectionName}'", database.DatabaseNamespace.DatabaseName, collectionName);
+                logger.LogDebug("[Test:Setup] Clean all matching documents in Azure Cosmos MongoDb collection '{DatabaseName}/{CollectionName}'", database.DatabaseNamespace.DatabaseName, collectionName);
                 await collection.DeleteManyAsync(options.OnSetup.IsMatched);
             }
         }
@@ -434,13 +434,13 @@ namespace Arcus.Testing
 
             if (_options.OnTeardown.Documents is OnTeardownMongoDbCollection.CleanAll)
             {
-                _logger.LogTrace("[Test:Teardown] Clean all documents in Azure Cosmos MongoDb '{DatabaseName}/{CollectionName}' collection", _database.DatabaseNamespace.DatabaseName, Name);
+                _logger.LogDebug("[Test:Teardown] Clean all documents in Azure Cosmos MongoDb '{DatabaseName}/{CollectionName}' collection", _database.DatabaseNamespace.DatabaseName, Name);
                 await collection.DeleteManyAsync(Builders<BsonDocument>.Filter.Empty);
             }
 
             if (_options.OnTeardown.Documents is OnTeardownMongoDbCollection.CleanIfMatched)
             {
-                _logger.LogTrace("[Test:Teardown] Clean all matching documents in Azure Cosmos MongoDb '{DatabaseName}/{CollectionName}' collection", _database.DatabaseNamespace.DatabaseName, Name);
+                _logger.LogDebug("[Test:Teardown] Clean all matching documents in Azure Cosmos MongoDb '{DatabaseName}/{CollectionName}' collection", _database.DatabaseNamespace.DatabaseName, Name);
                 await collection.DeleteManyAsync(_options.OnTeardown.IsMatched);
             }
         }

--- a/src/Arcus.Testing.Storage.Cosmos/TemporaryNoSqlContainer.cs
+++ b/src/Arcus.Testing.Storage.Cosmos/TemporaryNoSqlContainer.cs
@@ -547,7 +547,7 @@ namespace Arcus.Testing
             {
                 await ForEachItemAsync(container, async (id, partitionKey, _) =>
                 {
-                    logger.LogTrace("[Test:Setup] Delete Azure Cosmos NoSql item '{ItemId}' {PartitionKey} in container '{DatabaseName}/{ContainerName}'", id, partitionKey, container.Database.Id, container.Id);
+                    logger.LogDebug("[Test:Setup] Delete Azure Cosmos NoSql item '{ItemId}' {PartitionKey} in container '{DatabaseName}/{ContainerName}'", id, partitionKey, container.Database.Id, container.Id);
                     using ResponseMessage response = await container.DeleteItemStreamAsync(id, partitionKey);
                     
                     if (!response.IsSuccessStatusCode && response.StatusCode != HttpStatusCode.NotFound)
@@ -564,7 +564,7 @@ namespace Arcus.Testing
                 {
                     if (options.OnSetup.IsMatched(id, key, doc, container.Database.Client))
                     {
-                        logger.LogTrace("[Test:Setup] Delete matched Azure Cosmos NoSql item '{ItemId}' {PartitionKey} in container '{DatabaseName}/{ContainerName}'", id, key, container.Database.Id, container.Id);
+                        logger.LogDebug("[Test:Setup] Delete matched Azure Cosmos NoSql item '{ItemId}' {PartitionKey} in container '{DatabaseName}/{ContainerName}'", id, key, container.Database.Id, container.Id);
                         using ResponseMessage response = await container.DeleteItemStreamAsync(id, key);
 
                         if (!response.IsSuccessStatusCode && response.StatusCode != HttpStatusCode.NotFound)
@@ -630,7 +630,7 @@ namespace Arcus.Testing
                 {
                     disposables.Add(AsyncDisposable.Create(async () =>
                     {
-                        _logger.LogTrace("[Test:Teardown] Delete Azure Cosmos NoSql item '{ItemId}' {PartitionKey} in NoSql container '{DatabaseName}/{ContainerName}'", id, key, Client.Database.Id, Client.Id);
+                        _logger.LogDebug("[Test:Teardown] Delete Azure Cosmos NoSql item '{ItemId}' {PartitionKey} in NoSql container '{DatabaseName}/{ContainerName}'", id, key, Client.Database.Id, Client.Id);
                         using ResponseMessage response = await Client.DeleteItemStreamAsync(id, key);
                         
                         if (!response.IsSuccessStatusCode && response.StatusCode != HttpStatusCode.NotFound)
@@ -652,7 +652,7 @@ namespace Arcus.Testing
                     {
                         if (_options.OnTeardown.IsMatched(id, key, doc, Client.Database.Client))
                         {
-                            _logger.LogTrace("[Test:Teardown] Delete Azure Cosmos NoSql item '{ItemId}' {PartitionKey} in NoSql container '{DatabaseName}/{ContainerName}'", id, key, Client.Database.Id, Client.Id);
+                            _logger.LogDebug("[Test:Teardown] Delete Azure Cosmos NoSql item '{ItemId}' {PartitionKey} in NoSql container '{DatabaseName}/{ContainerName}'", id, key, Client.Database.Id, Client.Id);
                             using ResponseMessage response = await Client.DeleteItemStreamAsync(id, key);
                             
                             if (!response.IsSuccessStatusCode && response.StatusCode != HttpStatusCode.NotFound)

--- a/src/Arcus.Testing.Storage.Table/TemporaryTable.cs
+++ b/src/Arcus.Testing.Storage.Table/TemporaryTable.cs
@@ -415,7 +415,7 @@ namespace Arcus.Testing
             {
                 await foreach (TableEntity item in tableClient.QueryAsync<TableEntity>(_ => true))
                 {
-                    logger.LogTrace("[Test:Setup] Delete Azure Table entity (rowKey: '{RowKey}', partitionKey: '{PartitionKey}') from table '{AccountName}/{TableName}'", item.RowKey, item.PartitionKey, tableClient.AccountName, tableClient.Name);
+                    logger.LogDebug("[Test:Setup] Delete Azure Table entity (rowKey: '{RowKey}', partitionKey: '{PartitionKey}') from table '{AccountName}/{TableName}'", item.RowKey, item.PartitionKey, tableClient.AccountName, tableClient.Name);
                     using Response response = await tableClient.DeleteEntityAsync(item);
 
                     if (response.IsError && response.Status != NotFound)
@@ -433,7 +433,7 @@ namespace Arcus.Testing
                 {
                     if (options.OnSetup.IsMatch(item))
                     {
-                        logger.LogTrace("[Test:Setup] Delete Azure Table entity (rowKey: '{RowKey}', partitionKey: '{PartitionKey}') from table '{AccountName}/{TableName}'", item.RowKey, item.PartitionKey, tableClient.AccountName, tableClient.Name);
+                        logger.LogDebug("[Test:Setup] Delete Azure Table entity (rowKey: '{RowKey}', partitionKey: '{PartitionKey}') from table '{AccountName}/{TableName}'", item.RowKey, item.PartitionKey, tableClient.AccountName, tableClient.Name);
                         using Response response = await tableClient.DeleteEntityAsync(item);
 
                         if (response.IsError && response.Status != NotFound)
@@ -503,7 +503,7 @@ namespace Arcus.Testing
                 {
                     disposables.Add(AsyncDisposable.Create(async () =>
                     {
-                        _logger.LogTrace("[Test:Teardown] Delete Azure Table entity (rowKey: '{RowKey}', partitionKey: '{PartitionKey}') from table '{AccountName}/{TableName}'", item.RowKey, item.PartitionKey, Client.AccountName, Client.Name);
+                        _logger.LogDebug("[Test:Teardown] Delete Azure Table entity (rowKey: '{RowKey}', partitionKey: '{PartitionKey}') from table '{AccountName}/{TableName}'", item.RowKey, item.PartitionKey, Client.AccountName, Client.Name);
                         using Response response = await Client.DeleteEntityAsync(item);
 
                         if (response.IsError && response.Status != NotFound)
@@ -524,7 +524,7 @@ namespace Arcus.Testing
                     {
                         if (_options.OnTeardown.IsMatch(item))
                         {
-                            _logger.LogTrace("[Test:Teardown] Delete Azure Table entity (rowKey: '{RowKey}', partitionKey: '{PartitionKey}') from table '{AccountName}/{TableName}'", item.RowKey, item.PartitionKey, Client.AccountName, Client.Name);
+                            _logger.LogDebug("[Test:Teardown] Delete Azure Table entity (rowKey: '{RowKey}', partitionKey: '{PartitionKey}') from table '{AccountName}/{TableName}'", item.RowKey, item.PartitionKey, Client.AccountName, Client.Name);
                             using Response response = await Client.DeleteEntityAsync(item);
 
                             if (response.IsError && response.Status != NotFound)


### PR DESCRIPTION
Use `LogDebug` for all setup/teardown actions, use `LogTrace` for additional event actions besides the general setup/teardown, use `LogInformtation` for global operations.