### PR TITLE
chore(setup): add az env test config

### DIFF
--- a/src/Arcus.Testing.Tests.Integration/Configuration/AzureEnvironment.cs
+++ b/src/Arcus.Testing.Tests.Integration/Configuration/AzureEnvironment.cs
@@ -1,0 +1,45 @@
+﻿namespace Arcus.Testing.Tests.Integration.Configuration
+{
+    /// <summary>
+    /// Represents the environment on Azure where a set of test resources are located.
+    /// </summary>
+    public class AzureEnvironment
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AzureEnvironment" /> class.
+        /// </summary>
+        public AzureEnvironment(
+            string subscriptionId,
+            string resourceGroupName)
+        {
+            SubscriptionId = subscriptionId;
+            ResourceGroupName = resourceGroupName;
+        }
+
+        /// <summary>
+        /// Gets the subscription ID for the set of test resources.
+        /// </summary>
+        public string SubscriptionId { get; }
+
+        /// <summary>
+        /// Gets the resource group name for the set of test resources.
+        /// </summary>
+        public string ResourceGroupName { get; }
+    }
+
+    /// <summary>
+    /// Extensions on the <see cref="TestConfig"/> for more test-friendly interaction.
+    /// </summary>
+    public static partial class TestConfigExtensions
+    {
+        /// <summary>
+        /// Loads the <see cref="AzureEnvironment"/> from the current test <paramref name="config"/>.
+        /// </summary>
+        public static AzureEnvironment GetAzureEnvironment(this TestConfig config)
+        {
+            return new AzureEnvironment(
+                config["Arcus:SubscriptionId"],
+                config["Arcus:ResourceGroup:Name"]);
+        }
+    }
+}

--- a/src/Arcus.Testing.Tests.Integration/Configuration/ServicePrincipal.cs
+++ b/src/Arcus.Testing.Tests.Integration/Configuration/ServicePrincipal.cs
@@ -15,11 +15,11 @@
         public string TenantId { get; }
 
         public string ClientId { get; }
-        
+
         public string ClientSecret { get; }
     }
 
-    public static class TestConfigExtensions
+    public static partial class TestConfigExtensions
     {
         public static ServicePrincipal GetServicePrincipal(this TestConfig config)
         {

--- a/src/Arcus.Testing.Tests.Integration/Integration/DataFactory/Configuration/DataFactoryConfig.cs
+++ b/src/Arcus.Testing.Tests.Integration/Integration/DataFactory/Configuration/DataFactoryConfig.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using Arcus.Testing.Tests.Integration.Configuration;
 using Azure.Core;
+using Azure.ResourceManager.DataFactory;
 
 // ReSharper disable once CheckNamespace
 namespace Arcus.Testing
@@ -13,16 +15,14 @@ namespace Arcus.Testing
         /// Initializes a new instance of the <see cref="DataFactoryConfig" /> class.
         /// </summary>
         public DataFactoryConfig(
-            string subscriptionId, 
-            string resourceGroupName, 
-            string resourceName)
+            string factoryName,
+            ResourceIdentifier factoryResourceId)
         {
-            ArgumentException.ThrowIfNullOrWhiteSpace(subscriptionId);
-            ArgumentException.ThrowIfNullOrWhiteSpace(resourceGroupName);
-            ArgumentException.ThrowIfNullOrWhiteSpace(resourceName);
+            ArgumentException.ThrowIfNullOrWhiteSpace(factoryName);
+            ArgumentNullException.ThrowIfNull(factoryResourceId);
 
-            Name = resourceName;
-            ResourceId = ResourceIdentifier.Parse($"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DataFactory/factories/{resourceName}");
+            Name = factoryName;
+            ResourceId = factoryResourceId;
         }
 
         /// <summary>
@@ -37,7 +37,7 @@ namespace Arcus.Testing
     }
 
     /// <summary>
-    /// Extensions on the <see cref="TestConfig"/> for more easier access to the <see cref="DataFactoryConfig"/>.
+    /// Extensions on the <see cref="TestConfig"/> for easier access to the <see cref="DataFactoryConfig"/>.
     /// </summary>
     public static class TestConfigExtensions
     {
@@ -46,10 +46,15 @@ namespace Arcus.Testing
         /// </summary>
         public static DataFactoryConfig GetDataFactory(this TestConfig config)
         {
+            AzureEnvironment env = config.GetAzureEnvironment();
+
+            string factoryName = config["Arcus:DataFactory:Name"];
+            ResourceIdentifier factoryResourceId =
+                DataFactoryResource.CreateResourceIdentifier(env.SubscriptionId, env.ResourceGroupName, factoryName);
+
             return new DataFactoryConfig(
-                config["Arcus:SubscriptionId"],
-                config["Arcus:ResourceGroup:Name"],
-                config["Arcus:DataFactory:Name"]);
+                factoryName,
+                factoryResourceId);
         }
     }
 }

