### PR TITLE
feat(logging.mstest): add provider alias to mstest logger provider

### DIFF
--- a/src/Arcus.Testing.Logging.MSTest/Extensions/ILoggerBuilderExtensions.cs
+++ b/src/Arcus.Testing.Logging.MSTest/Extensions/ILoggerBuilderExtensions.cs
@@ -26,6 +26,7 @@ namespace Microsoft.Extensions.Logging
             return builder.AddProvider(provider);
         }
 
+        [ProviderAlias("MSTest")]
         private sealed class MSTestLoggerProvider : ILoggerProvider
         {
             private readonly ILogger _logger;


### PR DESCRIPTION
With multiple logger providers, it is sometimes the case that you want to filter certain logs based on category with specific log levels. To do this for custom logger providers, you can set the `[ProviderAlias(...)]` attribute.

This PR sets this attribute to the custom logger provider of the MSTest logging package.
This would allow stuff like:
```json
{
  "Logging": {
    "LogLevel": {
      "Default": "Information"
    },
    "MSTest": {
      "LogLevel": {
        "Default": "Trace"
      }
    }
  }
}
```

Relates to #242