### PR TITLE
fix: deprecate logger core package

### DIFF
--- a/src/Arcus.Testing.Logging.Core/Arcus.Testing.Logging.Core.csproj
+++ b/src/Arcus.Testing.Logging.Core/Arcus.Testing.Logging.Core.csproj
@@ -7,10 +7,10 @@
     <Company>Arcus</Company>
     <Description>Provides logging capabilities during Arcus testing</Description>
     <Copyright>Copyright (c) Arcus</Copyright>
-    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <WarningsNotAsErrors>$(WarningsNotAsErrors);NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);NU1901;NU1902;NU1903;NU1904;CS6018</WarningsNotAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Arcus.Testing.Logging.Core/CustomLoggerProvider.cs
+++ b/src/Arcus.Testing.Logging.Core/CustomLoggerProvider.cs
@@ -6,6 +6,9 @@ namespace Arcus.Testing
     /// <summary>
     /// Custom <see cref="ILoggerProvider"/> that creates a custom <see cref="ILogger"/> provider.
     /// </summary>
+#pragma warning disable S1133
+    [Obsolete("Will be removed in v2.0, use the specific logging packages (Xunit, NUnit, MSTest) instead")]
+#pragma warning restore
     public class CustomLoggerProvider : ILoggerProvider
     {
         private readonly ILogger _logger;

--- a/src/Arcus.Testing.Logging.Core/InMemoryLogSink.cs
+++ b/src/Arcus.Testing.Logging.Core/InMemoryLogSink.cs
@@ -10,11 +10,13 @@ namespace Arcus.Testing
     /// <summary>
     /// Represents a logging sink that collects the emitted log events in-memory.
     /// </summary>
+#pragma warning disable S1133
     [Obsolete("Arcus.Testing.Logging.Core will stop supporting Serilog by default, please implement Serilog sinks yourself as this sink will be removed in v2.0")]
+#pragma warning restore
     public class InMemoryLogSink : ILogEventSink
     {
         private readonly ConcurrentQueue<LogEvent> _logEmits = new ConcurrentQueue<LogEvent>();
-        
+
         /// <summary>
         /// Gets the current log emits available on the sink.
         /// </summary>
@@ -24,7 +26,7 @@ namespace Arcus.Testing
         /// Gets the current messages of the log emits available on the sink.
         /// </summary>
         public IEnumerable<string> CurrentLogMessages => CurrentLogEmits.Select(emit => emit.RenderMessage());
-        
+
         /// <summary>
         /// Emit the provided log event to the sink.
         /// </summary>

--- a/src/Arcus.Testing.Logging.Core/InMemoryLogger.cs
+++ b/src/Arcus.Testing.Logging.Core/InMemoryLogger.cs
@@ -9,6 +9,9 @@ namespace Arcus.Testing
     /// <summary>
     /// Spy (stub) <see cref="ILogger"/> implementation to track the logged messages in-memory.
     /// </summary>
+#pragma warning disable S1133
+    [Obsolete("Will be removed in v2.0, use the specific logging packages (Xunit, NUnit, MSTest) instead")]
+#pragma warning restore
     public class InMemoryLogger : ILogger
     {
         private readonly ConcurrentQueue<LogEntry> _entries = new ConcurrentQueue<LogEntry>();

--- a/src/Arcus.Testing.Logging.Core/InMemoryLoggerT.cs
+++ b/src/Arcus.Testing.Logging.Core/InMemoryLoggerT.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.Logging;
+﻿using System;
+using Microsoft.Extensions.Logging;
 
 namespace Arcus.Testing
 {
@@ -6,6 +7,9 @@ namespace Arcus.Testing
     /// Spy (stub) <see cref="ILogger{TCategoryName}"/> implementation to track the logged messages in-memory.
     /// </summary>
     /// <typeparam name="T">The type who's name is used for the logger category name.</typeparam>
+#pragma warning disable S1133
+    [Obsolete("Will be removed in v2.0, use the specific logging packages (Xunit, NUnit, MSTest) instead")]
+#pragma warning restore
     public class InMemoryLogger<T> : InMemoryLogger, ILogger<T>
     {
     }

--- a/src/Arcus.Testing.Logging.Core/LogEntry.cs
+++ b/src/Arcus.Testing.Logging.Core/LogEntry.cs
@@ -6,6 +6,9 @@ namespace Arcus.Testing
     /// <summary>
     /// Represents a logged message by a <see cref="ILogger"/> instance.
     /// </summary>
+#pragma warning disable S1133
+    [Obsolete("Will be removed in v2.0, use the specific logging packages (Xunit, NUnit, MSTest) instead")]
+#pragma warning restore
     public class LogEntry
     {
         /// <summary>

--- a/src/Arcus.Testing.Logging.MSTest/Arcus.Testing.Logging.MSTest.csproj
+++ b/src/Arcus.Testing.Logging.MSTest/Arcus.Testing.Logging.MSTest.csproj
@@ -32,7 +32,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!-- TODO: reference will be removed in v2.0 -->
     <ProjectReference Include="..\Arcus.Testing.Logging.Core\Arcus.Testing.Logging.Core.csproj" />
+    <!-- TODO: reference will be removed in v2.0 -->
   </ItemGroup>
 
 </Project>

--- a/src/Arcus.Testing.Logging.MSTest/Extensions/ILoggerBuilderExtensions.cs
+++ b/src/Arcus.Testing.Logging.MSTest/Extensions/ILoggerBuilderExtensions.cs
@@ -22,10 +22,27 @@ namespace Microsoft.Extensions.Logging
             ArgumentNullException.ThrowIfNull(builder);
             ArgumentNullException.ThrowIfNull(testContext);
 
-            var logger = new MSTestLogger(testContext);
-            var provider = new CustomLoggerProvider(logger);
-
+            var provider = new MSTestLoggerProvider(testContext);
             return builder.AddProvider(provider);
+        }
+
+        private sealed class MSTestLoggerProvider : ILoggerProvider
+        {
+            private readonly ILogger _logger;
+
+            public MSTestLoggerProvider(TestContext context)
+            {
+                _logger = new MSTestLogger(context);
+            }
+
+            public ILogger CreateLogger(string categoryName)
+            {
+                return _logger;
+            }
+
+            public void Dispose()
+            {
+            }
         }
     }
 }

--- a/src/Arcus.Testing.Logging.MSTest/Extensions/LoggerSinkConfigurationExtensions.cs
+++ b/src/Arcus.Testing.Logging.MSTest/Extensions/LoggerSinkConfigurationExtensions.cs
@@ -16,7 +16,9 @@ namespace Serilog.Configuration
         /// <param name="config">The Serilog sink configuration where the NUnit test logging will be added.</param>
         /// <param name="testContext">The MSTest test writer to write custom test output.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="config"/> or <paramref name="testContext"/> is <c>null</c>.</exception>
+#pragma warning disable S1133
         [Obsolete("Arcus.Testing.Logging.MSTest will stop supporting Serilog by default, please implement Serilog sinks yourself as this extension will be removed in v2.0")]
+#pragma warning restore
         public static LoggerConfiguration MSTestLogging(this LoggerSinkConfiguration config, TestContext testContext)
         {
             if (config is null)

--- a/src/Arcus.Testing.Logging.MSTest/MSTestLogEventSink.cs
+++ b/src/Arcus.Testing.Logging.MSTest/MSTestLogEventSink.cs
@@ -8,7 +8,9 @@ namespace Arcus.Testing
     /// <summary>
     /// <see cref="ILogEventSink"/> representation of an <see cref="MSTestLogger"/> instance.
     /// </summary>
+#pragma warning disable S1133
     [Obsolete("Arcus.Testing.Logging.MSTest will stop supporting Serilog by default, please implement Serilog sinks yourself as this sink will be removed in v2.0")]
+#pragma warning restore
     public class MSTestLogEventSink : ILogEventSink
     {
         private readonly TestContext _context;

--- a/src/Arcus.Testing.Logging.NUnit/Arcus.Testing.Logging.NUnit.csproj
+++ b/src/Arcus.Testing.Logging.NUnit/Arcus.Testing.Logging.NUnit.csproj
@@ -28,7 +28,8 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!-- TODO: reference will be removed in v2.0 -->
     <ProjectReference Include="..\Arcus.Testing.Logging.Core\Arcus.Testing.Logging.Core.csproj" />
-  </ItemGroup>
+    <!-- TODO: reference will be removed in v2.0 -->  </ItemGroup>
 
 </Project>

--- a/src/Arcus.Testing.Logging.NUnit/Extensions/ILoggerBuilderExtensions.cs
+++ b/src/Arcus.Testing.Logging.NUnit/Extensions/ILoggerBuilderExtensions.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Extensions.Logging
             ArgumentNullException.ThrowIfNull(outputWriter);
 
             var logger = new NUnitTestLogger(outputWriter);
-            var provider = new CustomLoggerProvider(logger);
+            var provider = new NUnitLoggerProvider(logger);
 
             return builder.AddProvider(provider);
         }
@@ -41,9 +41,28 @@ namespace Microsoft.Extensions.Logging
             ArgumentNullException.ThrowIfNull(outputWriter);
 
             var logger = new NUnitTestLogger(outputWriter, errorWriter);
-            var provider = new CustomLoggerProvider(logger);
+            var provider = new NUnitLoggerProvider(logger);
 
             return builder.AddProvider(provider);
+        }
+
+        private sealed class NUnitLoggerProvider : ILoggerProvider
+        {
+            private readonly NUnitTestLogger _logger;
+
+            public NUnitLoggerProvider(NUnitTestLogger logger)
+            {
+                _logger = logger;
+            }
+
+            public ILogger CreateLogger(string categoryName)
+            {
+                return _logger;
+            }
+
+            public void Dispose()
+            {
+            }
         }
     }
 }

