### PR TITLE
docs(cosmos): improve cosmosdb resource (id) construction

### DIFF
--- a/docs/preview/03-Features/04-Azure/04-Storage/02-cosmos.mdx
+++ b/docs/preview/03-Features/04-Azure/04-Storage/02-cosmos.mdx
@@ -24,7 +24,8 @@ The `TemporaryMongoDbCollection` provides a solution when the integration tes re
 ```csharp
 using Arcus.Testing;
 
-ResourceIdentifier cosmosDbAccountResourceId = ...
+ResourceIdentifier cosmosDbAccountResourceId =
+    CosmosDBAccountResource.CreateResourceIdentifier("<subscription-id>", "<resource-group>", "<account-name>");
 
 await using var collection = await TemporaryMongoDbCollection.CreateIfNotExistsAsync(
     cosmosDbAccountResourceId,
@@ -109,7 +110,8 @@ When the document already existed (already a document with a same configured doc
 ```csharp
 using Arcus.Testing;
 
-ResourceIdentifier cosmosDbAccountResourceId = ...
+ResourceIdentifier cosmosDbAccountResourceId =
+    CosmosDBAccountResource.CreateResourceIdentifier("<subscription-id>", "<resource-group>", "<account-name>");
 
 var shipment = new Shipment { BoatName = "The Alice" };
 
