### PR TITLE
fix(docs): auto-bump version with 'v' prefix

### DIFF
--- a/build/templates/trigger-bump-docs-version.yml
+++ b/build/templates/trigger-bump-docs-version.yml
@@ -8,13 +8,13 @@ steps:
       gh auth login --with-token $(GITHUB_TOKEN)
       gh repo view
       
-      if ($(VERSION) -notmatch '-' -and $(VERSION) -match '^v[0-9]+\.[0-9]+\.0$') {
+      if ($env:VERSION -notmatch '-' -and $env:VERSION -match '^v[0-9]+\.[0-9]+\.0$') {
         gh workflow run bump-docs-version.yml `
           --repo arcus-azure/arcus.testing `
           --ref main `
-          --field version=$(VERSION)
+          --field version=$env:VERSION
       }
     displayName: 'Trigger new feature docs version PR'
     env:
       GITHUB_TOKEN: ${{ parameters.gitHubToken }}
-      VERSION: $(Build.BuildNumber)
+      VERSION: v$(Build.BuildNumber)

--- a/build/templates/trigger-bump-docs-version.yml
+++ b/build/templates/trigger-bump-docs-version.yml
@@ -16,5 +16,4 @@ steps:
       }
     displayName: 'Trigger new feature docs version PR'
     env:
-      GITHUB_TOKEN: ${{ parameters.gitHubToken }}
       VERSION: v$(Build.BuildNumber)


### PR DESCRIPTION
While the Azure DevOps version parameter is without a `v` prefix, the feature documentation needs that prefix. This PR adds the `v` before the `$(Build.BuildNumber)`, so that it gets correctly passed to the GitHub action.