### PR TITLE
chore(blob): use base arg exn for blank-check

### DIFF
--- a/src/Arcus.Testing.Storage.Blob/TemporaryBlobFile.cs
+++ b/src/Arcus.Testing.Storage.Blob/TemporaryBlobFile.cs
@@ -65,7 +65,7 @@ namespace Arcus.Testing
         public static async Task<TemporaryBlobFile> UploadIfNotExistsAsync(Uri blobContainerUri, string blobName, BinaryData blobContent, ILogger logger)
         {
             ArgumentNullException.ThrowIfNull(blobContainerUri);
-            ArgumentNullException.ThrowIfNullOrWhiteSpace(blobName);
+            ArgumentException.ThrowIfNullOrWhiteSpace(blobName);
 
             var containerClient = new BlobContainerClient(blobContainerUri, new DefaultAzureCredential());
             BlobClient blobClient = containerClient.GetBlobClient(blobName);


### PR DESCRIPTION
> Follow-up of #358 

* Revert `TemporaryBlobFile` where the encoding was incorrectly set to MIXED.
* Use base argument exception type to blank-check. 
