### PR TITLE
chore(cosmos): deprecate unnecessary az cosmos nosql functionality

### DIFF
--- a/docs/preview/03-Features/04-Azure/04-Storage/02-cosmos.mdx
+++ b/docs/preview/03-Features/04-Azure/04-Storage/02-cosmos.mdx
@@ -190,9 +190,8 @@ await TemporaryNoSqlContainer.CreateIfNotExistsAsync(..., options =>
 
     // Delete all NoSql items that matches any of the configured filters,
     // upon the test fixture creation, when there was already a NoSql container available.
-    options.OnSetup.CleanMatchingItems(
-        NoSqlItemFilter.Where(ship => ship["BoatName"] == "The Alice"),
-        NoSqlItemFilter.ItemIdEqual("123"));
+    options.OnSetup.CleanMatchingItems((NoSqlItem item) => item.Id == "123");
+    options.OnSetup.CleanMatchingItems((Shipment item) => item.BoatName == "The Alice");
     
     // Options related to when the test fixture is teared down.
     // --------------------------------------------------------
@@ -207,9 +206,8 @@ await TemporaryNoSqlContainer.CreateIfNotExistsAsync(..., options =>
     // Delete all NoSql items that matches any of the configured filters,
     // upon the test fixture disposal, even if the test fixture didn't inserted them.
     // ⚠️ NoSql items inserted by the test fixture will always be deleted, regardless of the configured filters.
-    options.OnTeardown.CleanMatchingItems(
-        NoSqlItemFilter.Where((Shipment s) => s.BoatName == "The Alice"),
-        NoSqlItemFilter.IdEqual("123"));
+    options.OnTeardown.CleanMatchingItems((NoSqlItem item) => item.Id == "123"); 
+    options.OnTeardown.CleanMatchingItems((Shipment item) => item.BoatName == "The Alice");
 });
 
 // `OnTeardown` is also still available after the temporary container is created:

--- a/src/Arcus.Testing.Storage.Cosmos/TemporaryNoSqlContainer.cs
+++ b/src/Arcus.Testing.Storage.Cosmos/TemporaryNoSqlContainer.cs
@@ -294,7 +294,7 @@ namespace Arcus.Testing
             var item = new NoSqlItem(itemId, partitionKey, itemStream);
 
             return _typedFilters.Exists(filter => filter.IsMatch(itemId, partitionKey, itemStream, client))
-                || _genericFilters.Exists(filter => filter(item));
+                   || _genericFilters.Exists(filter => filter(item));
         }
     }
 

--- a/src/Arcus.Testing.Tests.Integration/Storage/TemporaryNoSqlContainerTests.cs
+++ b/src/Arcus.Testing.Tests.Integration/Storage/TemporaryNoSqlContainerTests.cs
@@ -160,7 +160,7 @@ namespace Arcus.Testing.Tests.Integration.Storage
                 }
                 else
                 {
-                    options.OnTeardown.CleanMatchingItems(item => item.Id == createdMatched.Id)
+                    options.OnTeardown.CleanMatchingItems(item => item.PartitionKey == createdMatched.GetPartitionKey())
                                       .CleanMatchingItems((Ship item) => item.GetPartitionKey() == createdMatched.GetPartitionKey());
                 }
             });
@@ -258,7 +258,7 @@ namespace Arcus.Testing.Tests.Integration.Storage
                 .RuleFor(s => s.Id, f => header + "item-" + f.Random.Guid())
                 .RuleFor(s => s.BoatName, f => f.Person.FirstName)
                 .RuleFor(s => s.CrewMembers, f => f.Random.Int(1, 10))
-                .RuleFor(s => s.Destination, f => new Destination { Country = f.Address.Country() })
+                .RuleFor(s => s.Destination, f => new Destination { Country = f.Random.Guid() + f.Address.Country() })
                 .Generate();
         }
 

--- a/src/Arcus.Testing.Tests.Unit/Storage/NoSqlItemFilterTests.cs
+++ b/src/Arcus.Testing.Tests.Unit/Storage/NoSqlItemFilterTests.cs
@@ -2,6 +2,8 @@
 using Bogus;
 using Xunit;
 
+#pragma warning disable CS0618 // Ignore obsolete warnings that we added ourselves, should be removed upon releasing v2.0.
+
 namespace Arcus.Testing.Tests.Unit.Storage
 {
     public class NoSqlItemFilterTests

--- a/src/Arcus.Testing.Tests.Unit/Storage/TemporaryNoSqlContainerOptionsTests.cs
+++ b/src/Arcus.Testing.Tests.Unit/Storage/TemporaryNoSqlContainerOptionsTests.cs
@@ -1,5 +1,8 @@
 ﻿using System;
+using Bogus;
 using Xunit;
+
+#pragma warning disable CS0618 // Ignore obsolete warnings that we added ourselves, should be removed upon releasing v2.0.
 
 namespace Arcus.Testing.Tests.Unit.Storage
 {
@@ -12,7 +15,9 @@ namespace Arcus.Testing.Tests.Unit.Storage
             var options = new TemporaryNoSqlContainerOptions();
 
             // Act / Assert
-            Assert.ThrowsAny<ArgumentException>(() => options.OnSetup.CleanMatchingItems(null));
+            Assert.ThrowsAny<ArgumentException>(() => options.OnSetup.CleanMatchingItems((Func<Person, bool>) null));
+            Assert.ThrowsAny<ArgumentException>(() => options.OnSetup.CleanMatchingItems((Func<NoSqlItem, bool>) null));
+            Assert.ThrowsAny<ArgumentException>(() => options.OnSetup.CleanMatchingItems((NoSqlItemFilter) null));
             Assert.ThrowsAny<ArgumentException>(() => options.OnSetup.CleanMatchingItems(NoSqlItemFilter.IdEqual("some-id"), null));
         }
 
@@ -23,7 +28,9 @@ namespace Arcus.Testing.Tests.Unit.Storage
             var options = new TemporaryNoSqlContainerOptions();
 
             // Act / Assert
-            Assert.ThrowsAny<ArgumentException>(() => options.OnTeardown.CleanMatchingItems(null));
+            Assert.ThrowsAny<ArgumentException>(() => options.OnTeardown.CleanMatchingItems((Func<Person, bool>) null));
+            Assert.ThrowsAny<ArgumentException>(() => options.OnTeardown.CleanMatchingItems((Func<NoSqlItem, bool>) null));
+            Assert.ThrowsAny<ArgumentException>(() => options.OnTeardown.CleanMatchingItems((NoSqlItemFilter) null));
             Assert.ThrowsAny<ArgumentException>(() => options.OnTeardown.CleanMatchingItems(NoSqlItemFilter.IdEqual("some-id"), null));
         }
     }


### PR DESCRIPTION
Mark the `NoSqlFilter` as deprecated in favor of a more dev-friendly direct predicate function.

Developers are used to having delegates `Func<...>` when they see `Where`/`Match` functions. Having an extra type only overcomplicates things.

Closes #261 