### PR TITLE
docs(df): improve data-factory guide on resource (id) construction

### DIFF
--- a/docs/preview/03-Features/04-Azure/06-Integration/01-data-factory.mdx
+++ b/docs/preview/03-Features/04-Azure/06-Integration/01-data-factory.mdx
@@ -32,7 +32,7 @@ await using var session =
   await TemporaryDataFlowDebugSession.StartDebugSessionAsync(dataFactoryResourceId, logger);
 ```
 
-> ⚡ Uses by default the `DefaultAzureCredential` but other type of authentication mechanisms are supported with overloads that take in the `DataFactoryResource` directly:
+> ⚡ Uses by default the `DefaultAzureCredential` but other types of authentication mechanism are supported with overloads that take in the `DataFactoryResource` directly:
 > ```csharp
 >  var credential = new DefaultAzureCredential();
 >  var arm = new ArmClient(credential);

--- a/docs/preview/03-Features/04-Azure/06-Integration/01-data-factory.mdx
+++ b/docs/preview/03-Features/04-Azure/06-Integration/01-data-factory.mdx
@@ -25,14 +25,19 @@ The test fixture instance is meant to be used across tests. By all using the sam
 ```csharp
 using Arcus.Testing;
 
-var dataFactoryResourceId = new ResourceIdentifier(
-    ".../Microsoft.DataFactory/factories/<dataFactoryName>")
+ResourceIdentifier dataFactoryResourceId =
+    DataFactoryResource.CreateResourceIdentifier("<subscription-id>", "<resource-group>", "<factory-name>");
 
 await using var session = 
   await TemporaryDataFlowDebugSession.StartDebugSessionAsync(dataFactoryResourceId, logger);
 ```
 
-> ⚡ Uses by default the `DefaultAzureCredential` but other type of authentication mechanisms are supported with overloads that take in the `DataFactoryResource` directly.
+> ⚡ Uses by default the `DefaultAzureCredential` but other type of authentication mechanisms are supported with overloads that take in the `DataFactoryResource` directly:
+> ```csharp
+>  var credential = new DefaultAzureCredential();
+>  var arm = new ArmClient(credential);
+>  DataFactoryResource resource = arm.GetDataFactoryResource(dataFactoryResourceId);
+> ```
 
 ### Customization
 The setup of the `TemporaryDataFlowDebugSession` test fixture can be customized with the following options: 

--- a/src/Arcus.Testing.Integration.DataFactory/TemporaryDataFlowDebugSession.cs
+++ b/src/Arcus.Testing.Integration.DataFactory/TemporaryDataFlowDebugSession.cs
@@ -99,7 +99,16 @@ namespace Arcus.Testing
         ///     Uses <see cref="DefaultAzureCredential"/> for authentication;
         ///     use the <see cref="StartDebugSessionAsync(DataFactoryResource,ILogger)"/> overload to provide a custom authentication mechanism.
         /// </remarks>
-        /// <param name="dataFactoryResourceId">The resource ID to the DataFactory instance where to start the active DataFlow debug session.</param>
+        /// <param name="dataFactoryResourceId">
+        ///   <para>The resource ID to the DataFactory instance where to start the active DataFlow debug session.</para>
+        ///   <para>The resource ID can be constructed via <see cref="DataFactoryResource.CreateResourceIdentifier"/>:</para>
+        ///   <example>
+        ///     <code>
+        ///       ResourceIdentifier dataFactoryResourceId =
+        ///           DataFactoryResource.CreateResourceIdentifier("&lt;subscription-id&gt;", "&lt;resource-group&gt;", "&lt;factory-name&gt;");
+        ///     </code>
+        ///   </example>  
+        /// </param>
         /// <param name="logger">The logger to write diagnostic messages during the debug session.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="dataFactoryResourceId"/> is <c>null</c>.</exception>
         /// <exception cref="InvalidOperationException">Thrown when the starting of the DataFlow debug session did not result in a session ID.</exception>
