### PR TITLE
chore(deps): add `renovate.json` w/ dependency dashboard issue

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,5 @@
+{
+  "extends": ["config:base"],
+  "prCreation": "not-pending",
+  "dependencyDashboard": true
+}

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,5 +1,6 @@
 {
   "extends": ["config:base"],
   "prCreation": "not-pending",
+  "rangeStrategy": "increase",
   "dependencyDashboard": true
 }


### PR DESCRIPTION
Adds the `renovate.json` file to the repository with custom configuration so that Renovate does not create a PR, but rather updates the 'Dependeny Dashboard' GitHub issue. This is a better option than to create PR's as in library development, one has to take backwards compatibility into account and cannot go through with every update at once. To minimize the noise, having the dependency dashboard allows us to update the dependencies at our own pace, yet be notified of updates.

👀 Oh, and security updates are still being taken care of by the built-in Dependabot in GitHub. There a security notification will be raised. 