### PR TITLE
chore: deprecate unnecessary az blob functionality

### DIFF
--- a/docs/preview/03-Features/04-Azure/04-Storage/01-storage-account.mdx
+++ b/docs/preview/03-Features/04-Azure/04-Storage/01-storage-account.mdx
@@ -64,11 +64,7 @@ await TemporaryBlobContainer.CreateIfNotExistsAsync(..., options =>
 
     // Delete Azure Blobs that matches any of the configured filters, 
     // upon the test fixture creation, when there was already an Azure Blob container available.
-    options.OnSetup.CleanMatchingBlobs(
-      BlobNameFilter.NameEqual("test-blob-1"),
-      BlobNameFilter.NameStartsWith("test-"),
-      BlobNameFilter.NameEndsWith("-123"),
-      BlobNameFilter.NameContains("test"));
+    options.OnSetup.CleanMatchingBlobs((BlobItem blob) => blob.Name.StartsWith("test-"));
 
     // Options related to when the test fixture is teared down.
     // --------------------------------------------------------
@@ -84,11 +80,7 @@ await TemporaryBlobContainer.CreateIfNotExistsAsync(..., options =>
     // Delete additional Azure Blobs that matches any of the configured filters, 
     // upon the test fixture disposal.
     // ⚠️ Blobs uploaded by the test fixture itself will always be deleted.
-    options.OnTeardown.CleanMatchingBlobs(
-      BlobNameFilter.NameEqual("test-blob-1"),
-      BlobNameFilter.NameStartsWith("test-"),
-      BlobNameFilter.NameEndsWith("-123"),
-      BlobNameFilter.NameContains("test"));
+    options.OnTeardown.CleanMatchingBlobs((BlobItem blob) => blob.Name.StartsWith("test-"));
 
     // (Default for deleting container)
     // Delete Azure Blob container if the test fixture created the container.
@@ -109,8 +101,6 @@ container.OnTeardown.CleanAllBlobs();
 ## Temporary Blob file
 The `TemporaryBlobFile` provides a solution when the integration test requires data (blob) during the test run. An Azure Blob file is created upon the setup of the test fixture and is deleted again when the test fixture is disposed.
 
-> ⚡ Whether or not the test fixture should use an existing file is configurable.
-
 ```csharp
 using Arcus.Testing;
 
@@ -122,43 +112,6 @@ await using var file = await TemporaryBlobFile.UploadIfNotExistsAsync(
 
 // Interact with the blob during the lifetime of the fixture.
 BlobClient client = file.Client;
-```
-
-### Customization
-The setup and teardown process of the temporary file is configurable. **By default, any setup that was changed by the test fixture, is always teared down.**
-
-```csharp
-using Arcus.Testing;
-
-await TemporaryBlobFile.UploadIfNotExistsAsync(..., options =>
-{
-    // Options related to when the test fixture is set up.
-    // ---------------------------------------------------
-
-    // (Default) Use the existing Azure Blob's content when it already exists.
-    // Nothing is being uploaded, only a link to the existing file is made.
-    options.OnSetup.UseExistingBlob();
-
-    // Override any existing Azure Blob's content when it already exists.
-    // ⚡ The original content will be reverted upon disposal, if the blob already existed upon setup.
-    options.OnSetup.OverrideExistingBlob();
-
-    // Options related to when the test fixture is teared down.
-    // --------------------------------------------------------
-
-    // (Default) Delete the Azure Blob file upon disposal,
-    // if the test fixture created the blob.
-    options.OnTeardown.DeleteCreatedBlob();
-
-    // Delete the Azure Blob file upon disposal,
-    // regardless if the test fixture created the blob.
-    options.OnTeardown.DeleteExistingBlob();
-});
-
-// `OnTeardown` is also still available after the temporary file is created.
-await using TemporaryBlobFile file = ...
-
-file.OnTeardown.DeleteExistingBlob();
 ```
 
 </TabItem>

--- a/src/Arcus.Testing.Storage.Blob/TemporaryBlobFile.cs
+++ b/src/Arcus.Testing.Storage.Blob/TemporaryBlobFile.cs
@@ -1,4 +1,4 @@
-﻿﻿using System;
+﻿using System;
 using System.Threading.Tasks;
 using Azure.Identity;
 using Azure.Storage.Blobs;
@@ -6,11 +6,15 @@ using Azure.Storage.Blobs.Models;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 
+#pragma warning disable CS0618, S1133 // Ignore obsolete warnings that we added ourselves, should be removed upon releasing v2.0.
+
 namespace Arcus.Testing
 {
     /// <summary>
     /// Represents the available options when creating a <see cref="TemporaryBlobFile"/>.
     /// </summary>
+    [Obsolete("Use the '" + nameof(TemporaryBlobContainerOptions) + "' instead on Azure Blob storage container-level to control " +
+              "whether or not existing/non-existing files should be cleaned during setup/teardown, options will be removed in v2.0")]
     public class OnSetupBlobFileOptions
     {
         /// <summary>
@@ -49,6 +53,8 @@ namespace Arcus.Testing
     /// <summary>
     /// Represents the available options when deleting a <see cref="TemporaryBlobFile"/>.
     /// </summary>
+    [Obsolete("Use the '" + nameof(TemporaryBlobContainerOptions) + "' instead on Azure Blob storage container-level to control " +
+              "whether or not existing/non-existing files should be cleaned during setup/teardown, options will be removed in v2.0")]
     public class OnTeardownBlobFileOptions
     {
         /// <summary>
@@ -79,6 +85,8 @@ namespace Arcus.Testing
     /// <summary>
     /// Represents the available options when uploading a <see cref="TemporaryBlobFile"/>.
     /// </summary>
+    [Obsolete("Use the '" + nameof(TemporaryBlobContainerOptions) + "' instead on Azure Blob storage container-level to control " +
+              "whether or not existing/non-existing files should be cleaned during setup/teardown, options will be removed in v2.0")]
     public class TemporaryBlobFileOptions
     {
         /// <summary>
@@ -116,7 +124,7 @@ namespace Arcus.Testing
             _originalData = originalData;
             _options = options;
             _logger = logger ?? NullLogger.Instance;
-            
+
             Client = blobClient;
         }
 
@@ -138,6 +146,8 @@ namespace Arcus.Testing
         /// <summary>
         /// Gets the additional options to manipulate the deletion of the <see cref="TemporaryBlobFile"/>.
         /// </summary>
+        [Obsolete("Use the '" + nameof(TemporaryBlobContainerOptions) + "' instead on Azure Blob storage container-level to control " +
+                  "whether or not existing/non-existing files should be cleaned during setup/teardown")]
         public OnTeardownBlobFileOptions OnTeardown => _options.OnTeardown;
 
         /// <summary>
@@ -186,6 +196,8 @@ namespace Arcus.Testing
         /// <param name="configureOptions">The function to configure the additional options of how the blob should be uploaded.</param>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="blobName"/> is blank.</exception>
         /// <exception cref="ArgumentNullException">Thrown when <paramref name="blobContainerUri"/> or the <paramref name="blobContent"/> is <c>null</c>.</exception>
+        [Obsolete("Use the '" + nameof(TemporaryBlobContainerOptions) + "' instead on Azure Blob storage container-level to control " +
+                  "whether or not existing/non-existing files should be cleaned during setup/teardown, this overload with options will be removed in v2.0")]
         public static async Task<TemporaryBlobFile> UploadIfNotExistsAsync(
             Uri blobContainerUri,
             string blobName,
@@ -227,6 +239,8 @@ namespace Arcus.Testing
         /// <param name="logger">The logger to write diagnostic messages during the upload process.</param>
         /// <param name="configureOptions">The function to configure the additional options of how the blob should be uploaded.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="blobClient"/> or the <paramref name="blobContent"/> is <c>null</c>.</exception>
+        [Obsolete("Use the '" + nameof(TemporaryBlobContainerOptions) + "' instead on Azure Blob storage container-level to control " +
+                  "whether or not existing/non-existing files should be cleaned during setup/teardown, this overload with options will be removed in v2.0")]
         public static async Task<TemporaryBlobFile> UploadIfNotExistsAsync(
             BlobClient blobClient,
             BinaryData blobContent,
@@ -246,9 +260,9 @@ namespace Arcus.Testing
         }
 
         private static async Task<(bool createdByUs, BinaryData originalData)> EnsureBlobContentCreatedAsync(
-            BlobClient client, 
+            BlobClient client,
             BinaryData newContent,
-            TemporaryBlobFileOptions options, 
+            TemporaryBlobFileOptions options,
             ILogger logger)
         {
             if (await client.ExistsAsync())
@@ -266,7 +280,7 @@ namespace Arcus.Testing
 
             logger.LogDebug("[Test:Setup] Upload Azure Blob file '{BlobName}' to container '{AccountName}/{ContainerName}'", client.Name, client.AccountName, client.BlobContainerName);
             await client.UploadAsync(newContent);
-            
+
             return (createdByUs: true, originalData: null);
         }
 
@@ -279,7 +293,7 @@ namespace Arcus.Testing
             if (!_createdByUs && _originalData != null && _options.OnTeardown.Content != OnTeardownBlob.DeleteIfExisted)
             {
                 _logger.LogDebug("[Test:Teardown] Revert replaced Azure Blob file '{BlobName}' to original content in container '{AccountName}/{ContainerName}'", Client.Name, Client.AccountName, Client.BlobContainerName);
-                await Client.UploadAsync(_originalData, overwrite: true); 
+                await Client.UploadAsync(_originalData, overwrite: true);
             }
 
             if (_createdByUs || _options.OnTeardown.Content is OnTeardownBlob.DeleteIfExisted)

--- a/src/Arcus.Testing.Tests.Integration/Storage/TemporaryBlobFileTests.cs
+++ b/src/Arcus.Testing.Tests.Integration/Storage/TemporaryBlobFileTests.cs
@@ -2,9 +2,10 @@
 using System.Threading.Tasks;
 using Arcus.Testing.Tests.Integration.Storage.Fixture;
 using Azure.Storage.Blobs;
-using Microsoft.Extensions.Options;
 using Xunit;
 using Xunit.Abstractions;
+
+#pragma warning disable CS0618 // Ignore obsolete warnings that we added ourselves, should be removed upon releasing v2.0.
 
 namespace Arcus.Testing.Tests.Integration.Storage
 {
@@ -92,7 +93,7 @@ namespace Arcus.Testing.Tests.Integration.Storage
             await using var context = await GivenBlobStorageAsync();
 
             BlobContainerClient containerClient = await context.WhenBlobContainerAvailableAsync();
-            
+
             BinaryData originalContent = context.CreateBlobContent();
             BlobClient existingBlob = await context.WhenBlobAvailableAsync(containerClient, blobContent: originalContent);
             BinaryData newContent = context.CreateBlobContent();
@@ -164,13 +165,17 @@ namespace Arcus.Testing.Tests.Integration.Storage
             blobName ??= $"test-{Guid.NewGuid():N}";
             blobContent ??= BinaryData.FromBytes(Bogus.Random.Bytes(100));
 
+#pragma warning disable S3358 // Sonar suggests extracting nested condition, but methods are now deprecated and will be removed with v2.0 anyway.
+
             TemporaryBlobFile temp = configureOptions is null
-                ? Bogus.Random.Bool() 
+                ? Bogus.Random.Bool()
                     ? await TemporaryBlobFile.UploadIfNotExistsAsync(client.Uri, blobName, blobContent, Logger)
                     : await TemporaryBlobFile.UploadIfNotExistsAsync(client.GetBlobClient(blobName), blobContent, Logger)
                 : Bogus.Random.Bool()
                     ? await TemporaryBlobFile.UploadIfNotExistsAsync(client.Uri, blobName, blobContent, Logger, configureOptions)
                     : await TemporaryBlobFile.UploadIfNotExistsAsync(client.GetBlobClient(blobName), blobContent, Logger, configureOptions);
+
+#pragma warning disable
 
             Assert.Equal(blobName, temp.Name);
             Assert.Equal(client.Name, temp.ContainerName);

--- a/src/Arcus.Testing.Tests.Unit/Storage/TemporaryBlobContainerOptionsTests.cs
+++ b/src/Arcus.Testing.Tests.Unit/Storage/TemporaryBlobContainerOptionsTests.cs
@@ -1,5 +1,8 @@
 ﻿using System;
+using Azure.Storage.Blobs.Models;
 using Xunit;
+
+#pragma warning disable CS0618 // Ignore obsolete warnings that we added ourselves, should be removed upon releasing v2.0.
 
 namespace Arcus.Testing.Tests.Unit.Storage
 {
@@ -12,7 +15,8 @@ namespace Arcus.Testing.Tests.Unit.Storage
             var options = new TemporaryBlobContainerOptions();
 
             // Act / Assert
-            Assert.ThrowsAny<ArgumentException>(() => options.OnSetup.CleanMatchingBlobs(filters: null));
+            Assert.ThrowsAny<ArgumentException>(() => options.OnSetup.CleanMatchingBlobs(filters: (Func<BlobItem, bool>[]) null));
+            Assert.ThrowsAny<ArgumentException>(() => options.OnSetup.CleanMatchingBlobs(filters: (BlobNameFilter) null));
             Assert.ThrowsAny<ArgumentException>(() => options.OnSetup.CleanMatchingBlobs(BlobNameFilter.NameEqual("some-name"), null));
         }
 
@@ -23,7 +27,8 @@ namespace Arcus.Testing.Tests.Unit.Storage
             var options = new TemporaryBlobContainerOptions();
 
             // Act / Assert
-            Assert.ThrowsAny<ArgumentException>(() => options.OnTeardown.CleanMatchingBlobs(filters: null));
+            Assert.ThrowsAny<ArgumentException>(() => options.OnTeardown.CleanMatchingBlobs(filters: (Func<BlobItem, bool>) null));
+            Assert.ThrowsAny<ArgumentException>(() => options.OnTeardown.CleanMatchingBlobs(filters: (BlobNameFilter) null));
             Assert.ThrowsAny<ArgumentException>(() => options.OnTeardown.CleanMatchingBlobs(BlobNameFilter.NameEqual("some-name"), null));
         }
     }


### PR DESCRIPTION
Remove unnecessary/duplicated functionality on the `TemporaryBlobFile` that could/should already be configured on the container.

Closes #257 
Closes #256 