### PR TITLE
fix(workflow): combine GitHub npm task into 1 of auto-bump docs version workflow

### DIFF
--- a/.github/workflows/bump-docs-version.yml
+++ b/.github/workflows/bump-docs-version.yml
@@ -16,15 +16,12 @@ jobs:
         uses: actions/checkout@v2
         with:
             fetch-depth: 0
-  
-      - name: navigate to docs folder
-        run: cd docs
-  
-      - name: Install npm dependencies
-        run: npm install
-  
+
       - name: Generate new version
-        run: npm run docusaurus docs:version ${{ github.event.inputs.version }}
+        run: |
+          cd docs
+          npm install
+          npm run docusaurus docs:version ${{ github.event.inputs.version }}
 
       - name: Check for changes
         run: |


### PR DESCRIPTION
The `cd docs` command did not run together with the other GitHub tasks in the workflow definition.

This PR combines the NPM commands into a single task to keep track of the changed directory.