### PR TITLE
chore(deps): correct `renovate.json` with correct syntax for ignored deps & paths

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,6 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
   "prCreation": "not-pending",
+  "recreateWhen": "never",
   "rangeStrategy": "widen",
   "ignoreDeps": [
     "Codit.Testing.Xslt.Helper"

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,11 +1,13 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:base", ":dependencyDashboardApproval"],
+  "extends": ["config:recommended"],
   "prCreation": "not-pending",
   "rangeStrategy": "widen",
-  "ignoreDeps": ["Codit.Testing.*"],
+  "ignoreDeps": [
+    "Codit.Testing.Xslt.Helper"
+  ],
   "ignorePaths": [
-    "**/Arcus.Testing.Sample.*/**",
+    "**/samples/**",
   ],
   "separateMajorMinor": true,
   "dependencyDashboard": true,

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,7 +7,7 @@
     "Codit.Testing.Xslt.Helper"
   ],
   "ignorePaths": [
-    "**/samples/**",
+    "samples/**",
   ],
   "separateMajorMinor": true,
   "dependencyDashboard": true,


### PR DESCRIPTION
The Renovate configuration states that no wildcards can be used for ignored dependencies and the `/samples` folder also does not seem to be ignored by the current config.

This PR fixes that by removing wildcards in favor of an explicit package name reference, plus using a more simpler `/samples/**` path.