### PR TITLE
chore(deps): upgrade test project packages

### DIFF
--- a/src/Arcus.Testing.Tests.Integration/Arcus.Testing.Tests.Integration.csproj
+++ b/src/Arcus.Testing.Tests.Integration/Arcus.Testing.Tests.Integration.csproj
@@ -6,17 +6,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Bogus" Version="29.0.2" />
-    <PackageReference Include="coverlet.collector" Version="6.0.2">
+    <PackageReference Include="Bogus" Version="35.6.1" />
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Guard.Net" Version="3.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>

--- a/src/Arcus.Testing.Tests.Integration/Core/Fixture/TemporaryDirectory.cs
+++ b/src/Arcus.Testing.Tests.Integration/Core/Fixture/TemporaryDirectory.cs
@@ -2,7 +2,6 @@
 using System.IO;
 using System.Linq;
 using Bogus;
-using GuardNet;
 
 namespace Arcus.Testing.Tests.Integration.Core.Fixture
 {
@@ -16,10 +15,6 @@ namespace Arcus.Testing.Tests.Integration.Core.Fixture
 
         private TemporaryDirectory(DirectoryInfo dir, string[] subDirNames)
         {
-            Guard.NotNull(dir, nameof(dir));
-            Guard.NotNull(subDirNames, nameof(subDirNames));
-            Guard.NotAny(subDirNames, nameof(subDirNames));
-
             _dir = dir;
             SubDirNames = subDirNames;
         }
@@ -39,7 +34,7 @@ namespace Arcus.Testing.Tests.Integration.Core.Fixture
         /// </summary>
         public static TemporaryDirectory GenerateAt(DirectoryInfo root)
         {
-            Guard.NotNull(root, nameof(root));
+            ArgumentNullException.ThrowIfNull(root);
 
             string[] subDirNames = Bogus.Lorem.Words();
             string path = System.IO.Path.Combine(subDirNames.Prepend(root.FullName).ToArray());

--- a/src/Arcus.Testing.Tests.Integration/Core/Fixture/TemporaryFile.cs
+++ b/src/Arcus.Testing.Tests.Integration/Core/Fixture/TemporaryFile.cs
@@ -2,7 +2,6 @@
 using System.IO;
 using System.Text;
 using Bogus;
-using GuardNet;
 
 namespace Arcus.Testing.Tests.Integration.Core.Fixture
 {
@@ -16,9 +15,6 @@ namespace Arcus.Testing.Tests.Integration.Core.Fixture
 
         private TemporaryFile(FileInfo file, byte[] fileContents)
         {
-            Guard.NotNull(file, nameof(file));
-            Guard.NotNull(fileContents, nameof(fileContents));
-
             _file = file;
             Contents = fileContents;
         }
@@ -32,7 +28,7 @@ namespace Arcus.Testing.Tests.Integration.Core.Fixture
         /// Gets the raw contents of the temporary file.
         /// </summary>
         public byte[] Contents { get; }
-        
+
         /// <summary>
         /// Gets the raw contents as text of the temporary file.
         /// </summary>
@@ -43,7 +39,7 @@ namespace Arcus.Testing.Tests.Integration.Core.Fixture
         /// </summary>
         public static TemporaryFile GenerateAt(DirectoryInfo directory)
         {
-            Guard.NotNull(directory, nameof(directory));
+            ArgumentNullException.ThrowIfNull(directory);
 
             string fileName = Bogus.System.FileName();
             byte[] fileContents = Bogus.Random.Bytes(Bogus.Random.Int(10, 20));
@@ -56,9 +52,9 @@ namespace Arcus.Testing.Tests.Integration.Core.Fixture
         /// </summary>
         public static TemporaryFile CreateAt(DirectoryInfo directory, string fileName, byte[] fileContents)
         {
-            Guard.NotNull(directory, nameof(directory));
-            Guard.NotNullOrWhitespace(fileName, nameof(fileContents));
-            Guard.NotNull(fileContents, nameof(fileContents));
+            ArgumentNullException.ThrowIfNull(directory);
+            ArgumentException.ThrowIfNullOrWhiteSpace(fileName);
+            ArgumentNullException.ThrowIfNull(fileName);
 
             string filePath = Path.Combine(directory.FullName, fileName);
             File.WriteAllBytes(filePath, fileContents);

--- a/src/Arcus.Testing.Tests.Integration/Core/Fixture/TemporaryFileEdit.cs
+++ b/src/Arcus.Testing.Tests.Integration/Core/Fixture/TemporaryFileEdit.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.IO;
-using GuardNet;
 
 namespace Arcus.Testing.Tests.Integration.Core.Fixture
 {
@@ -14,9 +13,6 @@ namespace Arcus.Testing.Tests.Integration.Core.Fixture
 
         private TemporaryFileEdit(FileInfo file, string originalContents)
         {
-            Guard.NotNull(file, nameof(file));
-            Guard.NotNull(originalContents, nameof(originalContents));
-
             _file = file;
             _originalContents = originalContents;
         }
@@ -26,8 +22,8 @@ namespace Arcus.Testing.Tests.Integration.Core.Fixture
         /// </summary>
         public static TemporaryFileEdit At(FileInfo file, Func<string, string> editContents)
         {
-            Guard.NotNull(file, nameof(file));
-            Guard.NotNull(editContents, nameof(editContents));
+            ArgumentNullException.ThrowIfNull(file);
+            ArgumentNullException.ThrowIfNull(editContents);
 
             string originalContents = File.ReadAllText(file.FullName);
             string editedContents = editContents(originalContents);

--- a/src/Arcus.Testing.Tests.Unit/Arcus.Testing.Tests.Unit.csproj
+++ b/src/Arcus.Testing.Tests.Unit/Arcus.Testing.Tests.Unit.csproj
@@ -6,16 +6,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Bogus" Version="29.0.2" />
-    <PackageReference Include="coverlet.collector" Version="6.0.2">
+    <PackageReference Include="Bogus" Version="35.6.1" />
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="FsCheck.Xunit" Version="2.16.6" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
-    <PackageReference Include="Moq" Version="4.14.5" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="MSTest.TestFramework" Version="3.4.3" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>
 
@@ -25,8 +24,8 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Remove, consolidate and upgrade NuGet packages in the test projects.

🗑️ Remove Guard.NET package.
🗑️ Remove transient packages that were explicitly referenced.
⬆️ Upgrade Bogus;
⬆️ Upgrade Coverlet;
⬆️ Upgrade Moq;
⬆️ Upgrade Microsoft Test SDK;