### PR TITLE
chore(table): deprecate unnecessary az table functionality

### DIFF
--- a/docs/preview/03-Features/04-Azure/04-Storage/01-storage-account.mdx
+++ b/docs/preview/03-Features/04-Azure/04-Storage/01-storage-account.mdx
@@ -222,10 +222,7 @@ await TemporaryTable.CreateIfNotExistsAsync(..., options =>
 
     // Delete Azure Table entities that matches any of the configured filters, 
     // upon the test fixture creation, when there was already an Azure Table available.
-    options.OnSetup.CleanMatchingEntities(
-      TableEntityFilter.RowKeyEqual("<row-key>"),
-      TableEntityFilter.PartitionKeyEqual("<partition-key>"),
-      TableEntityFilter.EntityEqual((TableEntity entity) => entity["Key"] == "Value"));
+    options.OnSetup.CleanMatchingEntities((TableEntity entity) => entity["Test"] = "Value");
 
     // Options related to when the test fixture is teared down.
     // --------------------------------------------------------
@@ -241,10 +238,7 @@ await TemporaryTable.CreateIfNotExistsAsync(..., options =>
     // Delete additional Azure Table entities that matches any of the configured filters, 
     // upon the test fixture disposal.
     // ⚠️ Entities added by the test fixture itself will always be deleted.
-    options.OnTeardown.CleanMatchingEntities(
-      TableEntityFilter.RowKeyEqual("<row-key>"),
-      TableEntityFilter.PartitionKeyEqual("<partition-key>"),
-      TableEntityFilter.EntityEqual((TableEntity entity) => entity["Key"] == "Value"));
+    options.OnTeardown.CleanMatchingEntities((TableEntity entity) => entity["Test"] = "Value");
 });
 
 // `OnTeardown` is also still available after the temporary table is created:

--- a/src/Arcus.Testing.Tests.Integration/Storage/TemporaryTableTests.cs
+++ b/src/Arcus.Testing.Tests.Integration/Storage/TemporaryTableTests.cs
@@ -6,6 +6,8 @@ using Azure.Data.Tables;
 using Xunit;
 using Xunit.Abstractions;
 
