### PR TITLE
chore(core): add exception test tags in core library

### DIFF
--- a/src/Arcus.Testing.Core/ResourceDirectory.cs
+++ b/src/Arcus.Testing.Core/ResourceDirectory.cs
@@ -26,7 +26,7 @@ namespace Arcus.Testing
             if (!Directory.Exists(directory.FullName))
             {
                 throw new DirectoryNotFoundException(
-                    $"Cannot use test resource directory '{directory.Name}' because it does not exists on disk" +
+                    $"[Test] Cannot use test resource directory '{directory.Name}' because it does not exists on disk" +
                     Environment.NewLine +
                     $"Resource directory: {directory.FullName}");
             }
@@ -65,7 +65,7 @@ namespace Arcus.Testing
             if (!Directory.Exists(newDirectoryPath))
             {
                 throw new DirectoryNotFoundException(
-                    $"Cannot use sub test resource directory '{subDirectoryName}' because it does not exists in resource directory '{Path.Name}'" +
+                    $"[Test] Cannot use sub test resource directory '{subDirectoryName}' because it does not exists in resource directory '{Path.Name}'" +
                     Environment.NewLine +
                     $"Sub-directory path: {newDirectoryPath}" +
                     Environment.NewLine +
@@ -152,7 +152,7 @@ namespace Arcus.Testing
             if (files.Length == 0)
             {
                 throw new FileNotFoundException(
-                    $"Cannot retrieve '{searchPattern}' file contents in the resource directory because it does not exists, " +
+                    $"[Test] Cannot retrieve '{searchPattern}' file contents in the resource directory because it does not exists, " +
                     "make sure that the test resource files are always copied to the output before loading their contents. " +
                     Environment.NewLine +
                     $"Search pattern: {searchPattern}" +
@@ -163,7 +163,7 @@ namespace Arcus.Testing
             if (files.Length > 1)
             {
                 throw new FileNotFoundException(
-                    $"Cannot retrieve '{searchPattern}' file contents in the resource directory because there are multiple files found, " +
+                    $"[Test] Cannot retrieve '{searchPattern}' file contents in the resource directory because there are multiple files found, " +
                     "make sure that the test resource files are always copied to the output before loading their contents. " +
                     Environment.NewLine +
                     $"Search pattern: {searchPattern}" +

--- a/src/Arcus.Testing.Core/TestConfig.cs
+++ b/src/Arcus.Testing.Core/TestConfig.cs
@@ -47,7 +47,7 @@ namespace Arcus.Testing
         /// Gets the main JSON path to the configuration source.
         /// </summary>
         internal string MainJsonPath { get; private set; } = "appsettings.json";
-        
+
         /// <summary>
         /// Gets all the configured additional JSON paths to files that acts as configuration sources.
         /// </summary>
@@ -104,7 +104,7 @@ namespace Arcus.Testing
         /// <param name="configureOptions">The function to configure the options that describe where the test configuration should be retrieved from.</param>
         public static TestConfig Create(Action<TestConfigOptions> configureOptions)
         {
-           return new TestConfig(configureOptions);
+            return new TestConfig(configureOptions);
         }
 
         /// <summary>
@@ -153,7 +153,7 @@ namespace Arcus.Testing
                 if (string.IsNullOrWhiteSpace(key))
                 {
                     throw new KeyNotFoundException(
-                        $"Cannot find any test configuration value for the blank key: '{key}', " +
+                        $"[Test] Cannot find any test configuration value for the blank key: '{key}', " +
                         $"please make sure that you use a non-blank key and that has a corresponding value specified in your (local or remote) '{mainFile}' file");
                 }
 
@@ -161,7 +161,7 @@ namespace Arcus.Testing
                 if (string.IsNullOrWhiteSpace(value))
                 {
                     throw new KeyNotFoundException(
-                        $"Cannot find any non-blank test configuration value for the key: '{key}', " +
+                        $"[Test] Cannot find any non-blank test configuration value for the key: '{key}', " +
                         $"please make sure that this key is specified in your (local or remote) '{mainFile}' file and it is copied to the build output in your .csproj/.fsproj project file: " +
                         $"<CopyToOutputDirectory>Always/CopyToOutputDirectory>");
                 }
@@ -170,7 +170,7 @@ namespace Arcus.Testing
                     && value.EndsWith("}#", StringComparison.InvariantCulture))
                 {
                     throw new KeyNotFoundException(
-                        $"Cannot find test configuration value for the key '{key}', as it is still having the token '{value}' and is not being replaced by the real value, " +
+                        $"[Test] Cannot find test configuration value for the key '{key}', as it is still having the token '{value}' and is not being replaced by the real value, " +
                         $"please make sure to add a local alternative in the (ex: 'appsettings.{{Env}}.local.json') for the token with the real value required for this key");
                 }
 


### PR DESCRIPTION
Adds `[Test] ` tags to the test-specific exceptions that are thrown by our test core components. This will make it more clear that the failure is happening to something 'test' related, instead of something that is 'not expected'.