--- a/src/Arcus.Testing.Tests.Integration/Integration/DataFactory/Fixture/TemporaryDataFactoryDataFlow.cs
+++ b/src/Arcus.Testing.Tests.Integration/Integration/DataFactory/Fixture/TemporaryDataFactoryDataFlow.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using Arcus.Testing.Tests.Integration.Configuration;
 using Arcus.Testing.Tests.Integration.Storage.Configuration;
 using Azure;
 using Azure.Core;
@@ -50,6 +51,10 @@ namespace Arcus.Testing.Tests.Integration.Integration.DataFactory.Fixture
             _config = config;
             _logger = logger;
 
+            var env = config.GetAzureEnvironment();
+            SubscriptionId = env.SubscriptionId;
+            ResourceGroupName = env.ResourceGroupName;
+
             Name = RandomizeWith("dataFlow");
             SourceName = RandomizeWith("sourceName");
             SinkName = RandomizeWith("sinkName");
@@ -57,8 +62,8 @@ namespace Arcus.Testing.Tests.Integration.Integration.DataFactory.Fixture
             SourceDataSetName = RandomizeWith("sourceDataSet");
         }
 
-        private string SubscriptionId => _config["Arcus:SubscriptionId"];
-        private string ResourceGroupName => _config["Arcus:ResourceGroup:Name"];
+        private string SubscriptionId { get; }
+        private string ResourceGroupName { get; }
         private DataFactoryConfig DataFactory => _config.GetDataFactory();
         private StorageAccount StorageAccount => _config.GetStorageAccount();
 

--- a/src/Arcus.Testing.Tests.Integration/Storage/Configuration/CosmosDbConfig.cs
+++ b/src/Arcus.Testing.Tests.Integration/Storage/Configuration/CosmosDbConfig.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using Arcus.Testing.Tests.Integration.Configuration;
 using Azure.Core;
+using Azure.ResourceManager.CosmosDB;
 
 // ReSharper disable once CheckNamespace
 namespace Arcus.Testing
@@ -9,88 +11,71 @@ namespace Arcus.Testing
         /// <summary>
         /// Initializes a new instance of the <see cref="CosmosDbConfig" /> class.
         /// </summary>
-        public CosmosDbConfig(ResourceIdentifier resourceId, MongoDbConfig mongoDb, NoSqlConfig noSql)
+        public CosmosDbConfig(ResourceIdentifier accountResourceId, string accountName, string databaseName)
         {
-            Name = resourceId.Name;
-            Endpoint = new Uri("https://arcus-testing-cosmos.mongo.cosmos.azure.com/").ToString();
-            ResourceId = resourceId;
-            MongoDb = mongoDb;
-            NoSql = noSql;
-        }
+            ArgumentNullException.ThrowIfNull(accountResourceId);
+            ArgumentException.ThrowIfNullOrWhiteSpace(accountName);
+            ArgumentException.ThrowIfNullOrWhiteSpace(databaseName);
 
-        public string Name { get; }
-        public string Endpoint { get; }
-        public ResourceIdentifier ResourceId { get; }
-        public MongoDbConfig MongoDb { get; }
-        public NoSqlConfig NoSql { get; }
-    }
-
-    public class MongoDbConfig
-    {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="MongoDbConfig" /> class.
-        /// </summary>
-        public MongoDbConfig(ResourceIdentifier resourceId, string accountName, string databaseName)
-        {
-            ResourceId = resourceId;
-            Name = accountName;
+            AccountName = accountName;
+            AccountEndpoint = new Uri($"https://{accountName}.documents.azure.com/");
+            AccountResourceId = accountResourceId;
             DatabaseName = databaseName;
         }
 
-        public string Name { get; }
-        public ResourceIdentifier ResourceId { get; }
-        public string DatabaseName { get; }
-    }
-
-    public class NoSqlConfig
-    {
         /// <summary>
-        /// Initializes a new instance of the <see cref="NoSqlConfig" /> class.
+        /// Gets the name of the Cosmos DB account associated with the current test setup.
         /// </summary>
-        public NoSqlConfig(ResourceIdentifier resourceId, string accountName, string databaseName)
-        {
-            ResourceId = resourceId;
-            DatabaseName = databaseName;
-            Endpoint = new Uri($"https://{accountName}.documents.azure.com/").ToString();
-        }
+        public string AccountName { get; }
 
-        public string Endpoint { get; }
-        public ResourceIdentifier ResourceId { get; }
+        /// <summary>
+        /// Gets the endpoint of the Cosmos DB account associated with the current test setup.
+        /// </summary>
+        public Uri AccountEndpoint { get; }
+
+        /// <summary>
+        /// Gets the resource ID of the Cosmos DB account associated with the current test setup.
+        /// </summary>
+        public ResourceIdentifier AccountResourceId { get; }
+
+        /// <summary>
+        /// Gets the name of the default database that was created on the Cosmos DB account associated with the current test setup.
+        /// </summary>
         public string DatabaseName { get; }
     }
 
