### PR TITLE
docs(logging): remove logging.core from logging feature docs

### DIFF
--- a/docs/preview/03-Features/03-logging.mdx
+++ b/docs/preview/03-Features/03-logging.mdx
@@ -42,7 +42,6 @@ This page describes functionality related to logging in tests.
     ```
 
     In the same fashion there is a:
-    * [`XunitTestLogging`] extension to add a Serilog log sink for an `ITestOutputHelper` that delegates written log emits to the xUnit test output,
     * [`AddXunitTestLogging`] extension to add a `ILoggerProvider` to a [Microsoft Logging](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/logging/?view=aspnetcore-3.1) setup.
   </TabItem>
   <TabItem value="nunit" label="NUnit">
@@ -78,7 +77,6 @@ This page describes functionality related to logging in tests.
     ```
 
     In the same fashion there is a:
-    * [`NUnitTestLogging`] extension to add a Serilog log sink for an `TestContext` that delegates written log emits to the NUnit test output,
     * [`AddNUnitTestLogging`] extension to add a `ILoggerProvider` to a [Microsoft Logging](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/logging/?view=aspnetcore-3.1) setup.
   </TabItem>
   <TabItem value="mstest" label="MSTest">
@@ -110,45 +108,6 @@ This page describes functionality related to logging in tests.
     ```
     
     In the same fashion there is a:
-    * [`MSTestLogging`] extension to add a Serilog log sink for an `TestContext` that delegates written log emits to the NUnit test output,
     * [`AddMSTestLogging`] extension to add a `ILoggerProvider` to a [Microsoft Logging](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/logging/?view=aspnetcore-3.1) setup.
   </TabItem>
 </Tabs>
-
-## In-memory test logging
-The `Arcus.Testing.Logging.Core` library provides a `InMemoryLogger` and `InMemoryLogger<T>` which are  `ILogger` and `ILogger<T>` implementations respectively.
-These types help in tracking logged messages and their metadata information like the level on which the message was logged or the related exception.
-
-```csharp
-using Arcus.Testing;
-using Microsoft.Extensions.Logging;
-
-ILogger logger = new InMemoryLogger();
-
-logger.LogInformation("This is an informational message");
-
-// Either get the message directly, or
-IEnumerable<string> messages = logger.Messages;
-
-// Use the full `LogEntry` object to retrieve the message.
-IEnumerable<LogEntry> entries = logger.Entries;
-LogEntry entry = entries.First();
-
-// Level = Information
-LogLevel level = entry.Level;
-// Message = "This is a informational message"
-string message = entry.Message;
-```
-
-Or, alternatively you can use the generic variant:
-
-```csharp
-using Arcus.Testing;
-using Microsoft.Extensions.Logging;
-
-ILogger<MyType> logger = new InMemoryLogger<MyType>();
-
-logger.LogInformation("This is an informational message");
-
-IEnumerable<string> messages = logger.Messages;
-```


### PR DESCRIPTION
> 👉 Since we have released all our deprecated messages, we can prepare for v2.0, meaning: removing stuff for real.

This PR removes the mentioning of th logging.core package and its in-memory/Serilog functionality from the logging feature documentation.

Relates to #212