### PR TITLE
fix(ioc): S6956 in bicep resource group

### DIFF
--- a/build/templates/resource-group.bicep
+++ b/build/templates/resource-group.bicep
@@ -1,10 +1,10 @@
+targetScope = 'subscription'
+
 // Define the location for the deployment of the components.
 param location string
 
 // Define the name of the resource group where the components will be deployed.
 param resourceGroupName string
-
-targetScope = 'subscription'
 
 module resourceGroup 'br/public:avm/res/resources/resource-group:0.2.3' = {
   name: 'resourceGroupDeployment'


### PR DESCRIPTION
Fixes the SonarCloud S6956 issue in the `resource-group.bicep` by correcing the order of elements.