### PR TITLE
chore(renovate): correct config w/ rangeStrategy, issue title & labels

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,10 @@
 {
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:base"],
   "prCreation": "not-pending",
-  "rangeStrategy": "increase",
-  "dependencyDashboard": true
+  "rangeStrategy": "widen",
+  "separateMajorMinor": true,
+  "dependencyDashboard": true,
+  "dependencyDashboardTitle": "📦 [Renovate] dependency dashboard",
+  "labels": ["dependencies", "management"]
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,6 +3,7 @@
   "extends": ["config:base"],
   "prCreation": "not-pending",
   "rangeStrategy": "widen",
+  "ignoreDeps": ["Codit.Testing.*"],
   "separateMajorMinor": true,
   "dependencyDashboard": true,
   "dependencyDashboardTitle": "📦 [Renovate] dependency dashboard",

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,6 +4,9 @@
   "prCreation": "not-pending",
   "rangeStrategy": "widen",
   "ignoreDeps": ["Codit.Testing.*"],
+  "ignorePaths": [
+    "**/Arcus.Testing.Sample.*/**",
+  ],
   "separateMajorMinor": true,
   "dependencyDashboard": true,
   "dependencyDashboardTitle": "📦 [Renovate] dependency dashboard",

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:base"],
+  "extends": ["config:base", ":dependencyDashboardApproval"],
   "prCreation": "not-pending",
   "rangeStrategy": "widen",
   "ignoreDeps": ["Codit.Testing.*"],


### PR DESCRIPTION
The `renovate.json` has some additional options that we can use to improve the dependency dashborad GitHub issue.

* Adds `dependencies` and `management` labels to the created PR's so that it always clear that this should be taken up by the code-owners.
* Use `rangeStrategy:widen` to 'widen' any package ranges we have ('increase' was not valid).
* Use a configured title for the issue, so that it is more clear what this is (includes 'Renovate' in the title).
* Adds a `$schema` property, so that we have intelesense when editing locally. 