### PR TITLE
chore(logging): remove net6.0 target framework from logging projects

### DIFF
--- a/src/Arcus.Testing.Logging.MSTest/Arcus.Testing.Logging.MSTest.csproj
+++ b/src/Arcus.Testing.Logging.MSTest/Arcus.Testing.Logging.MSTest.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>Arcus.Testing</RootNamespace>
     <Authors>Arcus</Authors>
     <Company>Arcus</Company>

--- a/src/Arcus.Testing.Logging.NUnit/Arcus.Testing.Logging.NUnit.csproj
+++ b/src/Arcus.Testing.Logging.NUnit/Arcus.Testing.Logging.NUnit.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>Arcus.Testing</RootNamespace>
     <Authors>Arcus</Authors>
     <Company>Arcus</Company>

--- a/src/Arcus.Testing.Logging.Xunit/Arcus.Testing.Logging.Xunit.csproj
+++ b/src/Arcus.Testing.Logging.Xunit/Arcus.Testing.Logging.Xunit.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>Arcus.Testing</RootNamespace>
     <Authors>Arcus</Authors>
     <Company>Arcus</Company>


### PR DESCRIPTION
> 👉 Since we already published our deprecating messages, we can remove stuff for real.

Microsoft's support for .NET 6 has ended, we should therefore remove it from our currently supported target frameworks. A previous PR #331 already removed it in the other non-logging projects, this PR removes it in the logging projects.