@@ -130,7 +132,7 @@ BsonValue documentId = document.Id;
 > 
 > **This role is not a built-in Azure RBAC, but a role specific for NoSql**. One can [assign this role with Azure CLI](https://learn.microsoft.com/en-us/cli/azure/cosmosdb/sql/role/assignment?view=azure-cli-latest#az-cosmosdb-sql-role-assignment-create):
 > ```powershell
-> az cosmosdb sql role assignment create `
+> PS> az cosmosdb sql role assignment create `
 >   --account-name "CosmosDBAccountName" `
 >   --resource-group "ResourceGroupName" `
 >   --role-definition-name "Cosmos DB Built-in Data Contributor" `
@@ -146,7 +148,8 @@ The `TemporaryNoSqlContainer` provides a solution when the integration tes requi
 ```csharp
 using Arcus.Testing;
 
-ResourceIdentifier cosmosDbAccountResourceId = ...
+ResourceIdentifier cosmosDbAccountResourceId =
+    CosmosDBAccountResource.CreateResourceIdentifier("<subscription-id>", "<resource-group>", "<account-name>");
 
 await using var container = await TemporaryNoSqlContainer.CreateIfNotExistsAsync(
     cosmosDbAccountResourceId,
@@ -233,9 +236,7 @@ Container containerClient = ...
 var shipment = new Shipment { Id = "123", BoatName = "The Alice" };
 
 await using var item = await TemporaryNoSqlItem.InsertIfNotExistsAsync(
-    containerClient,
-    shipment,
-    logger);
+    containerClient, shipment, logger);
 
 string itemId = item.Id;
 PartitionKey partitionKey = item.PartitionKey;

--- a/src/Arcus.Testing.Storage.Cosmos/TemporaryMongoDbCollection.cs
+++ b/src/Arcus.Testing.Storage.Cosmos/TemporaryMongoDbCollection.cs
@@ -3,6 +3,7 @@ using System.Collections.ObjectModel;
 using System.Linq.Expressions;
 using System.Threading.Tasks;
 using Azure.Core;
+using Azure.ResourceManager.CosmosDB;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using MongoDB.Bson;
@@ -234,7 +235,16 @@ namespace Arcus.Testing
         /// <summary>
         /// Creates a new instance of the <see cref="TemporaryMongoDbCollection"/> which creates a new Azure Cosmos MongoDb collection if it doesn't exist yet.
         /// </summary>
-        /// <param name="cosmosDbResourceId">The resource ID pointing towards the Azure Cosmos account.</param>
+        /// <param name="cosmosDbResourceId">
+        ///   <para>The resource ID pointing towards the Azure Cosmos account.</para>
+        ///   <para>The resource ID can be constructed with the <see cref="CosmosDBAccountResource.CreateResourceIdentifier"/>:</para>
+        ///   <example>
+        ///     <code>
+        ///       ResourceIdentifier cosmosDbAccountResourceId =
+        ///           CosmosDBAccountResource.CreateResourceIdentifier("&lt;subscription-id&gt;", "&lt;resource-group&gt;", "&lt;account-name&gt;");
+        ///     </code>
+        ///   </example>
+        /// </param>
         /// <param name="databaseName">The name of the MongoDb database in which the collection should be created.</param>
         /// <param name="collectionName">The unique name of the MongoDb collection.</param>
         /// <param name="logger">The logger to write diagnostic information during the lifetime of the MongoDb collection.</param>
@@ -252,7 +262,16 @@ namespace Arcus.Testing
         /// <summary>
         /// Creates a new instance of the <see cref="TemporaryMongoDbCollection"/> which creates a new Azure Cosmos MongoDb collection if it doesn't exist yet.
         /// </summary>
-        /// <param name="cosmosDbResourceId">The resource ID pointing towards the Azure Cosmos account.</param>
+        /// <param name="cosmosDbResourceId">
+        ///   <para>The resource ID pointing towards the Azure Cosmos account.</para>
+        ///   <para>The resource ID can be constructed with the <see cref="CosmosDBAccountResource.CreateResourceIdentifier"/>:</para>
+        ///   <example>
+        ///     <code>
+        ///       ResourceIdentifier cosmosDbAccountResourceId =
+        ///           CosmosDBAccountResource.CreateResourceIdentifier("&lt;subscription-id&gt;", "&lt;resource-group&gt;", "&lt;account-name&gt;");
+        ///     </code>
+        ///   </example>
+        /// </param>
         /// <param name="databaseName">The name of the MongoDb database in which the collection should be created.</param>
         /// <param name="collectionName">The unique name of the MongoDb collection.</param>
         /// <param name="logger">The logger to write diagnostic information during the lifetime of the MongoDb collection.</param>

--- a/src/Arcus.Testing.Storage.Cosmos/TemporaryMongoDbDocument.cs
+++ b/src/Arcus.Testing.Storage.Cosmos/TemporaryMongoDbDocument.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Azure.Core;
+using Azure.ResourceManager.CosmosDB;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using MongoDB.Bson;
@@ -52,7 +53,16 @@ namespace Arcus.Testing
         /// <summary>
         /// Inserts a temporary document to an Azure Cosmos MongoDb collection.
         /// </summary>
-        /// <param name="cosmosDbResourceId">The resource ID pointing towards the Azure CosmosDb account.</param>
+        /// <param name="cosmosDbResourceId">
+        ///   <para>The resource ID pointing towards the Azure Cosmos account.</para>
+        ///   <para>The resource ID can be constructed with the <see cref="CosmosDBAccountResource.CreateResourceIdentifier"/>:</para>
+        ///   <example>
+        ///     <code>
+        ///       ResourceIdentifier cosmosDbAccountResourceId =
+        ///           CosmosDBAccountResource.CreateResourceIdentifier("&lt;subscription-id&gt;", "&lt;resource-group&gt;", "&lt;account-name&gt;");
+        ///     </code>
+        ///   </example>
+        /// </param>
         /// <param name="databaseName">The name of the MongoDb database in which the collection resides where the document should be created.</param>
         /// <param name="collectionName">The name of the MongoDb collection in which the document should be created.</param>
         /// <param name="document">The document that should be temporarily inserted into the MongoDb collection.</param>
@@ -87,7 +97,7 @@ namespace Arcus.Testing
             MongoClient client = await MongoDbConnection.AuthenticateMongoClientAsync(cosmosDbResourceId, databaseName, collectionName, logger);
             IMongoDatabase database = client.GetDatabase(databaseName);
             IMongoCollection<TDocument> collection = database.GetCollection<TDocument>(collectionName);
-            
+
             return await InsertIfNotExistsAsync(collection, document, logger);
         }
 
@@ -149,7 +159,7 @@ namespace Arcus.Testing
                     $"as the passed document type '{typeof(TDocument).Name}' has no member map defined for the '_id' property, " +
                     $"please see the MongoDb documentation for more information on this required property: https://www.mongodb.com/docs/drivers/csharp/current/fundamentals/crud/write-operations/insert/#the-_id-field");
             }
-            
+
             return classMap.IdMemberMap;
         }
 
@@ -157,7 +167,7 @@ namespace Arcus.Testing
         {
             BsonValue id = bson[idMemberMap.ElementName];
             object idValue = BsonTypeMapper.MapToDotNetValue(id);
-         
+
             if (idMemberMap.IdGenerator.IsEmpty(idValue))
             {
                 object newId = idMemberMap.IdGenerator.GenerateId(collection, bson);

--- a/src/Arcus.Testing.Storage.Cosmos/TemporaryNoSqlContainer.cs
+++ b/src/Arcus.Testing.Storage.Cosmos/TemporaryNoSqlContainer.cs
@@ -25,7 +25,7 @@ namespace Arcus.Testing
     /// Represents the available options when the <see cref="TemporaryNoSqlContainer"/> is created.
     /// </summary>
     internal enum OnSetupNoSqlContainer { LeaveExisted = 0, CleanIfExisted, CleanIfMatched }
-    
+
     /// <summary>
     /// Represents the available options when the <see cref="TemporaryNoSqlContainer"/> is deleted.
     /// </summary>
@@ -104,7 +104,7 @@ namespace Arcus.Testing
                 }
 
                 using var body = new MemoryStream(Encoding.UTF8.GetBytes(json.ToString()));
-                
+
                 var item = client.ClientOptions.Serializer.FromStream<TItem>(body);
                 if (item is null)
                 {
@@ -342,7 +342,16 @@ namespace Arcus.Testing
         /// <summary>
         /// Creates a new instance of the <see cref="TemporaryNoSqlContainer"/> which creates a new Azure Cosmos NoSql container if it doesn't exist yet.
         /// </summary>
-        /// <param name="cosmosDbAccountResourceId">The resource ID of the Azure Cosmos resource where the temporary NoSql container should be created.</param>
+        /// <param name="cosmosDbAccountResourceId">
+        ///   <para>The resource ID of the Azure Cosmos resource where the temporary NoSql container should be created.</para>
+        ///   <para>The resource ID can be constructed with the <see cref="CosmosDBAccountResource.CreateResourceIdentifier"/>:</para>
+        ///   <example>
+        ///     <code>
+        ///       ResourceIdentifier cosmosDbAccountResourceId =
+        ///           CosmosDBAccountResource.CreateResourceIdentifier("&lt;subscription-id&gt;", "&lt;resource-group&gt;", "&lt;account-name&gt;");
+        ///     </code>
+        ///   </example>
+        /// </param>
         /// <param name="databaseName">The name of the existing NoSql database in the Azure Cosmos resource.</param>
         /// <param name="containerName">The name of the NoSql container to be created within the Azure Cosmos resource.</param>
         /// <param name="partitionKeyPath">The path to the partition key of the NoSql item which describes how the items should be partitioned.</param>
@@ -370,7 +379,16 @@ namespace Arcus.Testing
         /// <summary>
         /// Creates a new instance of the <see cref="TemporaryNoSqlContainer"/> which creates a new Azure Cosmos NoSql container if it doesn't exist yet.
         /// </summary>
-        /// <param name="cosmosDbAccountResourceId">The resource ID of the Azure Cosmos resource where the temporary NoSql container should be created.</param>
+        /// <param name="cosmosDbAccountResourceId">
+        ///   <para>The resource ID of the Azure Cosmos resource where the temporary NoSql container should be created.</para>
+        ///   <para>The resource ID can be constructed with the <see cref="CosmosDBAccountResource.CreateResourceIdentifier"/>:</para>
+        ///   <example>
+        ///     <code>
+        ///       ResourceIdentifier cosmosDbAccountResourceId =
+        ///           CosmosDBAccountResource.CreateResourceIdentifier("&lt;subscription-id&gt;", "&lt;resource-group&gt;", "&lt;account-name&gt;");
+        ///     </code>
+        ///   </example>
+        /// </param>
         /// <param name="databaseName">The name of the existing NoSql database in the Azure Cosmos resource.</param>
         /// <param name="containerName">The name of the NoSql container to be created within the Azure Cosmos resource.</param>
         /// <param name="partitionKeyPath">The path to the partition key of the NoSql item which describes how the items should be partitioned.</param>
@@ -401,7 +419,16 @@ namespace Arcus.Testing
         /// <summary>
         /// Creates a new instance of the <see cref="TemporaryNoSqlContainer"/> which creates a new Azure Cosmos NoSql container if it doesn't exist yet.
         /// </summary>
-        /// <param name="cosmosDbAccountResourceId">The resource ID of the Azure Cosmos resource where the temporary NoSql container should be created.</param>
+        /// <param name="cosmosDbAccountResourceId">
+        ///   <para>The resource ID of the Azure Cosmos resource where the temporary NoSql container should be created.</para>
+        ///   <para>The resource ID can be constructed with the <see cref="CosmosDBAccountResource.CreateResourceIdentifier"/>:</para>
+        ///   <example>
+        ///     <code>
+        ///       ResourceIdentifier cosmosDbAccountResourceId =
+        ///           CosmosDBAccountResource.CreateResourceIdentifier("&lt;subscription-id&gt;", "&lt;resource-group&gt;", "&lt;account-name&gt;");
+        ///     </code>
+        ///   </example>
+        /// </param>
         /// <param name="credential">The credential implementation to authenticate with the Azure Cosmos resource.</param>
         /// <param name="databaseName">The name of the existing NoSql database in the Azure Cosmos resource.</param>
         /// <param name="containerName">The name of the NoSql container to be created within the Azure Cosmos resource.</param>
@@ -434,7 +461,16 @@ namespace Arcus.Testing
         /// <summary>
         /// Creates a new instance of the <see cref="TemporaryNoSqlContainer"/> which creates a new Azure Cosmos NoSql container if it doesn't exist yet.
         /// </summary>
-        /// <param name="cosmosDbAccountResourceId">The resource ID of the Azure Cosmos resource where the temporary NoSql container should be created.</param>
+        /// <param name="cosmosDbAccountResourceId">
+        ///   <para>The resource ID of the Azure Cosmos resource where the temporary NoSql container should be created.</para>
+        ///   <para>The resource ID can be constructed with the <see cref="CosmosDBAccountResource.CreateResourceIdentifier"/>:</para>
+        ///   <example>
+        ///     <code>
+        ///       ResourceIdentifier cosmosDbAccountResourceId =
+        ///           CosmosDBAccountResource.CreateResourceIdentifier("&lt;subscription-id&gt;", "&lt;resource-group&gt;", "&lt;account-name&gt;");
+        ///     </code>
+        ///   </example>
+        /// </param>
         /// <param name="credential">The credential implementation to authenticate with the Azure Cosmos resource.</param>
         /// <param name="databaseName">The name of the existing NoSql database in the Azure Cosmos resource.</param>
         /// <param name="containerName">The name of the NoSql container to be created within the Azure Cosmos resource.</param>
@@ -501,7 +537,7 @@ namespace Arcus.Testing
 
                 var properties = new ContainerProperties(containerName, partitionKeyPath);
                 CosmosDBSqlContainerResource container = await CreateNewNoSqlContainerAsync(cosmosDb, database, properties);
-                
+
                 return new TemporaryNoSqlContainer(cosmosClient, containerClient, container, createdByUs: true, options, logger);
             }
         }
@@ -532,7 +568,7 @@ namespace Arcus.Testing
         {
             var arm = new ArmClient(credential);
             CosmosDBAccountResource cosmosDb = arm.GetCosmosDBAccountResource(cosmosDbAccountResourceId);
-            
+
             return await cosmosDb.GetAsync();
         }
 
@@ -542,14 +578,14 @@ namespace Arcus.Testing
             {
                 return;
             }
-            
+
             if (options.OnSetup.Items is OnSetupNoSqlContainer.CleanIfExisted)
             {
                 await ForEachItemAsync(container, async (id, partitionKey, _) =>
                 {
                     logger.LogDebug("[Test:Setup] Delete Azure Cosmos NoSql item '{ItemId}' {PartitionKey} in container '{DatabaseName}/{ContainerName}'", id, partitionKey, container.Database.Id, container.Id);
                     using ResponseMessage response = await container.DeleteItemStreamAsync(id, partitionKey);
-                    
+
                     if (!response.IsSuccessStatusCode && response.StatusCode != HttpStatusCode.NotFound)
                     {
                         throw new RequestFailedException(
@@ -605,7 +641,7 @@ namespace Arcus.Testing
                 {
                     _logger.LogDebug("[Test:Teardown] Delete Azure Cosmos NoSql '{ContainerName}' container in database '{DatabaseName}'", _container.Id.Name, _container.Id.Parent?.Name);
                     await _container.DeleteAsync(WaitUntil.Completed);
-                })); 
+                }));
             }
             else
             {
@@ -632,7 +668,7 @@ namespace Arcus.Testing
                     {
                         _logger.LogDebug("[Test:Teardown] Delete Azure Cosmos NoSql item '{ItemId}' {PartitionKey} in NoSql container '{DatabaseName}/{ContainerName}'", id, key, Client.Database.Id, Client.Id);
                         using ResponseMessage response = await Client.DeleteItemStreamAsync(id, key);
-                        
+
                         if (!response.IsSuccessStatusCode && response.StatusCode != HttpStatusCode.NotFound)
                         {
                             throw new RequestFailedException(
@@ -654,7 +690,7 @@ namespace Arcus.Testing
                         {
                             _logger.LogDebug("[Test:Teardown] Delete Azure Cosmos NoSql item '{ItemId}' {PartitionKey} in NoSql container '{DatabaseName}/{ContainerName}'", id, key, Client.Database.Id, Client.Id);
                             using ResponseMessage response = await Client.DeleteItemStreamAsync(id, key);
-                            
+
                             if (!response.IsSuccessStatusCode && response.StatusCode != HttpStatusCode.NotFound)
                             {
                                 throw new RequestFailedException(


### PR DESCRIPTION
Improve both the feature documentation and the XML code docs to show how the CosmosDb's `ResourceIdentifier` can be constructed easily by using their respective types (i.e. `CosmosDBAccountResource.CreateResourceIdentifier`).

✅ This helps a little more to construct resource ID's than to mention: `ResourceIdentifier id = ...`.