+#pragma warning disable CS0618 // Ignore obsolete warnings that we added ourselves, should be removed upon releasing v2.0.
+
 namespace Arcus.Testing.Tests.Integration.Storage
 {
     public class TemporaryTableTests : IntegrationTest
@@ -88,7 +90,7 @@ namespace Arcus.Testing.Tests.Integration.Storage
             TableEntity createdBefore = await context.WhenTableEntityAvailableAsync(client);
 
             // Act
-            TemporaryTable _ = await CreateTempTableAsync(client, options =>
+            _ = await CreateTempTableAsync(client, options =>
             {
                 options.OnSetup.CleanAllEntities();
             });
@@ -105,7 +107,7 @@ namespace Arcus.Testing.Tests.Integration.Storage
 
             TableClient client = await context.WhenTableAvailableAsync();
             TableEntity createdBefore = await context.WhenTableEntityAvailableAsync(client);
-            
+
             TemporaryTable temp = await CreateTempTableAsync(client, options =>
             {
                 options.OnTeardown.CleanAllEntities();
@@ -136,7 +138,14 @@ namespace Arcus.Testing.Tests.Integration.Storage
             // Act
             TemporaryTable temp = await CreateTempTableAsync(client, options =>
             {
-                options.OnSetup.CleanMatchingEntities(CreateMatchFilter(matchedEntity));
+                if (Bogus.Random.Bool())
+                {
+                    options.OnSetup.CleanMatchingEntities(CreateDeprecatedMatchFilter(matchedEntity));
+                }
+                else
+                {
+                    options.OnSetup.CleanMatchingEntities(entity => entity.RowKey == matchedEntity.RowKey);
+                }
             });
 
             // Assert
@@ -162,7 +171,14 @@ namespace Arcus.Testing.Tests.Integration.Storage
             // Act
             TemporaryTable temp = await CreateTempTableAsync(client, options =>
             {
-                options.OnTeardown.CleanMatchingEntities(CreateMatchFilter(matchedEntity));
+                if (Bogus.Random.Bool())
+                {
+                    options.OnTeardown.CleanMatchingEntities(CreateDeprecatedMatchFilter(matchedEntity));
+                }
+                else
+                {
+                    options.OnTeardown.CleanMatchingEntities(entity => entity.RowKey == matchedEntity.RowKey);
+                }
             });
 
             // Assert
@@ -194,7 +210,7 @@ namespace Arcus.Testing.Tests.Integration.Storage
             TableEntity createdByUs = await AddTableEntityAsync(context, temp);
             TableEntity matched = await context.WhenTableEntityAvailableAsync(client);
             TableEntity notMatched = await context.WhenTableEntityAvailableAsync(client);
-            temp.OnTeardown.CleanMatchingEntities(CreateMatchFilter(matched));
+            temp.OnTeardown.CleanMatchingEntities(CreateDeprecatedMatchFilter(matched));
 
             // Act
             await temp.DisposeAsync();
@@ -205,7 +221,7 @@ namespace Arcus.Testing.Tests.Integration.Storage
             await context.ShouldStoreTableEntityAsync(client, notMatched);
         }
 
-        private static TableEntityFilter CreateMatchFilter(TableEntity entity)
+        private static TableEntityFilter CreateDeprecatedMatchFilter(TableEntity entity)
         {
             return Bogus.Random.Int(1, 3) switch
             {

--- a/src/Arcus.Testing.Tests.Unit/Storage/TemporaryTableTests.cs
+++ b/src/Arcus.Testing.Tests.Unit/Storage/TemporaryTableTests.cs
@@ -1,11 +1,12 @@
 ﻿using System;
 using System.Threading.Tasks;
 using Azure.Data.Tables;
-using Azure.Identity;
 using Bogus;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Xunit;
+
+#pragma warning disable CS0618 // Ignore obsolete warnings that we added ourselves, should be removed upon releasing v2.0.
 
 namespace Arcus.Testing.Tests.Unit.Storage
 {
@@ -35,7 +36,8 @@ namespace Arcus.Testing.Tests.Unit.Storage
             var options = new TemporaryTableOptions();
 
             // Act / Assert
-            Assert.ThrowsAny<ArgumentException>(() => options.OnSetup.CleanMatchingEntities(null));
+            Assert.ThrowsAny<ArgumentException>(() => options.OnSetup.CleanMatchingEntities((Func<TableEntity, bool>) null));
+            Assert.ThrowsAny<ArgumentException>(() => options.OnSetup.CleanMatchingEntities((TableEntityFilter) null));
             Assert.ThrowsAny<ArgumentException>(() => options.OnSetup.CleanMatchingEntities(TableEntityFilter.RowKeyEqual("<row-key>"), null));
         }
 
@@ -46,7 +48,8 @@ namespace Arcus.Testing.Tests.Unit.Storage
             var options = new TemporaryTableOptions();
 
             // Act / Assert
-            Assert.ThrowsAny<ArgumentException>(() => options.OnTeardown.CleanMatchingEntities(null));
+            Assert.ThrowsAny<ArgumentException>(() => options.OnTeardown.CleanMatchingEntities((Func<TableEntity, bool>) null));
+            Assert.ThrowsAny<ArgumentException>(() => options.OnTeardown.CleanMatchingEntities((TableEntityFilter) null));
             Assert.ThrowsAny<ArgumentException>(() => options.OnTeardown.CleanMatchingEntities(TableEntityFilter.PartitionKeyEqual("<partition-key>"), null));
         }
 


### PR DESCRIPTION
Deprecate unnecessary functionality that adds an additional layer of abstraction for the `TemporaryTable` filters.

Developers are used to having delegates `Func<...>` when they see `Where`/`Match` functions. Having an extra type only overcomplicates things.

Closes #259