### PR TITLE
fix(ci): use custom `dotnet nuget` to push PR previews to MyGet

### DIFF
--- a/build/ci-build.yml
+++ b/build/ci-build.yml
@@ -93,3 +93,14 @@ stages:
               artifact: 'Build'
               path: '$(Build.SourcesDirectory)'
           - template: nuget/publish-preview-package.yml@templates
+          - task: NuGetAuthenticate@1
+            displayName: 'Authenticate to MyGet.org'
+            inputs:
+              nuGetServiceConnections: 'MyGet.org (Push)'
+          - task: DotNetCoreCLI@2
+            displayName: 'Push to MyGet.org'
+            inputs:
+              command: 'custom'
+              custom: 'nuget push'
+              arguments: 'src/**/*.nupkg --skip-duplicate --skip-duplicate --source $(MyGet.SourceUrl)'
+              

--- a/build/ci-build.yml
+++ b/build/ci-build.yml
@@ -92,14 +92,10 @@ stages:
             inputs:
               artifact: 'Build'
               path: '$(Build.SourcesDirectory)'
-          - task: NuGetAuthenticate@1
-            displayName: 'Authenticate to MyGet.org'
-            inputs:
-              nuGetServiceConnections: 'MyGet.org (Push)'
           - task: DotNetCoreCLI@2
             displayName: 'Push to MyGet.org'
             inputs:
               command: 'custom'
               custom: 'nuget push'
-              arguments: 'src/**/*.nupkg --skip-duplicate --skip-duplicate --source $(MyGet.SourceUrl)'
+              arguments: 'src/**/*.nupkg --skip-duplicate --skip-duplicate --source $(MyGet.SourceUrl) --api-key $(MyGet.ApiKey)'
               

--- a/build/ci-build.yml
+++ b/build/ci-build.yml
@@ -98,5 +98,5 @@ stages:
             inputs:
               command: 'custom'
               custom: 'nuget'
-              arguments: 'push src/**/*.nupkg --skip-duplicate --skip-duplicate --source $(MyGet.SourceUrl) --api-key $(MyGet.ApiKey)'
+              arguments: 'push src/**/*.nupkg --skip-duplicate --source $(MyGet.SourceUrl) --api-key $(MyGet.ApiKey)'
               

--- a/build/ci-build.yml
+++ b/build/ci-build.yml
@@ -97,6 +97,6 @@ stages:
             displayName: 'Push to MyGet.org'
             inputs:
               command: 'custom'
-              custom: 'tool nuget push'
+              custom: 'nuget push'
               arguments: '"src/**/*.nupkg" --skip-duplicate --skip-duplicate --source $(MyGet.SourceUrl) --api-key $(MyGet.ApiKey)'
               

--- a/build/ci-build.yml
+++ b/build/ci-build.yml
@@ -97,6 +97,6 @@ stages:
             displayName: 'Push to MyGet.org'
             inputs:
               command: 'custom'
-              custom: 'nuget push'
+              custom: 'tool nuget push'
               arguments: '"src/**/*.nupkg" --skip-duplicate --skip-duplicate --source $(MyGet.SourceUrl) --api-key $(MyGet.ApiKey)'
               

--- a/build/ci-build.yml
+++ b/build/ci-build.yml
@@ -33,6 +33,7 @@ resources:
 variables:
   - group: 'GitHub Configuration'
   - group: 'Build Configuration'
+  - group: 'MyGet'
   - template: ./variables/build.yml
   - template: ./variables/test.yml
 
@@ -97,5 +98,5 @@ stages:
             inputs:
               command: 'custom'
               custom: 'nuget push'
-              arguments: 'src/**/*.nupkg --skip-duplicate --skip-duplicate --source $(MyGet.SourceUrl) --api-key $(MyGet.ApiKey)'
+              arguments: '"src/**/*.nupkg" --skip-duplicate --skip-duplicate --source $(MyGet.SourceUrl) --api-key $(MyGet.ApiKey)'
               

--- a/build/ci-build.yml
+++ b/build/ci-build.yml
@@ -97,6 +97,6 @@ stages:
             displayName: 'Push to MyGet.org'
             inputs:
               command: 'custom'
-              custom: 'nuget push'
-              arguments: '"src/**/*.nupkg" --skip-duplicate --skip-duplicate --source $(MyGet.SourceUrl) --api-key $(MyGet.ApiKey)'
+              custom: 'nuget'
+              arguments: 'push src/**/*.nupkg --skip-duplicate --skip-duplicate --source $(MyGet.SourceUrl) --api-key $(MyGet.ApiKey)'
               

--- a/build/ci-build.yml
+++ b/build/ci-build.yml
@@ -92,7 +92,6 @@ stages:
             inputs:
               artifact: 'Build'
               path: '$(Build.SourcesDirectory)'
-          - template: nuget/publish-preview-package.yml@templates
           - task: NuGetAuthenticate@1
             displayName: 'Authenticate to MyGet.org'
             inputs:


### PR DESCRIPTION
Since we use the `ubuntu-latest` in our CI pipelines, it notified us that the current approach on pushing NuGet packages to our MyGet feed (which gets pushed on every open PR), is now not working anymore with the newest Ubuntu release (v24.04).

Because of this, and the fact that we use YAML templates to streamline throughout Arcus repo's, we are left with a broken CI build.

This PR removes the YAML template in favor of a custom `dotnet nuget` command, as this will both fix the CI build, as well as removing a bit of unnecessary relationship with other Arcus repo's. It allows for Arcus repositories to grow more on their own, and to fix issues (like these) more quicker, without the overhead of other repo's. The downside, is that there might be some duplicated code, but since the amount of Arcus repositories is under review, that duplication might be very little.