### PR TITLE
feat(core): add user-friendly operators to resource directory

### DIFF
--- a/docs/preview/03-Features/01-core.md
+++ b/docs/preview/03-Features/01-core.md
@@ -171,7 +171,9 @@ string txt = root.ReadFileTextByName("file.txt");
 byte[] img = root.ReadFileBytesByName("file.png");
 
 // Path: /bin/net8.0/resources
-ResourceDirectory sub = root.WithSubDirectory("resources");
+ResourceDirectory sub = 
+    root.WithSubDirectory("resources")
+        .WithSubDirectory("component");
 
 string txt = sub.ReadFileTextByName("file.txt");
 byte[] img = sub.ReadFileBytesByPattern("*.png");
@@ -183,6 +185,12 @@ byte[] img = sub.ReadFileBytesByPattern("*.png");
 //    File path: /bin/net8.0/resources/file.txt
 //    Resource directory: /bin/net8.0/resources
 ```
+
+> 🚀 The `ResourceDirectory` overrides the `/` operator, which points to the `.SubDirectory` call, which means you can create complex paths with ease:
+> ```csharp
+> ResourceDirectory sub = 
+>     ResourceDirectory.CurrentDirectory / "resources" / "components" / "module";
+> ``` 
 
 ## Temporary environment variable
 The `TemporaryEnvironmentVariable` provides a solution when the test needs to set certain environment information on the hosting system itself. This is fairly common when testing locally and spinning up the application on your own system. It can also be used for authentication, like managed identity connections. The test fixture will temporarily set or override an environment variable and remove or revert it upon disposal.

--- a/src/Arcus.Testing.Core/ResourceDirectory.cs
+++ b/src/Arcus.Testing.Core/ResourceDirectory.cs
@@ -6,7 +6,7 @@ namespace Arcus.Testing
     /// <summary>
     /// Represents a test-friendly resource directory where one or more resource files are located on disk.
     /// </summary>
-    public class ResourceDirectory
+    public class ResourceDirectory : IEquatable<ResourceDirectory>
     {
         private readonly DirectoryInfo _directory;
 
@@ -172,6 +172,79 @@ namespace Arcus.Testing
             }
 
             return files[0];
+        }
+
+        /// <summary>
+        /// Indicates whether the current object is equal to another object of the same type.
+        /// </summary>
+        /// <param name="other">An object to compare with this object.</param>
+        /// <returns>
+        /// <see langword="true" /> if the current object is equal to the <paramref name="other" /> parameter; otherwise, <see langword="false" />.</returns>
+        public bool Equals(ResourceDirectory other)
+        {
+            if (other is null)
+            {
+                return false;
+            }
+
+            return _directory.FullName.Equals(other._directory.FullName, StringComparison.InvariantCultureIgnoreCase);
+        }
+
+        /// <summary>
+        /// Determines whether the specified object is equal to the current object.
+        /// </summary>
+        /// <param name="obj">The object to compare with the current object.</param>
+        /// <returns>
+        /// <see langword="true" /> if the specified object  is equal to the current object; otherwise, <see langword="false" />.</returns>
+        public override bool Equals(object obj)
+        {
+            return obj is ResourceDirectory other && Equals(other);
+        }
+
+        /// <summary>
+        /// Serves as the default hash function.
+        /// </summary>
+        /// <returns>A hash code for the current object.</returns>
+        public override int GetHashCode()
+        {
+            return _directory.GetHashCode();
+        }
+
+        /// <summary>
+        /// Determines whether the specified object is equal to the current object.
+        /// </summary>
+        /// <returns>
+        /// <see langword="true" /> if the specified object  is equal to the current object; otherwise, <see langword="false" />.</returns>
+        public static bool operator ==(ResourceDirectory left, ResourceDirectory right)
+        {
+            ArgumentNullException.ThrowIfNull(left);
+            return left.Equals(right);
+        }
+
+        /// <summary>
+        /// Determines whether the specified object is not equal to the current object.
+        /// </summary>
+        /// <returns>
+        /// <see langword="true" /> if the specified object  is equal to the current object; otherwise, <see langword="false" />.</returns>
+        public static bool operator !=(ResourceDirectory left, ResourceDirectory right)
+        {
+            ArgumentNullException.ThrowIfNull(left);
+            return !left.Equals(right);
+        }
+
+        /// <summary>
+        /// Appends to the <paramref name="current"/> test resource directory a sub-directory based on the given <paramref name="subDirectoryName"/>.
+        /// </summary>
+        /// <param name="current">The subject test resource directory currently.</param>
+        /// <param name="subDirectoryName">The name of the sub-directory within the current test resource directory.</param>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="subDirectoryName"/> is blank.</exception>
+        /// <exception cref="DirectoryNotFoundException">
+        ///     Thrown when no test resource sub-directory is found within the current test resource directory with the given <paramref name="subDirectoryName"/>.
+        /// </exception>
+        public static ResourceDirectory operator /(ResourceDirectory current, string subDirectoryName)
+        {
+            ArgumentNullException.ThrowIfNull(current);
+            return current.WithSubDirectory(subDirectoryName);
         }
     }
 }

--- a/src/Arcus.Testing.Tests.Integration/Core/ResourceDirectoryTests.cs
+++ b/src/Arcus.Testing.Tests.Integration/Core/ResourceDirectoryTests.cs
@@ -24,6 +24,22 @@ namespace Arcus.Testing.Tests.Integration.Core
 
             // Act / Assert
             AssertContainsFile(tempFile, subDir);
+            Assert.True(Root != subDir, $"sub resource directory should not be equal to root, but it is ({Root.Path} != {subDir.Path})");
+        }
+
+        [Fact]
+        public void Directory_WithSamePath_Equals()
+        {
+            // Arrange
+            using var tempDir = TemporaryDirectory.GenerateAt(Root.Path);
+            var dir1 = WithSubDirectories(Root, tempDir);
+            var dir2 = WithSubDirectories(Root, tempDir);
+
+            // Act
+            bool isEqual = dir1 == dir2;
+
+            // Assert
+            Assert.True(isEqual, $"two resource directories pointing to the same path should be equal, but they aren't ({dir1.Path} == {dir2.Path})");
         }
 
         [Fact]

--- a/src/Arcus.Testing.Tests.Unit/Assert_/AssertJsonTests.cs
+++ b/src/Arcus.Testing.Tests.Unit/Assert_/AssertJsonTests.cs
@@ -26,7 +26,7 @@ namespace Arcus.Testing.Tests.Unit.Assert_
         public AssertJsonTests(ITestOutputHelper outputWriter)
         {
             _outputWriter = outputWriter;
-            _resourceDir = ResourceDirectory.CurrentDirectory.WithSubDirectory(nameof(Assert_)).WithSubDirectory("Resources");
+            _resourceDir = ResourceDirectory.CurrentDirectory / nameof(Assert_) / "Resources";
         }
 
         [Fact]


### PR DESCRIPTION
When building large paths for test resources, many `.WithSubDirectory(...)` calls can be a lot of noise. This PR overrides the `/` operator to act as a path seperator for resource directories.

Closes #341  