### PR TITLE
chore(service-bus): use net8.0 arg constructs in messaging library

### DIFF
--- a/src/Arcus.Testing.Messaging.ServiceBus/ServiceBusMessageFilter.cs
+++ b/src/Arcus.Testing.Messaging.ServiceBus/ServiceBusMessageFilter.cs
@@ -72,10 +72,7 @@ namespace Arcus.Testing
         /// <exception cref="ArgumentOutOfRangeException">Thrown when the <paramref name="maxMessages"/> is below one.</exception>
         public ServiceBusMessageFilter Take(int maxMessages)
         {
-            if (maxMessages < 1)
-            {
-                throw new ArgumentOutOfRangeException(nameof(maxMessages), maxMessages, "Requires at least a single message to be taken from the Azure Service bus");
-            }
+            ArgumentOutOfRangeException.ThrowIfLessThan(maxMessages, 1);
 
             _maxMessages = maxMessages;
             return this;

--- a/src/Arcus.Testing.Messaging.ServiceBus/TemporaryQueue.cs
+++ b/src/Arcus.Testing.Messaging.ServiceBus/TemporaryQueue.cs
@@ -73,10 +73,7 @@ namespace Arcus.Testing
         /// <exception cref="ArgumentOutOfRangeException">Thrown when the <paramref name="maxWaitTime"/> is a negative duration.</exception>
         public OnSetupTemporaryQueueOptions DeadLetterMessages(TimeSpan maxWaitTime)
         {
-            if (maxWaitTime < TimeSpan.Zero)
-            {
-                throw new ArgumentOutOfRangeException(nameof(maxWaitTime), maxWaitTime, "Requires positive time duration to represent the maximum wait time for messages");
-            }
+            ArgumentOutOfRangeException.ThrowIfLessThan(maxWaitTime, TimeSpan.Zero);
 
             MaxWaitTime = maxWaitTime;
             Messages = OnSetupQueue.DeadLetterMessages;
@@ -127,10 +124,7 @@ namespace Arcus.Testing
         /// <exception cref="ArgumentOutOfRangeException">Thrown when the <paramref name="maxWaitTime"/> is a negative duration.</exception>
         public OnSetupTemporaryQueueOptions CompleteMessages(TimeSpan maxWaitTime)
         {
-            if (maxWaitTime < TimeSpan.Zero)
-            {
-                throw new ArgumentOutOfRangeException(nameof(maxWaitTime), maxWaitTime, "Requires positive time duration to represent the maximum wait time for messages");
-            }
+            ArgumentOutOfRangeException.ThrowIfLessThan(maxWaitTime, TimeSpan.Zero);
 
             MaxWaitTime = maxWaitTime;
             Messages = OnSetupQueue.CompleteMessages;
@@ -228,10 +222,7 @@ namespace Arcus.Testing
         /// <exception cref="ArgumentOutOfRangeException">Thrown when the <paramref name="maxWaitTime"/> is a negative duration.</exception>
         public OnTeardownTemporaryQueueOptions DeadLetterMessages(TimeSpan maxWaitTime)
         {
-            if (maxWaitTime < TimeSpan.Zero)
-            {
-                throw new ArgumentOutOfRangeException(nameof(maxWaitTime), maxWaitTime, "Requires positive time duration to represent the maximum wait time for messages");
-            }
+            ArgumentOutOfRangeException.ThrowIfLessThan(maxWaitTime, TimeSpan.Zero);
 
             MaxWaitTime = maxWaitTime;
             Messages = OnTeardownQueue.DeadLetterMessages;
@@ -295,10 +286,7 @@ namespace Arcus.Testing
         /// <exception cref="ArgumentOutOfRangeException">Thrown when the <paramref name="maxWaitTime"/> is a negative duration.</exception>
         public OnTeardownTemporaryQueueOptions CompleteMessages(TimeSpan maxWaitTime)
         {
-            if (maxWaitTime < TimeSpan.Zero)
-            {
-                throw new ArgumentOutOfRangeException(nameof(maxWaitTime), maxWaitTime, "Requires positive time duration to represent the maximum wait time for messages");
-            }
+            ArgumentOutOfRangeException.ThrowIfLessThan(maxWaitTime, TimeSpan.Zero);
 
             MaxWaitTime = maxWaitTime;
             Messages = OnTeardownQueue.CompleteMessages;
@@ -467,11 +455,7 @@ namespace Arcus.Testing
             ILogger logger,
             Action<TemporaryQueueOptions> configureOptions)
         {
-            if (string.IsNullOrWhiteSpace(fullyQualifiedNamespace))
-            {
-                throw new ArgumentException(
-                    "Requires a non-blank fully-qualified Azure Service bus namespace to set up a temporary queue", nameof(fullyQualifiedNamespace));
-            }
+            ArgumentException.ThrowIfNullOrWhiteSpace(fullyQualifiedNamespace);
 
             var credential = new DefaultAzureCredential();
             var adminClient = new ServiceBusAdministrationClient(fullyQualifiedNamespace, credential);
@@ -537,13 +521,8 @@ namespace Arcus.Testing
             Action<TemporaryQueueOptions> configureOptions)
         {
             ArgumentNullException.ThrowIfNull(adminClient);
+            ArgumentException.ThrowIfNullOrWhiteSpace(queueName);
             logger ??= NullLogger.Instance;
-
-            if (string.IsNullOrWhiteSpace(queueName))
-            {
-                throw new ArgumentException(
-                    "Requires a non-blank Azure Service bus queue name to set up a temporary queue", nameof(queueName));
-            }
 
             var options = new TemporaryQueueOptions();
             configureOptions?.Invoke(options);

--- a/src/Arcus.Testing.Messaging.ServiceBus/TemporaryTopic.cs
+++ b/src/Arcus.Testing.Messaging.ServiceBus/TemporaryTopic.cs
@@ -71,10 +71,7 @@ namespace Arcus.Testing
         /// <exception cref="ArgumentOutOfRangeException">Thrown when the <paramref name="maxWaitTime"/> is a negative duration.</exception>
         public OnSetupTemporaryTopicOptions DeadLetterMessages(TimeSpan maxWaitTime)
         {
-            if (maxWaitTime < TimeSpan.Zero)
-            {
-                throw new ArgumentOutOfRangeException(nameof(maxWaitTime), maxWaitTime, "Requires positive time duration to represent the maximum wait time for messages");
-            }
+            ArgumentOutOfRangeException.ThrowIfLessThan(maxWaitTime, TimeSpan.Zero);
 
             MaxWaitTime = maxWaitTime;
             Messages = OnSetupMessagesTopic.DeadLetterMessages;
@@ -122,11 +119,8 @@ namespace Arcus.Testing
         /// <exception cref="ArgumentOutOfRangeException">Thrown when the <paramref name="maxWaitTime"/> is a negative duration.</exception>
         public OnSetupTemporaryTopicOptions CompleteMessages(TimeSpan maxWaitTime)
         {
-            if (maxWaitTime < TimeSpan.Zero)
-            {
-                throw new ArgumentOutOfRangeException(nameof(maxWaitTime), maxWaitTime, "Requires positive time duration to represent the maximum wait time for messages");
-            }
-
+            ArgumentOutOfRangeException.ThrowIfLessThan(maxWaitTime, TimeSpan.Zero);
+            
             MaxWaitTime = maxWaitTime;
             Messages = OnSetupMessagesTopic.CompleteMessages;
             
@@ -222,10 +216,7 @@ namespace Arcus.Testing
         /// <exception cref="ArgumentOutOfRangeException">Thrown when the <paramref name="maxWaitTime"/> is a negative duration.</exception>
         public OnTeardownTemporaryTopicOptions DeadLetterMessages(TimeSpan maxWaitTime)
         {
-            if (maxWaitTime < TimeSpan.Zero)
-            {
-                throw new ArgumentOutOfRangeException(nameof(maxWaitTime), maxWaitTime, "Requires positive time duration to represent the maximum wait time for messages");
-            }
+            ArgumentOutOfRangeException.ThrowIfLessThan(maxWaitTime, TimeSpan.Zero);
 
             MaxWaitTime = maxWaitTime;
             Messages = OnTeardownMessagesTopic.DeadLetterMessages;
@@ -289,10 +280,7 @@ namespace Arcus.Testing
         /// <exception cref="ArgumentOutOfRangeException">Thrown when the <paramref name="maxWaitTime"/> is a negative duration.</exception>
         public OnTeardownTemporaryTopicOptions CompleteMessages(TimeSpan maxWaitTime)
         {
-            if (maxWaitTime < TimeSpan.Zero)
-            {
-                throw new ArgumentOutOfRangeException(nameof(maxWaitTime), maxWaitTime, "Requires positive time duration to represent the maximum wait time for messages");
-            }
+            ArgumentOutOfRangeException.ThrowIfLessThan(maxWaitTime, TimeSpan.Zero);
 
             MaxWaitTime = maxWaitTime;
             Messages = OnTeardownMessagesTopic.CompleteMessages;
@@ -465,11 +453,7 @@ namespace Arcus.Testing
             ILogger logger,
             Action<TemporaryTopicOptions> configureOptions)
         {
-            if (string.IsNullOrWhiteSpace(fullyQualifiedNamespace))
-            {
-                throw new ArgumentException(
-                    "Requires a non-blank fully-qualified Azure Service bus namespace to create a temporary topic", nameof(fullyQualifiedNamespace));
-            }
+            ArgumentException.ThrowIfNullOrWhiteSpace(fullyQualifiedNamespace);
 
             var credential = new DefaultAzureCredential();
             var adminClient = new ServiceBusAdministrationClient(fullyQualifiedNamespace, credential);
@@ -532,13 +516,8 @@ namespace Arcus.Testing
         {
             ArgumentNullException.ThrowIfNull(adminClient);
             ArgumentNullException.ThrowIfNull(messagingClient);
+            ArgumentException.ThrowIfNullOrWhiteSpace(topicName);
             logger ??= NullLogger.Instance;
-
-            if (string.IsNullOrWhiteSpace(topicName))
-            {
-                throw new ArgumentException(
-                    "Requires a non-blank Azure Service Bus topic name to create a temporary topic", nameof(topicName));
-            }
 
             var options = new TemporaryTopicOptions();
             configureOptions?.Invoke(options);

--- a/src/Arcus.Testing.Messaging.ServiceBus/TemporaryTopicSubscription.cs
+++ b/src/Arcus.Testing.Messaging.ServiceBus/TemporaryTopicSubscription.cs
@@ -145,11 +145,7 @@ namespace Arcus.Testing
             ILogger logger,
             Action<TemporaryTopicSubscriptionOptions> configureOptions)
         {
-            if (string.IsNullOrWhiteSpace(fullyQualifiedNamespace))
-            {
-                throw new ArgumentException(
-                    "Requires a non-blank Azure Service bus namespace to create a temporary topic subscription", nameof(fullyQualifiedNamespace));
-            }
+            ArgumentException.ThrowIfNullOrWhiteSpace(fullyQualifiedNamespace);
 
             var client = new ServiceBusAdministrationClient(fullyQualifiedNamespace, new DefaultAzureCredential());
             return await CreateIfNotExistsAsync(client, topicName, subscriptionName, logger, configureOptions);
@@ -201,19 +197,8 @@ namespace Arcus.Testing
             Action<TemporaryTopicSubscriptionOptions> configureOptions)
         {
             ArgumentNullException.ThrowIfNull(adminClient);
-
-            if (string.IsNullOrWhiteSpace(topicName))
-            {
-                throw new ArgumentException(
-                    "Requires a non-blank Azure Service bus topic name to create a temporary topic subscription", nameof(topicName));
-            }
-
-            if (string.IsNullOrWhiteSpace(subscriptionName))
-            {
-                throw new ArgumentException(
-                    "Requires a non-blank Azure Service bus topic subscription name to create a temporary topic subscription", nameof(subscriptionName));
-            }
-
+            ArgumentException.ThrowIfNullOrWhiteSpace(topicName);
+            ArgumentException.ThrowIfNullOrWhiteSpace(subscriptionName);
             logger ??= NullLogger.Instance;
 
             var options = new TemporaryTopicSubscriptionOptions();
@@ -255,7 +240,7 @@ namespace Arcus.Testing
         {
             ArgumentNullException.ThrowIfNull(ruleName);
             ArgumentNullException.ThrowIfNull(ruleFilter);
-
+            
             if (ruleName == CreateRuleOptions.DefaultRuleName)
             {
                 throw new ArgumentException(

--- a/src/Arcus.Testing.Messaging.ServiceBus/TemporaryTopicSubscription.cs
+++ b/src/Arcus.Testing.Messaging.ServiceBus/TemporaryTopicSubscription.cs
@@ -240,7 +240,7 @@ namespace Arcus.Testing
         {
             ArgumentNullException.ThrowIfNull(ruleName);
             ArgumentNullException.ThrowIfNull(ruleFilter);
-            
+
             if (ruleName == CreateRuleOptions.DefaultRuleName)
             {
                 throw new ArgumentException(


### PR DESCRIPTION
The primary change is the replacement of manual argument validation with the use of built-in exception methods for cleaner and more concise code.