### PR TITLE
feat(logging.nunit): add provider alias to nunit logger provider

### DIFF
--- a/src/Arcus.Testing.Logging.NUnit/Extensions/ILoggerBuilderExtensions.cs
+++ b/src/Arcus.Testing.Logging.NUnit/Extensions/ILoggerBuilderExtensions.cs
@@ -46,6 +46,7 @@ namespace Microsoft.Extensions.Logging
             return builder.AddProvider(provider);
         }
 
+        [ProviderAlias("NUnit")]
         private sealed class NUnitLoggerProvider : ILoggerProvider
         {
             private readonly NUnitTestLogger _logger;


### PR DESCRIPTION
With multiple logger providers, it is sometimes the case that you want to filter certain logs based on category with specific log levels. To do this for custom logger providers, you can set the `[ProviderAlias(...)]` attribute.

This PR sets this attribute to the custom logger provider of the NUnit logging package.
This would allow stuff like:
```json
{
  "Logging": {
    "LogLevel": {
      "Default": "Information"
    },
    "NUnit": {
      "LogLevel": {
        "Default": "Trace"
      }
    }
  }
}
```

Relates to #242