### PR TITLE
chore(core): streamline w/ net8.0 constructs in core

### DIFF
--- a/src/Arcus.Testing.Core/AsyncDisposable.cs
+++ b/src/Arcus.Testing.Core/AsyncDisposable.cs
@@ -12,7 +12,8 @@ namespace Arcus.Testing
 
         private AsyncDisposable(Func<ValueTask> disposeAsync)
         {
-            _disposeAsync = disposeAsync ?? throw new ArgumentNullException(nameof(disposeAsync));
+            ArgumentNullException.ThrowIfNull(disposeAsync);
+            _disposeAsync = disposeAsync;
         }
 
         /// <summary>
@@ -22,11 +23,7 @@ namespace Arcus.Testing
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="disposable"/> is <c>null</c>.</exception>
         public static AsyncDisposable Create(IDisposable disposable)
         {
-            if (disposable is null)
-            {
-                throw new ArgumentNullException(nameof(disposable));
-            }
-
+            ArgumentNullException.ThrowIfNull(disposable);
             return Create(disposable.Dispose);
         }
 
@@ -37,10 +34,7 @@ namespace Arcus.Testing
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="dispose"/> is <c>null</c>.</exception>
         public static AsyncDisposable Create(Action dispose)
         {
-            if (dispose is null)
-            {
-                throw new ArgumentNullException(nameof(dispose));
-            }
+            ArgumentNullException.ThrowIfNull(dispose);
 
             return Create(() =>
             {
@@ -56,11 +50,7 @@ namespace Arcus.Testing
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="disposeAsync"/> is <c>null</c>.</exception>
         public static AsyncDisposable Create(Func<Task> disposeAsync)
         {
-            if (disposeAsync is null)
-            {
-                throw new ArgumentNullException(nameof(disposeAsync));
-            }
-
+            ArgumentNullException.ThrowIfNull(disposeAsync);
             return new AsyncDisposable(async () => await disposeAsync());
         }
 
@@ -71,6 +61,7 @@ namespace Arcus.Testing
         public async ValueTask DisposeAsync()
         {
             await _disposeAsync();
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/src/Arcus.Testing.Core/DisposableCollection.cs
+++ b/src/Arcus.Testing.Core/DisposableCollection.cs
@@ -52,7 +52,7 @@ namespace Arcus.Testing
     /// </summary>
     public sealed class DisposableCollection : IAsyncDisposable
     {
-        private readonly Collection<IAsyncDisposable> _disposables = new();
+        private readonly Collection<IAsyncDisposable> _disposables = [];
         private readonly ILogger _logger;
 
         /// <summary>

--- a/src/Arcus.Testing.Core/ResourceDirectory.cs
+++ b/src/Arcus.Testing.Core/ResourceDirectory.cs
@@ -4,12 +4,11 @@ using System.IO;
 namespace Arcus.Testing
 {
     /// <summary>
-    /// Represents a test-friendly resource directory where one or more resource files are located on disk.
+    /// <para>Represents a test-friendly resource directory where one or more resource files are located on disk.</para>
+    /// <para>See also: <a href="https://testing.arcus-azure.net/features/core"/></para>
     /// </summary>
-    public class ResourceDirectory : IEquatable<ResourceDirectory>
+    public sealed class ResourceDirectory : IEquatable<ResourceDirectory>
     {
-        private readonly DirectoryInfo _directory;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="ResourceDirectory"/> class.
         /// </summary>
@@ -18,10 +17,7 @@ namespace Arcus.Testing
         /// <exception cref="DirectoryNotFoundException">Thrown when no directory was found on disk for the given <paramref name="directory"/>.</exception>
         public ResourceDirectory(DirectoryInfo directory)
         {
-            if (directory is null)
-            {
-                throw new ArgumentNullException(nameof(directory));
-            }
+            ArgumentNullException.ThrowIfNull(directory);
 
             if (!Directory.Exists(directory.FullName))
             {
@@ -31,13 +27,13 @@ namespace Arcus.Testing
                     $"Resource directory: {directory.FullName}");
             }
 
-            _directory = directory;
+            Path = directory;
         }
 
         /// <summary>
         /// Gets the path of the current resource directory.
         /// </summary>
-        public DirectoryInfo Path => _directory;
+        public DirectoryInfo Path { get; }
 
         /// <summary>
         /// Gets the root application working directory as test resource directory.
@@ -45,23 +41,23 @@ namespace Arcus.Testing
         public static ResourceDirectory CurrentDirectory => new(new DirectoryInfo(Directory.GetCurrentDirectory()));
 
         /// <summary>
-        /// Creates a test resource sub-directory based on the current test resource directory.
+        /// Creates a test resource subdirectory based on the current test resource directory.
         /// </summary>
-        /// <param name="subDirectoryName">The name of the sub-directory within the current test resource directory.</param>
-        /// <returns>The test resource sub-directory.</returns>
+        /// <param name="subDirectoryName">The name of the subdirectory within the current test resource directory.</param>
+        /// <returns>The test resource subdirectory.</returns>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="subDirectoryName"/> is blank.</exception>
         /// <exception cref="DirectoryNotFoundException">
-        ///     Thrown when no test resource sub-directory is found within the current test resource directory with the given <paramref name="subDirectoryName"/>.
+        ///     Thrown when no test resource subdirectory is found within the current test resource directory with the given <paramref name="subDirectoryName"/>.
         /// </exception>
         public ResourceDirectory WithSubDirectory(string subDirectoryName)
         {
             if (string.IsNullOrWhiteSpace(subDirectoryName))
             {
                 throw new ArgumentException(
-                    $"Requires a non-blank sub-directory name to create a test resource sub-directory in the root test directory: '{_directory.FullName}'", nameof(subDirectoryName));
+                    $"Requires a non-blank sub-directory name to create a test resource sub-directory in the root test directory: '{Path.FullName}'", nameof(subDirectoryName));
             }
 
-            string newDirectoryPath = System.IO.Path.Combine(_directory.FullName, subDirectoryName);
+            string newDirectoryPath = System.IO.Path.Combine(Path.FullName, subDirectoryName);
             if (!Directory.Exists(newDirectoryPath))
             {
                 throw new DirectoryNotFoundException(
@@ -143,12 +139,9 @@ namespace Arcus.Testing
 
         private FileInfo GetFileByPattern(string searchPattern)
         {
-            if (string.IsNullOrWhiteSpace(searchPattern))
-            {
-                throw new ArgumentException("Requires a non-blank search pattern to retrieve the contents of a test resource file in the resource directory", nameof(searchPattern));
-            }
+            ArgumentException.ThrowIfNullOrWhiteSpace(searchPattern);
 
-            FileInfo[] files = _directory.GetFiles(searchPattern);
+            FileInfo[] files = Path.GetFiles(searchPattern);
             if (files.Length == 0)
             {
                 throw new FileNotFoundException(
@@ -187,7 +180,7 @@ namespace Arcus.Testing
                 return false;
             }
 
-            return _directory.FullName.Equals(other._directory.FullName, StringComparison.InvariantCultureIgnoreCase);
+            return Path.FullName.Equals(other.Path.FullName, StringComparison.InvariantCultureIgnoreCase);
         }
 
         /// <summary>
@@ -207,7 +200,7 @@ namespace Arcus.Testing
         /// <returns>A hash code for the current object.</returns>
         public override int GetHashCode()
         {
-            return _directory.GetHashCode();
+            return Path.GetHashCode();
         }
 
         /// <summary>
@@ -233,13 +226,13 @@ namespace Arcus.Testing
         }
 
         /// <summary>
-        /// Appends to the <paramref name="current"/> test resource directory a sub-directory based on the given <paramref name="subDirectoryName"/>.
+        /// Appends to the <paramref name="current"/> test resource directory a subdirectory based on the given <paramref name="subDirectoryName"/>.
         /// </summary>
         /// <param name="current">The subject test resource directory currently.</param>
-        /// <param name="subDirectoryName">The name of the sub-directory within the current test resource directory.</param>
+        /// <param name="subDirectoryName">The name of the subdirectory within the current test resource directory.</param>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="subDirectoryName"/> is blank.</exception>
         /// <exception cref="DirectoryNotFoundException">
-        ///     Thrown when no test resource sub-directory is found within the current test resource directory with the given <paramref name="subDirectoryName"/>.
+        ///     Thrown when no test resource subdirectory is found within the current test resource directory with the given <paramref name="subDirectoryName"/>.
         /// </exception>
         public static ResourceDirectory operator /(ResourceDirectory current, string subDirectoryName)
         {

--- a/src/Arcus.Testing.Core/TemporaryEnvironmentVariable.cs
+++ b/src/Arcus.Testing.Core/TemporaryEnvironmentVariable.cs
@@ -54,11 +54,7 @@ namespace Arcus.Testing
             bool isSecret,
             ILogger logger)
         {
-            if (string.IsNullOrWhiteSpace(variableName))
-            {
-                throw new ArgumentException("Environment variable name cannot be blank", nameof(variableValue));
-            }
-
+            ArgumentException.ThrowIfNullOrWhiteSpace(variableName);
             logger ??= NullLogger.Instance;
 
             string currentValue = Environment.GetEnvironmentVariable(variableName);

--- a/src/Arcus.Testing.Core/TestConfig.cs
+++ b/src/Arcus.Testing.Core/TestConfig.cs
@@ -17,14 +17,12 @@ namespace Arcus.Testing
         /// Override the default 'appsettings.json' JSON path where the test configuration values are retrieved from.
         /// </summary>
         /// <param name="path">The new default path (currently: 'appsettings.json').</param>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="path"/> is blank.</exception>
         public TestConfigOptions UseMainJsonFile(string path)
         {
-            if (string.IsNullOrWhiteSpace(path))
-            {
-                throw new ArgumentException("Requires a non-blank relative path to the '*.json' file used as the default for the test configuration", nameof(path));
-            }
-
+            ArgumentException.ThrowIfNullOrWhiteSpace(path);
             MainJsonPath = path;
+
             return this;
         }
 
@@ -32,14 +30,12 @@ namespace Arcus.Testing
         /// Adds the JSON configuration provider at <paramref name="path" /> the configuration.
         /// </summary>
         /// <param name="path">The path relative to the project output folder of the test suite project.</param>
+        /// <exception cref="path">Thrown when the <paramref name="path"/> is blank.</exception>
         public TestConfigOptions AddOptionalJsonFile(string path)
         {
-            if (string.IsNullOrWhiteSpace(path))
-            {
-                throw new ArgumentException("Requires a non-blank relative path to the '*.json' file used for the test configuration", nameof(path));
-            }
-
+            ArgumentException.ThrowIfNullOrWhiteSpace(path);
             _localAppSettingsNames.Add(path);
+
             return this;
         }
 

--- a/src/Arcus.Testing.Core/TestConfig.cs
+++ b/src/Arcus.Testing.Core/TestConfig.cs
@@ -30,7 +30,7 @@ namespace Arcus.Testing
         /// Adds the JSON configuration provider at <paramref name="path" /> the configuration.
         /// </summary>
         /// <param name="path">The path relative to the project output folder of the test suite project.</param>
-        /// <exception cref="path">Thrown when the <paramref name="path"/> is blank.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="path"/> is blank.</exception>
         public TestConfigOptions AddOptionalJsonFile(string path)
         {
             ArgumentException.ThrowIfNullOrWhiteSpace(path);


### PR DESCRIPTION
Uses the new .NET 8 constructs to argument-check parameters, together with additional streamlining on the links to the feature documentation and including default values in the XML code docs.

Relates to #356 