+    /// <summary>
+    /// Extensions on the <see cref="TestConfig"/> for more test-friendly interaction.
+    /// </summary>
     public static class CosmosDbTestConfigExtensions
     {
-        public static MongoDbConfig GetMongoDb(this TestConfig config)
+        /// <summary>
+        /// Loads the <see cref="CosmosDbConfig"/> specific for the Mongo storage.
+        /// </summary>
+        public static CosmosDbConfig GetMongoDb(this TestConfig config)
         {
-            string subscriptionId = config["Arcus:SubscriptionId"];
-            string resourceGroupName = config["Arcus:ResourceGroup:Name"];
-            string cosmosDbName = config["Arcus:Cosmos:MongoDb:Name"];
-            var resourceId = ResourceIdentifier.Parse($"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{cosmosDbName}");
-            string databaseName = config["Arcus:Cosmos:MongoDb:DatabaseName"];
-
-            return new MongoDbConfig(
-                resourceId,
-                cosmosDbName,
-                databaseName);
+            return config.GetCosmosDb(CosmosDbType.MongoDb);
         }
 
-        public static NoSqlConfig GetNoSql(this TestConfig config)
+        /// <summary>
+        /// Loads the <see cref="CosmosDbConfig"/> specific for the NoSql storage.
+        /// </summary>
+        public static CosmosDbConfig GetNoSql(this TestConfig config)
         {
-            ResourceIdentifier resourceId = CreateResourceId(config, config["Arcus:Cosmos:NoSql:Name"]);
-
-            return new NoSqlConfig(
-                resourceId,
-                config["Arcus:Cosmos:NoSql:Name"],
-                config["Arcus:Cosmos:NoSql:DatabaseName"]);
+            return config.GetCosmosDb(CosmosDbType.NoSql);
         }
 
-        private static ResourceIdentifier CreateResourceId(TestConfig config, string accountName)
+        private enum CosmosDbType { NoSql, MongoDb }
+
+        private static CosmosDbConfig GetCosmosDb(this TestConfig config, CosmosDbType cosmosDbType)
         {
-            string subscriptionId = config["Arcus:SubscriptionId"];
-            string resourceGroupName = config["Arcus:ResourceGroup:Name"];
-            
-            return ResourceIdentifier.Parse($"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}");
+            AzureEnvironment env = config.GetAzureEnvironment();
+
+            string cosmosDbName = config[$"Arcus:Cosmos:{cosmosDbType}:Name"];
+            string databaseName = config[$"Arcus:Cosmos:{cosmosDbType}:DatabaseName"];
+            ResourceIdentifier resourceId = CosmosDBAccountResource.CreateResourceIdentifier(env.SubscriptionId, env.ResourceGroupName, cosmosDbName);
+
+            return new CosmosDbConfig(resourceId, cosmosDbName, databaseName);
         }
     }
 }

--- a/src/Arcus.Testing.Tests.Integration/Storage/Fixture/MongoDbTestContext.cs
+++ b/src/Arcus.Testing.Tests.Integration/Storage/Fixture/MongoDbTestContext.cs
@@ -62,9 +62,10 @@ namespace Arcus.Testing.Tests.Integration.Storage.Fixture
             var tokenProvider = new DefaultAzureCredential();
             AccessToken accessToken = await tokenProvider.GetTokenAsync(new TokenRequestContext(scopes: new[] { scope }));
 