--- a/src/Arcus.Testing.Logging.Xunit/Arcus.Testing.Logging.Xunit.csproj
+++ b/src/Arcus.Testing.Logging.Xunit/Arcus.Testing.Logging.Xunit.csproj
@@ -32,7 +32,8 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!-- TODO: reference will be removed in v2.0 -->
     <ProjectReference Include="..\Arcus.Testing.Logging.Core\Arcus.Testing.Logging.Core.csproj" />
-  </ItemGroup>
+    <!-- TODO: reference will be removed in v2.0 -->  </ItemGroup>
 
 </Project>

--- a/src/Arcus.Testing.Logging.Xunit/Extensions/ILoggerBuilderExtensions.cs
+++ b/src/Arcus.Testing.Logging.Xunit/Extensions/ILoggerBuilderExtensions.cs
@@ -22,10 +22,27 @@ namespace Microsoft.Extensions.Logging
             ArgumentNullException.ThrowIfNull(builder);
             ArgumentNullException.ThrowIfNull(outputWriter);
 
-            var logger = new XunitTestLogger(outputWriter);
-            var provider = new CustomLoggerProvider(logger);
-
+            var provider = new XunitLoggerProvider(outputWriter);
             return builder.AddProvider(provider);
+        }
+
+        private sealed class XunitLoggerProvider : ILoggerProvider
+        {
+            private readonly ILogger _logger;
+
+            public XunitLoggerProvider(ITestOutputHelper outputWriter)
+            {
+                _logger = new XunitTestLogger(outputWriter);
+            }
+
+            public ILogger CreateLogger(string categoryName)
+            {
+                return _logger;
+            }
+
+            public void Dispose()
+            {
+            }
         }
     }
 }


### PR DESCRIPTION
The logger core package is actually deprecated in the sense that we don't/shouldn't support these very technical in-memory stuff, in favor of having test framework-specific packages.

The core package was made to not create a NuGet package anymore before, but that caused issues related to project references of the other packages. Therefore, we still have to generate such a package until v2.0.

All functionality in the core package is made deprecated here. 