@@ -115,8 +124,16 @@ namespace Arcus.Testing
         ///     Uses <see cref="DefaultAzureCredential"/> for authentication;
         ///     use the <see cref="StartDebugSessionAsync(DataFactoryResource,ILogger,Action{TemporaryDataFlowDebugSessionOptions})"/> overload to provide a custom authentication mechanism.
         /// </remarks>
-        /// <param name="dataFactoryResourceId">The resource ID to the DataFactory instance where to start the active DataFlow debug session.</param>
-        /// <param name="logger">The logger to write diagnostic messages during the debug session.</param>
+        /// <param name="dataFactoryResourceId">
+        ///   <para>The resource ID to the DataFactory instance where to start the active DataFlow debug session.</para>
+        ///   <para>The resource ID can be constructed via <see cref="DataFactoryResource.CreateResourceIdentifier"/>:</para>
+        ///   <example>
+        ///     <code>
+        ///       ResourceIdentifier dataFactoryResourceId =
+        ///           DataFactoryResource.CreateResourceIdentifier("&lt;subscription-id&gt;", "&lt;resource-group&gt;", "&lt;factory-name&gt;");
+        ///     </code>
+        ///   </example>  
+        /// </param>        /// <param name="logger">The logger to write diagnostic messages during the debug session.</param>
         /// <param name="configureOptions">The function to configure the options of the debug session.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="dataFactoryResourceId"/> is <c>null</c>.</exception>
         /// <exception cref="InvalidOperationException">Thrown when the starting of the DataFlow debug session did not result in a session ID.</exception>
@@ -136,7 +153,17 @@ namespace Arcus.Testing
         /// <summary>
         /// Starts a new active DataFactory DataFlow debug session for the given <paramref name="resource"/>.
         /// </summary>
-        /// <param name="resource">The resource to start the active DataFlow debug session for.</param>
+        /// <param name="resource">
+        ///   <para>The resource to start the active DataFlow debug session for.</para>
+        ///   <para>The resource should be retrieved via the <see cref="ArmClient"/>:</para>
+        ///   <example>
+        ///     <code>
+        ///       var credential = new DefaultAzureCredential();
+        ///       var arm = new ArmClient(credential);
+        ///       DataFactoryResource resource = arm.GetDataFactoryResource(dataFactoryResourceId);
+        ///     </code>
+        ///   </example>
+        /// </param>
         /// <param name="logger">The logger to write diagnostic messages during the debug session.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="resource"/> is <c>null</c>.</exception>
         /// <exception cref="InvalidOperationException">Thrown when the starting of the DataFlow debug session did not result in a session ID.</exception>
@@ -148,7 +175,17 @@ namespace Arcus.Testing
         /// <summary>
         /// Starts a new active DataFactory DataFlow debug session for the given <paramref name="resource"/>.
         /// </summary>
-        /// <param name="resource">The resource to start the active DataFlow debug session for.</param>
+        /// <param name="resource">
+        ///   <para>The resource to start the active DataFlow debug session for.</para>
+        ///   <para>The resource should be retrieved via the <see cref="ArmClient"/>:</para>
+        ///   <example>
+        ///     <code>
+        ///       var credential = new DefaultAzureCredential();
+        ///       var arm = new ArmClient(credential);
+        ///       DataFactoryResource resource = arm.GetDataFactoryResource(dataFactoryResourceId);
+        ///     </code>
+        ///   </example>
+        /// </param>
         /// <param name="logger">The logger to write diagnostic messages during the debug session.</param>
         /// <param name="configureOptions">The function to configure the options of the debug session.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="resource"/> is <c>null</c>.</exception>


### PR DESCRIPTION
Improve both the feature documentation as the XML code docs of the DataFactory test components by explaining how `DataFactoryResource`s and their `ResourceIdentifier`s can be constructed by using their respective type (i.e. `DataFactoryResource.CreateResourceIdenfier`). 

✅ This helps a little more to construct resource ID's than to mention: `ResourceIdentifier id = ...`.