-            string subscriptionId = config["Arcus:SubscriptionId"];
-            string resourceGroupName = config["Arcus:ResourceGroup:Name"];
-            string cosmosDbName = config["Arcus:Cosmos:MongoDb:Name"];
+            AzureEnvironment env = config.GetAzureEnvironment();
+            string subscriptionId = env.SubscriptionId;
+            string resourceGroupName = env.ResourceGroupName;
+            string cosmosDbName = config.GetMongoDb().AccountName;
 
             var listConnectionStringUrl = $"https://management.azure.com/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{cosmosDbName}/listConnectionStrings?api-version=2021-04-15";
 
@@ -201,7 +202,7 @@ namespace Arcus.Testing.Tests.Integration.Storage.Fixture
         }
 
         /// <summary>
-        /// Verifies that a document does not exists in the MongoDb collection.
+        /// Verifies that a document does not exist in the MongoDb collection.
         /// </summary>
         public async Task ShouldNotStoreDocumentAsync<T>(string collectionName, BsonValue id)
         {

--- a/src/Arcus.Testing.Tests.Integration/Storage/TemporaryMongoDbCollectionTests.cs
+++ b/src/Arcus.Testing.Tests.Integration/Storage/TemporaryMongoDbCollectionTests.cs
@@ -19,7 +19,7 @@ namespace Arcus.Testing.Tests.Integration.Storage
         {
         }
 
-        private MongoDbConfig MongoDb => Configuration.GetMongoDb();
+        private CosmosDbConfig MongoDb => Configuration.GetMongoDb();
 
         [Fact]
         public async Task CreateTempMongoDbCollection_OnNonExistingCollection_SucceedsByExistingDuringLifetimeFixture()
@@ -114,7 +114,7 @@ namespace Arcus.Testing.Tests.Integration.Storage
             // Assert
             await context.ShouldNotStoreDocumentAsync<Shipment>(collectionName, matchedId);
             await context.ShouldStoreDocumentAsync<Shipment>(collectionName, unmatchedId);
-            
+
             await collection.DisposeAsync();
             await context.ShouldStoreDocumentAsync<Shipment>(collectionName, unmatchedId);
         }
