### PR TITLE
test(fix.setup): stabelize unique xml changed attribute name generation

### DIFF
--- a/src/Arcus.Testing.Tests.Unit/Assert_/AssertXmlTests.cs
+++ b/src/Arcus.Testing.Tests.Unit/Assert_/AssertXmlTests.cs
@@ -58,7 +58,7 @@ namespace Arcus.Testing.Tests.Unit.Assert_
                 // Arrange
                 TestXml actual = expected.Copy();
 
-                string newName = Bogus.Lorem.Word();
+                string newName = Bogus.Lorem.Word() + Guid.NewGuid().ToString("N");
                 actual.ChangeAttributeName(newName);
 
                 // Act / Assert


### PR DESCRIPTION
In (super) rare cases, the generated lorem XML attribute name is already in the XML. This PR adds a GUID to the name, so it is definitely always unique. 