### PR TITLE
chore(logging): streamline w/ net8.0 constructs in logging

### DIFF
--- a/src/Arcus.Testing.Logging.MSTest/MSTestLogger.cs
+++ b/src/Arcus.Testing.Logging.MSTest/MSTestLogger.cs
@@ -18,7 +18,8 @@ namespace Arcus.Testing
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="testContext"/> is <c>null</c>.</exception>
         public MSTestLogger(TestContext testContext)
         {
-            _testContext = testContext ?? throw new ArgumentNullException(nameof(testContext));
+            ArgumentNullException.ThrowIfNull(testContext);
+            _testContext = testContext;
         }
 
         /// <summary>
@@ -67,6 +68,22 @@ namespace Arcus.Testing
         public IDisposable BeginScope<TState>(TState state)
         {
             return null;
+        }
+    }
+
+    /// <summary>
+    /// <see cref="ILogger"/> representation of a MSTest <see cref="TestContext"/>.
+    /// </summary>
+    /// <typeparam name="TCategoryName">The type whose name is used for the logger category name.</typeparam>
+    public class MSTestLogger<TCategoryName> : MSTestLogger, ILogger<TCategoryName>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MSTestLogger" /> class.
+        /// </summary>
+        /// <param name="testContext">The MSTest context to write custom test output.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="testContext"/> is <c>null</c>.</exception>
+        public MSTestLogger(TestContext testContext) : base(testContext)
+        {
         }
     }
 }

--- a/src/Arcus.Testing.Logging.NUnit/NUnitTestLogger.cs
+++ b/src/Arcus.Testing.Logging.NUnit/NUnitTestLogger.cs
@@ -18,11 +18,7 @@ namespace Arcus.Testing
         /// <exception cref="ArgumentException">Thrown when the <paramref name="testContextOut"/> is <c>null</c>.</exception>
         public NUnitTestLogger(TextWriter testContextOut)
         {
-            if (testContextOut is null)
-            {
-                throw new ArgumentNullException(nameof(testContextOut));
-            }
-
+            ArgumentNullException.ThrowIfNull(testContextOut);
             _testContextOut = testContextOut;
         }
 
@@ -34,15 +30,8 @@ namespace Arcus.Testing
         /// <exception cref="ArgumentException">Thrown when the <paramref name="testContextOut"/> or the <paramref name="testContextError"/> is <c>null</c>.</exception>
         public NUnitTestLogger(TextWriter testContextOut, TextWriter testContextError)
         {
-            if (testContextOut is null)
-            {
-                throw new ArgumentNullException(nameof(testContextOut));
-            }
-
-            if (testContextError is null)
-            {
-                throw new ArgumentNullException(nameof(testContextError));
-            }
+            ArgumentNullException.ThrowIfNull(testContextOut);
+            ArgumentNullException.ThrowIfNull(testContextError);
 
             _testContextOut = testContextOut;
             _testContextError = testContextError;
@@ -112,7 +101,7 @@ namespace Arcus.Testing
     /// <summary>
     /// <see cref="ILogger"/> representation of a NUnit logger.
     /// </summary>
-    /// <typeparam name="TCategoryName">The type who's name is used for the logger category name.</typeparam>
+    /// <typeparam name="TCategoryName">The type whose name is used for the logger category name.</typeparam>
     public class NUnitTestLogger<TCategoryName> : NUnitTestLogger, ILogger<TCategoryName>
     {
         /// <summary>

--- a/src/Arcus.Testing.Logging.Xunit/XunitTestLogger.cs
+++ b/src/Arcus.Testing.Logging.Xunit/XunitTestLogger.cs
@@ -15,13 +15,10 @@ namespace Arcus.Testing
         /// Initializes a new instance of the <see cref="XunitTestLogger"/> class.
         /// </summary>
         /// <param name="testOutput">The xUnit test output logger.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="testOutput"/> is <c>null</c>.</exception>
         public XunitTestLogger(ITestOutputHelper testOutput)
         {
-            if (testOutput is null)
-            {
-                throw new ArgumentNullException(nameof(testOutput));
-            }
-
+            ArgumentNullException.ThrowIfNull(testOutput);
             _testOutput = testOutput;
         }
 
@@ -66,7 +63,7 @@ namespace Arcus.Testing
     /// <summary>
     /// <see cref="ILogger"/> representation of a xUnit <see cref="ITestOutputHelper"/> logger.
     /// </summary>
-    /// <typeparam name="TCategoryName">The type who's name is used for the logger category name.</typeparam>
+    /// <typeparam name="TCategoryName">The type whose name is used for the logger category name.</typeparam>
     public class XunitTestLogger<TCategoryName> : XunitTestLogger, ILogger<TCategoryName>
     {
         /// <summary>

--- a/src/Arcus.Testing.Tests.Unit/Logging/MSTestLoggerTests.cs
+++ b/src/Arcus.Testing.Tests.Unit/Logging/MSTestLoggerTests.cs
@@ -15,7 +15,7 @@ namespace Arcus.Testing.Tests.Unit.Logging
         {
             // Arrange
             var mockContext = new MockTestContext();
-            var logger = new MSTestLogger(mockContext);
+            var logger = new MSTestLogger<MSTestLoggerTests>(mockContext);
             string message = Bogus.Lorem.Sentence();
 
             // Act
@@ -30,7 +30,7 @@ namespace Arcus.Testing.Tests.Unit.Logging
         {
             // Arrange
             var mockContext = new MockTestContext();
-            var logger = new MSTestLogger(mockContext);
+            var logger = new MSTestLogger<int>(mockContext);
             Exception exception = Bogus.System.Exception();
             string message = Bogus.Lorem.Sentence();
 


### PR DESCRIPTION
Use the new .NET 8 constructs for argument checking throughout the logging libraries, streamlining along the way. Plus, adding the missing `MSTestLogger<TCategoryName>` (#364).


Relates to #356 
Closes #364 