@@ -236,8 +236,8 @@ namespace Arcus.Testing.Tests.Integration.Storage
         private async Task<TemporaryMongoDbCollection> WhenTempCollectionCreatedAsync(string collectionName, Action<TemporaryMongoDbCollectionOptions> configureOptions = null)
         {
             var collection = configureOptions is null
-                ? await TemporaryMongoDbCollection.CreateIfNotExistsAsync(MongoDb.ResourceId, MongoDb.DatabaseName, collectionName, Logger)
-                : await TemporaryMongoDbCollection.CreateIfNotExistsAsync(MongoDb.ResourceId, MongoDb.DatabaseName, collectionName, Logger, configureOptions);
+                ? await TemporaryMongoDbCollection.CreateIfNotExistsAsync(MongoDb.AccountResourceId, MongoDb.DatabaseName, collectionName, Logger)
+                : await TemporaryMongoDbCollection.CreateIfNotExistsAsync(MongoDb.AccountResourceId, MongoDb.DatabaseName, collectionName, Logger, configureOptions);
 
             Assert.Equal(collectionName, collection.Name);
             return collection;

--- a/src/Arcus.Testing.Tests.Integration/Storage/TemporaryMongoDbDocumentTests.cs
+++ b/src/Arcus.Testing.Tests.Integration/Storage/TemporaryMongoDbDocumentTests.cs
@@ -20,7 +20,7 @@ namespace Arcus.Testing.Tests.Integration.Storage
         {
         }
 
-        private MongoDbConfig MongoDb => Configuration.GetMongoDb();
+        private CosmosDbConfig MongoDb => Configuration.GetMongoDb();
 
         [Fact]
         public async Task CreateTempMongoDbDocument_OnNonExistingDocumentId_SucceedsByExistingDuringLifetimeFixture()
@@ -53,7 +53,7 @@ namespace Arcus.Testing.Tests.Integration.Storage
             BsonValue id = await context.WhenDocumentAvailableAsync(collectionName, original);
 
             Product replacement = CreateProduct();
-            replacement.Id = (ObjectId)id;
+            replacement.Id = (ObjectId) id;
 
             TemporaryMongoDbDocument temp = await WhenTempDocumentCreatedAsync(collectionName, replacement);
             await context.ShouldStoreDocumentAsync<Product>(collectionName, id, stored => AssertProduct(replacement, stored));
@@ -69,7 +69,7 @@ namespace Arcus.Testing.Tests.Integration.Storage
             where TDoc : class
         {
             return await TemporaryMongoDbDocument.InsertIfNotExistsAsync(
-                MongoDb.ResourceId,
+                MongoDb.AccountResourceId,
                 MongoDb.DatabaseName,
                 collectionName,
                 doc,
@@ -113,7 +113,7 @@ namespace Arcus.Testing.Tests.Integration.Storage
             BsonValue id = await context.WhenDocumentAvailableAsync(collectionName, original);
 
             var replacement = DocWithStringId.Generate();
-            replacement.Id = (string)id;
+            replacement.Id = (string) id;
 
             TemporaryMongoDbDocument temp = await WhenTempDocumentCreatedAsync(collectionName, replacement);
             await context.ShouldStoreDocumentAsync<DocWithStringId>(collectionName, id, stored => Assert.Equal(replacement.Name, stored.Name));

--- a/src/Arcus.Testing.Tests.Integration/Storage/TemporaryNoSqlContainerTests.cs
+++ b/src/Arcus.Testing.Tests.Integration/Storage/TemporaryNoSqlContainerTests.cs
@@ -13,7 +13,7 @@ namespace Arcus.Testing.Tests.Integration.Storage
     [Collection(TestCollections.NoSql)]
     public class TemporaryNoSqlContainerTests : IntegrationTest
     {
-        private string[] PartitionKeyPaths => new[]
+        private static string[] PartitionKeyPaths => new[]
         {
             "/" + nameof(Ship.Destination) + "/" + nameof(Destination.Country)
         };
@@ -25,7 +25,7 @@ namespace Arcus.Testing.Tests.Integration.Storage
         {
         }
 
-        private NoSqlConfig NoSql => Configuration.GetNoSql();
+        private CosmosDbConfig NoSql => Configuration.GetNoSql();
 
         [Fact]
         public async Task CreateTempNoSqlContainer_WithNonExistingContainer_SucceedsByExistingDuringLifetimeFixture()
@@ -182,7 +182,7 @@ namespace Arcus.Testing.Tests.Integration.Storage
 
             string containerName = await WhenContainerAlreadyAvailableAsync(context);
             Ship createdBefore = await context.WhenItemAvailableAsync(containerName, CreateShip("before"));
-            
+
             TemporaryNoSqlContainer container = await WhenTempContainerCreatedAsync(containerName);
             container.OnTeardown.CleanAllItems();
             await context.ShouldStoreItemAsync(containerName, createdBefore);
@@ -206,7 +206,7 @@ namespace Arcus.Testing.Tests.Integration.Storage
             return NoSqlTestContext.Given(Configuration, Logger);
         }
 
-        private async Task<string> WhenContainerAlreadyAvailableAsync(NoSqlTestContext context)
+        private static async Task<string> WhenContainerAlreadyAvailableAsync(NoSqlTestContext context)
         {
             return await context.WhenContainerNameAvailableAsync(PartitionKeyPaths.Single());
         }
@@ -215,10 +215,10 @@ namespace Arcus.Testing.Tests.Integration.Storage
             string containerName,
             Action<TemporaryNoSqlContainerOptions> configureOptions = null)
         {
-            var container = 
+            var container =
                 configureOptions is null
-                    ? await TemporaryNoSqlContainer.CreateIfNotExistsAsync(NoSql.ResourceId, NoSql.DatabaseName, containerName, PartitionKeyPaths.Single(), Logger)
-                    : await TemporaryNoSqlContainer.CreateIfNotExistsAsync(NoSql.ResourceId, NoSql.DatabaseName, containerName, PartitionKeyPaths.Single(), Logger, configureOptions);
+                    ? await TemporaryNoSqlContainer.CreateIfNotExistsAsync(NoSql.AccountResourceId, NoSql.DatabaseName, containerName, PartitionKeyPaths.Single(), Logger)
+                    : await TemporaryNoSqlContainer.CreateIfNotExistsAsync(NoSql.AccountResourceId, NoSql.DatabaseName, containerName, PartitionKeyPaths.Single(), Logger, configureOptions);
 
             Assert.Equal(NoSql.DatabaseName, container.Client.Database.Id);
             Assert.Equal(containerName, container.Name);


### PR DESCRIPTION
Introduce `AzureEnvironment` test config subsection to eliminate duplication and centralize configuration in the integration test project.

✅ Centralizing this test config subsection will help with change as there is now only a single place where the subscription ID and resource group name is retrieved from the `appsettings.json`.