### PR TITLE
chore: open test-config for extension

### DIFF
--- a/docs/preview/03-Features/01-core.md
+++ b/docs/preview/03-Features/01-core.md
@@ -64,6 +64,9 @@ var config = TestConfig.Create(options =>
 
     // Adds 'configuration.Dev.json' to local alternatives [ 'appsettings.local.json' ]
     options.AddOptionalJsonFile("configuration.Dev.json");
+
+    // Or other methods for `ConfigurationBuilder`
+    options.AddEnvironmentVariables();
 });
 ```
 

--- a/src/Arcus.Testing.Core/TestConfig.cs
+++ b/src/Arcus.Testing.Core/TestConfig.cs
@@ -9,7 +9,7 @@ namespace Arcus.Testing
     /// <summary>
     /// Represents the available options for the <see cref="TestConfig"/>.
     /// </summary>
-    public class TestConfigOptions
+    public class TestConfigOptions : ConfigurationBuilder
     {
         private readonly Collection<string> _localAppSettingsNames = new() { "appsettings.local.json" };
 
@@ -47,7 +47,7 @@ namespace Arcus.Testing
         /// Gets the main JSON path to the configuration source.
         /// </summary>
         internal string MainJsonPath { get; private set; } = "appsettings.json";
-        
+
         /// <summary>
         /// Gets all the configured additional JSON paths to files that acts as configuration sources.
         /// </summary>
@@ -78,15 +78,14 @@ namespace Arcus.Testing
             var options = new TestConfigOptions();
             configureOptions?.Invoke(options);
 
-            IConfigurationBuilder builder = new ConfigurationBuilder()
-                .AddJsonFile(options.MainJsonPath, optional: true);
+            options.AddJsonFile(options.MainJsonPath, optional: true);
 
             foreach (string path in options.OptionalJsonPaths)
             {
-                builder.AddJsonFile(path, optional: true);
+                options.AddJsonFile(path, optional: true);
             }
 
-            _implementation = builder.Build();
+            _implementation = options.Build();
             _options = options;
         }
 
@@ -104,7 +103,7 @@ namespace Arcus.Testing
         /// <param name="configureOptions">The function to configure the options that describe where the test configuration should be retrieved from.</param>
         public static TestConfig Create(Action<TestConfigOptions> configureOptions)
         {
-           return new TestConfig(configureOptions);
+            return new TestConfig(configureOptions);
         }
 
         /// <summary>

--- a/src/Arcus.Testing.Tests.Integration/Core/TestConfigTests.cs
+++ b/src/Arcus.Testing.Tests.Integration/Core/TestConfigTests.cs
@@ -6,6 +6,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Arcus.Testing.Tests.Integration.Core.Fixture;
 using Bogus;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
 using Newtonsoft.Json.Linq;
 using Xunit;
@@ -44,7 +45,7 @@ namespace Arcus.Testing.Tests.Integration.Core
             {
                 options.UseMainJsonFile(mainAppSettingsName)
                        .AddOptionalJsonFile(localAppSettingsName1)
-                       .AddOptionalJsonFile(localAppSettingsName2);
+                       .AddJsonFile(localAppSettingsName2, optional: true);
             });
 
             // Act / Assert
@@ -55,8 +56,8 @@ namespace Arcus.Testing.Tests.Integration.Core
         private void AddLocalValueToCustomMain(string fileName, string key, string value, string newMainFile)
         {
             _disposables.Add(TemporaryFile.CreateAt(
-                CurrentDirectory.Path, 
-                fileName, 
+                CurrentDirectory.Path,
+                fileName,
                 Encoding.UTF8.GetBytes($"{{ \"{key}\": \"{value}\" }}")));
 
             AddTokenToCustomMain(key, newMainFile);
@@ -122,8 +123,8 @@ namespace Arcus.Testing.Tests.Integration.Core
         private void AddLocalValueToDefaultMain(string fileName, string key, string value)
         {
             _disposables.Add(TemporaryFile.CreateAt(
-                CurrentDirectory.Path, 
-                fileName, 
+                CurrentDirectory.Path,
+                fileName,
                 Encoding.UTF8.GetBytes($"{{ \"{key}\": \"{value}\" }}")));
 
             AddTokenToDefaultMain(key);


### PR DESCRIPTION
Small improvement with a big impact. By letting the `TestConfigOptions` inherit `ConfigurationBuilder`, we open up the `IConfiguration` build-up for other usages besides the `appsettings.json` files. It could very well be, in certain security scenarios where you do not want secrets to be exposed as mere values in a local file, but only via environment variables or even Key vault. By opening up, people can choose whatever system they want, but still use `appsettings.json` as a backbone.