### PR TITLE
feat(logging.xunit): add provider alias to xunit logger provider

### DIFF
--- a/src/Arcus.Testing.Logging.Xunit/Extensions/ILoggerBuilderExtensions.cs
+++ b/src/Arcus.Testing.Logging.Xunit/Extensions/ILoggerBuilderExtensions.cs
@@ -26,6 +26,7 @@ namespace Microsoft.Extensions.Logging
             return builder.AddProvider(provider);
         }
 
+        [ProviderAlias("Xunit")]
         private sealed class XunitLoggerProvider : ILoggerProvider
         {
             private readonly ILogger _logger;


### PR DESCRIPTION
With multiple logger providers, it is sometimes the case that you want to filter certain logs based on category with specific log levels. To do this for custom logger providers, you can set the `[ProviderAlias(...)]` attribute.

This PR sets this attribute to the custom logger provider of the xUnit logging package.
This would allow stuff like:
```json
{
  "Logging": {
    "LogLevel": {
      "Default": "Information"
    },
    "Xunit": {
      "LogLevel": {
        "Default": "Trace"
      }
    }
  }
}
```

Relates to #242