### PR TITLE
fix: add exception serialization constructors

### DIFF
--- a/src/Arcus.Testing.Assert/Failure/AssertionException.cs
+++ b/src/Arcus.Testing.Assert/Failure/AssertionException.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Runtime.Serialization;
 
 // ReSharper disable once CheckNamespace - place the exceptions in the root namespace for less clutter when exception is written to test output.
 namespace Arcus.Testing
@@ -27,6 +28,18 @@ namespace Arcus.Testing
         /// Initializes a new instance of the <see cref="AssertionException" /> class.
         /// </summary>
         public AssertionException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AssertionException" /> class with serialized data.
+        /// </summary>
+        /// <param name="info">The <see cref="SerializationInfo" /> that holds the serialized object data about the exception being thrown.</param>
+        /// <param name="context">The <see cref="StreamingContext" /> that contains contextual information about the source or destination.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="info" /> is <see langword="null" />.</exception>
+        /// <exception cref="SerializationException">Thrown when the class name is <see langword="null" /> or <see cref="Exception.HResult" /> is zero (0).</exception>
+        protected AssertionException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
         {
         }
     }

--- a/src/Arcus.Testing.Assert/Failure/CsvException.cs
+++ b/src/Arcus.Testing.Assert/Failure/CsvException.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Runtime.Serialization;
 
 namespace Arcus.Testing.Failure
 {
@@ -29,6 +30,18 @@ namespace Arcus.Testing.Failure
         /// <param name="message">The message that describes the exception.</param>
         /// <param name="innerException">The exception that is the cause of the current exception.</param>
         public CsvException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CsvException" /> class with serialized data.
+        /// </summary>
+        /// <param name="info">The <see cref="SerializationInfo" /> that holds the serialized object data about the exception being thrown.</param>
+        /// <param name="context">The <see cref="StreamingContext" /> that contains contextual information about the source or destination.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="info" /> is <see langword="null" />.</exception>
+        /// <exception cref="SerializationException">Thrown when the class name is <see langword="null" /> or <see cref="Exception.HResult" /> is zero (0).</exception>
+        protected CsvException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
         {
         }
     }

--- a/src/Arcus.Testing.Assert/Failure/EqualAssertionException.cs
+++ b/src/Arcus.Testing.Assert/Failure/EqualAssertionException.cs
@@ -1,10 +1,11 @@
 ﻿using System;
+using System.Runtime.Serialization;
 
 // ReSharper disable once CheckNamespace - place the exceptions in the root namespace for less clutter when exception is written to test output.
 namespace Arcus.Testing
 {
     /// <summary>
-    /// <para>Represents the exception implementation that gets thrown when an actual result does not matches an expectation.</para>
+    /// <para>Represents the exception implementation that gets thrown when an actual result does not match an expectation.</para>
     /// <para>See also: <see cref="AssertXml"/>, <see cref="AssertJson"/>.</para>
     /// </summary>
     [Serializable]
@@ -31,6 +32,18 @@ namespace Arcus.Testing
         /// <param name="message">The message that describes the failure.</param>
         /// <param name="innerException">The exception that is the cause of the current exception.</param>
         public EqualAssertionException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EqualAssertionException" /> class with serialized data.
+        /// </summary>
+        /// <param name="info">The <see cref="SerializationInfo" /> that holds the serialized object data about the exception being thrown.</param>
+        /// <param name="context">The <see cref="StreamingContext" /> that contains contextual information about the source or destination.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="info" /> is <see langword="null" />.</exception>
+        /// <exception cref="SerializationException">Thrown when the class name is <see langword="null" /> or <see cref="Exception.HResult" /> is zero (0).</exception>
+        protected EqualAssertionException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
         {
         }
     }


### PR DESCRIPTION
We already have the three common exception constructors and marked as `[Serilizable]` for our custom exception types, but we didn't had the serialization constructor yet.
This helps with not loosing any information on throwal, but also when we decide to enhance the exceptions with additional properties in the future, the data is not lost.