### PR TITLE
chore(deps): use `bump` io `widen`

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,12 +3,12 @@
   "extends": ["config:recommended"],
   "prCreation": "not-pending",
   "recreateWhen": "never",
-  "rangeStrategy": "widen",
+  "rangeStrategy": "bump",
   "ignoreDeps": [
     "Codit.Testing.Xslt.Helper"
   ],
   "ignorePaths": [
-    "samples/**",
+    "samples/**"
   ],
   "separateMajorMinor": true,
   "dependencyDashboard": true,


### PR DESCRIPTION
For some reason, the Renovate/Mend.IO does not fully support package ranges for NuGet packages, trying to use the `bump` range strategy instead.