### PR TITLE
chore(table): use net8.0 arg constructs in table library

### DIFF
--- a/src/Arcus.Testing.Storage.Table/TemporaryTable.cs
+++ b/src/Arcus.Testing.Storage.Table/TemporaryTable.cs
@@ -235,12 +235,7 @@ namespace Arcus.Testing
             ILogger logger,
             Action<TemporaryTableOptions> configureOptions)
         {
-            if (string.IsNullOrWhiteSpace(accountName))
-            {
-                throw new ArgumentException(
-                    "Requires a non-blank Azure Storage account name to create a temporary Azure Table test fixture," +
-                    " used in container URI: 'https://{account_name}.table.core.windows.net'", nameof(accountName));
-            }
+            ArgumentException.ThrowIfNullOrWhiteSpace(accountName);
 
             var tableEndpoint = new Uri($"https://{accountName}.table.core.windows.net");
             var serviceClient = new TableServiceClient(tableEndpoint, new DefaultAzureCredential());
@@ -277,13 +272,7 @@ namespace Arcus.Testing
             Action<TemporaryTableOptions> configureOptions)
         {
             ArgumentNullException.ThrowIfNull(serviceClient);
-            ArgumentNullException.ThrowIfNull(tableName);
-
-            if (string.IsNullOrWhiteSpace(tableName))
-            {
-                throw new ArgumentException(
-                    "Requires a non-blank Azure Table nme to create a temporary Azure Table test fixture", nameof(tableName));
-            }
+            ArgumentException.ThrowIfNullOrWhiteSpace(tableName);
 
             logger ??= NullLogger.Instance;
             var options = new TemporaryTableOptions();

--- a/src/Arcus.Testing.Storage.Table/TemporaryTableEntity.cs
+++ b/src/Arcus.Testing.Storage.Table/TemporaryTableEntity.cs
@@ -57,18 +57,8 @@ namespace Arcus.Testing
             ILogger logger)
             where TEntity : class, ITableEntity
         {
-            if (string.IsNullOrWhiteSpace(accountName))
-            {
-                throw new ArgumentException(
-                    "Requires a non-blank Azure Storage account name to create a temporary Azure Table entity test fixture," +
-                    " used in container URI: 'https://{account_name}.table.core.windows.net'", nameof(accountName));
-            }
-
-            if (string.IsNullOrWhiteSpace(tableName))
-            {
-                throw new ArgumentException(
-                    "Requires a non-blank Azure Table nme to create a temporary Azure Table entity test fixture", nameof(tableName));
-            }
+            ArgumentException.ThrowIfNullOrWhiteSpace(accountName);
+            ArgumentException.ThrowIfNullOrWhiteSpace(tableName);
 
             var tableEndpoint = new Uri($"https://{accountName}.table.core.windows.net");
             var tableClient = new TableClient(tableEndpoint, tableName, new DefaultAzureCredential());


### PR DESCRIPTION
improve the handling of null or whitespace arguments by using the new `ArgumentException.ThrowIfNullOrWhiteSpace` method. These changes help to simplify the code and make it more readable.