### PR TITLE
fix(docs.core): use correct resource directory method

### DIFF
--- a/docs/preview/03-Features/01-core.md
+++ b/docs/preview/03-Features/01-core.md
@@ -186,7 +186,7 @@ byte[] img = sub.ReadFileBytesByPattern("*.png");
 //    Resource directory: /bin/net8.0/resources
 ```
 
-> 🚀 The `ResourceDirectory` overrides the `/` operator, which points to the `.SubDirectory` call, which means you can create complex paths with ease:
+> 🚀 The `ResourceDirectory` overrides the `/` operator, which points to the `.WithSubDirectory(...)` call, which means you can create complex paths with ease:
 > ```csharp
 > ResourceDirectory sub = 
 >     ResourceDirectory.CurrentDirectory / "resources" / "components" / "module";


### PR DESCRIPTION
The `ResourceDirectory` has a `.WithSubDirectory(...)` method, but this was wrongly mentioned in the feature docs.

This PR fixes that.
Follow-up PR of #344