### PR TITLE
feat(storage): add initial file-share dir+file fixtures

### DIFF
--- a/docs/preview/03-Features/04-Azure/04-Storage/01-storage-account.mdx
+++ b/docs/preview/03-Features/04-Azure/04-Storage/01-storage-account.mdx
@@ -290,9 +290,8 @@ await TemporaryShareDirectory.CreateIfNotExistsAsync(..., options =>
     // Options related to when the test fixture is teared down.
     // --------------------------------------------------------
 
-    // (Default for cleaning items)
-    // Delete Azure Share items upon the test fixture disposal that were added by the fixture.
-    options.OnTeardown.CleanCreatedItems();
+    // (Default) Delete Azure Share items upon the test fixture disposal that were upserted by the fixture.
+    options.OnTeardown.CleanUpsertedItems();
 
     // Delete all Azure Share items upon the test fixture disposal, 
     // even if the test fixture didn't added them.
@@ -300,7 +299,7 @@ await TemporaryShareDirectory.CreateIfNotExistsAsync(..., options =>
 
     // Delete additional Azure Share items that matches any of the configured filters, 
     // upon the test fixture disposal.
-    // ⚠️ Items added by the test fixture itself will always be deleted.
+    // ⚠️ Items upserted by the test fixture itself will always be deleted/reverted.
     options.OnTeardown.CleanMatchingItems((ShareFileItem item) => item.Name == "TestFile");
 });
 

--- a/docs/preview/03-Features/04-Azure/04-Storage/01-storage-account.mdx
+++ b/docs/preview/03-Features/04-Azure/04-Storage/01-storage-account.mdx
@@ -217,4 +217,115 @@ await using var entity = await TemporaryTableEntity.AddIfNotExistsAsync(
 > 🎖️ Overloads are available to fully control the authentication mechanism to Azure Table storage. By default, it uses the [`DefaultAzureCredential`](https://learn.microsoft.com/en-us/dotnet/api/azure.identity.defaultazurecredential).
 
 </TabItem>
+<TabItem value="file-share" label="File share storage">
+
+The `Arcus.Testing.Storage.File.Share` package provides test fixtures related to Azure File share storage. By using the common testing practice 'clean environment', it provides a temporary Share directory and Share file.
+
+## Installation
+The following functionality is available when installing this package:
+
+```powershell
+PM> Install-Package -Name Arcus.Testing.Storage.File.Share
+```
+
+> ⚠️ When using `TokenCredential` overloads (recommended: managed-identity), make sure to:
+> * 🛡️ enable [Identity-based access for file shares](https://learn.microsoft.com/en-us/azure/storage/files/storage-files-identity-auth-domain-services-enable?tabs=azure-portal) to make sure that the file shares can be accessed via Entra ID.
+>* 🛡️ Make sure that the test client that interacts with the File share storage has at least [`Storage File Data SMB Share Contributor`](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles/storage#storage-file-data-smb-share-contributor)-rights if the test needs to create/update/delete share directories/files.
+> * 🛡️ include the [Share token intent](https://learn.microsoft.com/en-us/azure/storage/files/authorize-oauth-rest?tabs=portal#authorize-access-to-file-data-in-application-code), otherwise the file operations won't get authorized correctly.
+
+## Temporary share directory
+The `TemporaryShareDirectory` provides a solution when the integration test requires a storage system (file share) during the test run. An Azure Share directory is created upon the setup of the test fixture and is deleted again when the test fixture is disposed.
+
+```csharp
+using Arcus.Testing;
+using Azure.Storage.Files.Shares;
+
+var shareClient = new ShareClient(...);
+
+await using var directory = await TemporaryShareDirectory.CreateIfNotExistsAsync(
+    shareClient, "<directory-name", logger);
+
+// Interact with the directory during the lifetime of the fixture.
+ShareDirectoryClient client = directory.Client;
+```
+
+Uploading files to the directory can also be done via the test fixture. It always make sure that any uploaded files will be deleted afterwards upon disposal.
+
+```csharp
+using Arcus.Testing;
+
+await using TemporaryShareDirectory directory = ...
+
+string fileName = "TestFile";
+await using Stream fileContents = File.OpenRead(...);
+
+await directory.UploadFileAsync(fileName, fileContents);
+```
+
+### Customization
+The setup and teardown process of the temporary table is configurable. **By default, it always removes any resources that it was responsible for creating.**
+
+> ❔ Both files and subdirectories are meant by 'Azure Share items':
+
+```csharp
+using Arcus.Testing;
+
+await TemporaryShareDirectory.CreateIfNotExistsAsync(..., options =>
+{
+    // Options related to when the test fixture is set up.
+    // ---------------------------------------------------
+
+    // (Default) Leaves all Azure Share items untouched that already existed,
+    // upon the test fixture creation, when there was already an Azure Share available.
+    options.OnSetup.LeaveAllItems();
+
+    // Delete all Azure Share items upon the test fixture creation, 
+    // when there was already an Azure Share available.
+    options.OnSetup.CleanAllItems();
+
+    // Delete Azure Share items that matches any of the configured filters, 
+    // upon the test fixture creation, when there was already an Azure Share available.
+    options.OnSetup.CleanMatchingItems((ShareFileItem item) => item.Name == "TestFile");
+
+    // Options related to when the test fixture is teared down.
+    // --------------------------------------------------------
+
+    // (Default for cleaning items)
+    // Delete Azure Share items upon the test fixture disposal that were added by the fixture.
+    options.OnTeardown.CleanCreatedItems();
+
+    // Delete all Azure Share items upon the test fixture disposal, 
+    // even if the test fixture didn't added them.
+    options.OnTeardown.CleanAllItems();
+
+    // Delete additional Azure Share items that matches any of the configured filters, 
+    // upon the test fixture disposal.
+    // ⚠️ Items added by the test fixture itself will always be deleted.
+    options.OnTeardown.CleanMatchingItems((ShareFileItem item) => item.Name == "TestFile");
+});
+
+// `OnTeardown` is also still available after the temporary directory is created:
+await using TemporaryShareDirectory directory = ...
+
+directory.OnTeardown.CleanAllItems();
+```
+
+> 🎖️ The `TemporaryShareDirectory` will always remove any Azure Share files that were added on the temporary directory  itself with the `directory.UploadFileAsync`. This follows the 'clean environment' testing principal that any test should not leave any state it created behind after the test has run.
+
+## Temporary share file
+The `TemporaryShareFile` provides a solution when the integration test requires data (file share) during the test run. An Azure Share file item is added upon the setup of the test fixture and is deleted again when the test fixture is disposed.
+
+```csharp
+using Arcus.Testing;
+
+ShareDirectoryClient client = ...
+
+string fileName = "TestFile";
+await using Stream fileContents = File.OpenRead(...);
+
+await using var file = await TemporaryShareFile.CreateIfNotExistsAsync(
+    client, fileName, fileContents, logger);
+```
+
+</TabItem>
 </Tabs>

--- a/docs/preview/03-Features/04-Azure/04-Storage/01-storage-account.mdx
+++ b/docs/preview/03-Features/04-Azure/04-Storage/01-storage-account.mdx
@@ -314,6 +314,8 @@ directory.OnTeardown.CleanAllItems();
 ## Temporary share file
 The `TemporaryShareFile` provides a solution when the integration test requires data (file share) during the test run. An Azure Share file item is added upon the setup of the test fixture and is deleted again when the test fixture is disposed.
 
+> ⚡ When the file already existed (already a file with a same file name), then the test fixture will revert to the original content of the file upon the test fixture disposal.
+
 ```csharp
 using Arcus.Testing;
 

--- a/docs/preview/03-Features/04-Azure/04-Storage/01-storage-account.mdx
+++ b/docs/preview/03-Features/04-Azure/04-Storage/01-storage-account.mdx
@@ -290,7 +290,7 @@ await TemporaryShareDirectory.CreateIfNotExistsAsync(..., options =>
     // Options related to when the test fixture is teared down.
     // --------------------------------------------------------
 
-    // (Default) Delete Azure Share items upon the test fixture disposal that were upserted by the fixture.
+    // (Default) Delete/Revert Azure Share items upon the test fixture disposal that were upserted by the fixture.
     options.OnTeardown.CleanUpsertedItems();
 
     // Delete all Azure Share items upon the test fixture disposal, 

--- a/docs/preview/03-Features/04-Azure/04-Storage/01-storage-account.mdx
+++ b/docs/preview/03-Features/04-Azure/04-Storage/01-storage-account.mdx
@@ -249,7 +249,7 @@ await using var directory = await TemporaryShareDirectory.CreateIfNotExistsAsync
 ShareDirectoryClient client = directory.Client;
 ```
 
-Uploading files to the directory can also be done via the test fixture. It always make sure that any uploaded files will be deleted (if the file was new) or reverted (if the file already existed) afterwards upon disposal.
+Upserting files to the directory can also be done via the test fixture. It always make sure that any uploaded files will be deleted (if the file was new) or reverted (if the file already existed) afterwards upon disposal.
 
 ```csharp
 using Arcus.Testing;

--- a/docs/preview/03-Features/04-Azure/04-Storage/01-storage-account.mdx
+++ b/docs/preview/03-Features/04-Azure/04-Storage/01-storage-account.mdx
@@ -323,7 +323,7 @@ ShareDirectoryClient client = ...
 string fileName = "TestFile";
 await using Stream fileContents = File.OpenRead(...);
 
-await using var file = await TemporaryShareFile.CreateIfNotExistsAsync(
+await using var file = await TemporaryShareFile.UpsertFileAsync(
     client, fileName, fileContents, logger);
 ```
 

--- a/docs/preview/03-Features/04-Azure/04-Storage/01-storage-account.mdx
+++ b/docs/preview/03-Features/04-Azure/04-Storage/01-storage-account.mdx
@@ -249,7 +249,7 @@ await using var directory = await TemporaryShareDirectory.CreateIfNotExistsAsync
 ShareDirectoryClient client = directory.Client;
 ```
 
-Uploading files to the directory can also be done via the test fixture. It always make sure that any uploaded files will be deleted afterwards upon disposal.
+Uploading files to the directory can also be done via the test fixture. It always make sure that any uploaded files will be deleted (if the file was new) or reverted (if the file already existed) afterwards upon disposal.
 
 ```csharp
 using Arcus.Testing;
@@ -259,7 +259,7 @@ await using TemporaryShareDirectory directory = ...
 string fileName = "TestFile";
 await using Stream fileContents = File.OpenRead(...);
 
-await directory.UploadFileAsync(fileName, fileContents);
+await directory.UpsertFileAsync(fileName, fileContents);
 ```
 
 ### Customization

--- a/src/Arcus.Testing.Storage.File.Share/Arcus.Testing.Storage.File.Share.csproj
+++ b/src/Arcus.Testing.Storage.File.Share/Arcus.Testing.Storage.File.Share.csproj
@@ -1,0 +1,39 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <RootNamespace>Arcus.Testing</RootNamespace>
+    <Authors>Arcus</Authors>
+    <Company>Arcus</Company>
+    <Description>Provides capabilities during testing of Azure File share storage interactions</Description>
+    <Copyright>Copyright (c) Arcus</Copyright>
+    <PackageProjectUrl>https://github.com/arcus-azure/arcus.testing</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/arcus-azure/arcus.testing</RepositoryUrl>
+    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageIcon>icon.png</PackageIcon>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <RepositoryType>Git</RepositoryType>
+    <PackageTags>Azure;Testing;Storage</PackageTags>
+    <PackageId>Arcus.Testing.Storage.File.Share</PackageId>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
+    <None Include="..\..\LICENSE" Pack="true" PackagePath="\" />
+    <None Include="..\..\docs\static\img\icon.png" Pack="true" PackagePath="\" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Azure.Identity" Version="[1.*,2.0.0)" />
+    <PackageReference Include="Azure.Storage.Files.Shares" Version="[12.*,13.0.0)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Arcus.Testing.Core\Arcus.Testing.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Arcus.Testing.Storage.File.Share/TemporaryShareDirectory.cs
+++ b/src/Arcus.Testing.Storage.File.Share/TemporaryShareDirectory.cs
@@ -287,16 +287,16 @@ namespace Arcus.Testing
         }
 
         /// <summary>
-        /// Uploads a file temporary to this directory share.
+        /// Creates a new or replaces an existing file in this directory share (a.k.a. UPSERT).
         /// </summary>
         /// <remarks>
-        ///     Any files uploaded here will be deleted when the <see cref="TemporaryShareDirectory"/> is disposed.
+        ///     Any files uploaded via this call will always be deleted (if new) or reverted (if existing) when this instance is disposed.
         /// </remarks>
         /// <param name="fileName">The name of the file to upload to the share directory.</param>
         /// <param name="fileContents">The contents of the file to upload to the share directory.</param>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="fileName"/> is blank.</exception>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="fileContents"/> is <c>null</c>.</exception>
-        public async Task UploadFileAsync(string fileName, Stream fileContents)
+        public async Task UpsertFileAsync(string fileName, Stream fileContents)
         {
             _files.Add(await TemporaryShareFile.UpsertFileAsync(Client, fileName, fileContents, _logger));
         }

--- a/src/Arcus.Testing.Storage.File.Share/TemporaryShareDirectory.cs
+++ b/src/Arcus.Testing.Storage.File.Share/TemporaryShareDirectory.cs
@@ -83,9 +83,9 @@ namespace Arcus.Testing
 
         /// <summary>
         /// (default) Configures the <see cref="TemporaryShareDirectory"/> to clean only the items (both files and directories) in the directory share
-        /// that the test fixture was responsible for creating, upon the deletion of the fixture.
+        /// that the test fixture was responsible for upserting (via <see cref="TemporaryShareDirectory.UpsertFileAsync"/>), upon the deletion of the fixture.
         /// </summary>
-        public OnTeardownTemporaryShareDirectoryOptions CleanCreatedItems()
+        public OnTeardownTemporaryShareDirectoryOptions CleanUpsertedItems()
         {
             Items = OnTeardownDirectoryShare.CleanIfCreated;
             return this;
@@ -142,7 +142,7 @@ namespace Arcus.Testing
         /// <summary>
         /// Gets the options to manipulate the deletion of the <see cref="TemporaryShareDirectory"/>.
         /// </summary>
-        public OnTeardownTemporaryShareDirectoryOptions OnTeardown { get; } = new OnTeardownTemporaryShareDirectoryOptions().CleanCreatedItems();
+        public OnTeardownTemporaryShareDirectoryOptions OnTeardown { get; } = new OnTeardownTemporaryShareDirectoryOptions().CleanUpsertedItems();
     }
 
     /// <summary>

--- a/src/Arcus.Testing.Storage.File.Share/TemporaryShareDirectory.cs
+++ b/src/Arcus.Testing.Storage.File.Share/TemporaryShareDirectory.cs
@@ -1,0 +1,395 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Threading.Tasks;
+using Azure;
+using Azure.Storage.Files.Shares;
+using Azure.Storage.Files.Shares.Models;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Arcus.Testing
+{
+    internal enum OnSetupDirectoryShare { LeaveExisted = 0, CleanIfExisted, CleanIfMatched }
+
+    internal enum OnTeardownDirectoryShare { CleanIfCreated = 0, CleanAll, CleanIfMatched }
+
+    /// <summary>
+    /// Represents the available options when creating a <see cref="TemporaryShareDirectory"/>.
+    /// </summary>
+    public class OnSetupTemporaryShareDirectoryOptions
+    {
+        private readonly List<Func<ShareFileItem, bool>> _filters = [];
+
+        internal OnSetupDirectoryShare Items { get; private set; }
+
+        /// <summary>
+        /// (default) Configures the <see cref="TemporaryShareDirectory"/> to leave all the items (both files and directories) in the directory share untouched
+        /// that already existed before the creation of the <see cref="TemporaryShareDirectory"/>.
+        /// </summary>
+        public OnSetupTemporaryShareDirectoryOptions LeaveAllItems()
+        {
+            Items = OnSetupDirectoryShare.LeaveExisted;
+            return this;
+        }
+
+        /// <summary>
+        /// Configures the <see cref="TemporaryShareDirectory"/> to clean all the items (both files and directories) in the directory share
+        /// that already existed before the creation of the <see cref="TemporaryShareDirectory"/>.
+        /// </summary>
+        public OnSetupTemporaryShareDirectoryOptions CleanAllItems()
+        {
+            Items = OnSetupDirectoryShare.CleanIfExisted;
+            return this;
+        }
+
+        /// <summary>
+        /// Configures the <see cref="TemporaryShareDirectory"/> to clean all the items (both files and directories) in the directory share
+        /// upon the creation of the test fixture that matches one of the provided <paramref name="filters"/>.
+        /// </summary>
+        /// <param name="filters">The filters to match the stored items in the directory share.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="filters"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="filters"/> contains a <c>null</c> element.</exception>
+        public OnSetupTemporaryShareDirectoryOptions CleanMatchingItems(params Func<ShareFileItem, bool>[] filters)
+        {
+            ArgumentNullException.ThrowIfNull(filters);
+
+            if (Array.Exists(filters, f => f is null))
+            {
+                throw new ArgumentException("Requires all provided Azure File share item filters to be non-null", nameof(filters));
+            }
+
+            _filters.AddRange(filters);
+            Items = OnSetupDirectoryShare.CleanIfMatched;
+
+            return this;
+        }
+
+        internal bool IsMatch(ShareFileItem item)
+        {
+            return _filters.Exists(f => f(item));
+        }
+    }
+
+    /// <summary>
+    /// Represents the available options when deleting a <see cref="TemporaryShareDirectory"/>.
+    /// </summary>
+    public class OnTeardownTemporaryShareDirectoryOptions
+    {
+        private readonly List<Func<ShareFileItem, bool>> _filters = [];
+
+        internal OnTeardownDirectoryShare Items { get; private set; }
+
+        /// <summary>
+        /// (default) Configures the <see cref="TemporaryShareDirectory"/> to clean only the items (both files and directories) in the directory share
+        /// that the test fixture was responsible for creating, upon the deletion of the fixture.
+        /// </summary>
+        public OnTeardownTemporaryShareDirectoryOptions CleanCreatedItems()
+        {
+            Items = OnTeardownDirectoryShare.CleanIfCreated;
+            return this;
+        }
+
+        /// <summary>
+        /// Configures the <see cref="TemporaryShareDirectory"/> to clean all the items (both files and directories) in the directory share
+        /// upon the deletion of the test fixture.
+        /// </summary>
+        public OnTeardownTemporaryShareDirectoryOptions CleanAllItems()
+        {
+            Items = OnTeardownDirectoryShare.CleanAll;
+            return this;
+        }
+
+        /// <summary>
+        /// Configures the <see cref="TemporaryShareDirectory"/> to clean all the items (both files and directories) in the directory share
+        /// upon the deletion of the test fixture that matches one of the provided <paramref name="filters"/>.
+        /// </summary>
+        /// <param name="filters">The filters to match the stored items in the directory share.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="filters"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="filters"/> contains a <c>null</c> element.</exception>
+        public OnTeardownTemporaryShareDirectoryOptions CleanMatchingItems(params Func<ShareFileItem, bool>[] filters)
+        {
+            ArgumentNullException.ThrowIfNull(filters);
+
+            if (Array.Exists(filters, f => f is null))
+            {
+                throw new ArgumentException("Requires all provided Azure File share item filters to be non-null", nameof(filters));
+            }
+
+            _filters.AddRange(filters);
+            Items = OnTeardownDirectoryShare.CleanIfMatched;
+
+            return this;
+        }
+
+        internal bool IsMatch(ShareFileItem item)
+        {
+            return _filters.Exists(filter => filter(item));
+        }
+    }
+
+    /// <summary>
+    /// Represents the available options to manipulate the behavior of the <see cref="TemporaryShareDirectory"/>.
+    /// </summary>
+    public class TemporaryShareDirectoryOptions
+    {
+        /// <summary>
+        /// Gets the options to manipulate the creation of the <see cref="TemporaryShareDirectory"/>.
+        /// </summary>
+        public OnSetupTemporaryShareDirectoryOptions OnSetup { get; } = new OnSetupTemporaryShareDirectoryOptions().LeaveAllItems();
+
+        /// <summary>
+        /// Gets the options to manipulate the deletion of the <see cref="TemporaryShareDirectory"/>.
+        /// </summary>
+        public OnTeardownTemporaryShareDirectoryOptions OnTeardown { get; } = new OnTeardownTemporaryShareDirectoryOptions().CleanCreatedItems();
+    }
+
+    /// <summary>
+    /// Represents a temporary directory share on an Azure Storage file share.
+    /// </summary>
+    public class TemporaryShareDirectory : IAsyncDisposable
+    {
+        private readonly bool _createdByUs;
+        private readonly Collection<TemporaryShareFile> _files = [];
+        private readonly TemporaryShareDirectoryOptions _options;
+        private readonly ILogger _logger;
+
+        private TemporaryShareDirectory(
+            ShareDirectoryClient client,
+            bool createdByUs,
+            TemporaryShareDirectoryOptions options,
+            ILogger logger)
+        {
+            ArgumentNullException.ThrowIfNull(client);
+
+            _createdByUs = createdByUs;
+            _options = options;
+            _logger = logger ?? NullLogger.Instance;
+
+            Client = client;
+        }
+
+        /// <summary>
+        /// Represents the client to interact with the temporary stored Azure Storage file share currently in storage.
+        /// </summary>
+        public ShareDirectoryClient Client { get; }
+
+        /// <summary>
+        /// Gets the options to manipulate the deletion of the <see cref="TemporaryShareDirectory"/>.
+        /// </summary>
+        public OnTeardownTemporaryShareDirectoryOptions OnTeardown => _options.OnTeardown;
+
+        /// <summary>
+        /// Creates a temporary directory share on an Azure Storage file share resource.
+        /// </summary>
+        /// <param name="shareClient">The client to interact with the Azure File share resource.</param>
+        /// <param name="directoryName">The name of the directory to create on the file share.</param>
+        /// <param name="logger">The logger instance to write diagnostic traces during the lifetime of the fixture.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="shareClient"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="directoryName"/> is blank.</exception>
+        public static async Task<TemporaryShareDirectory> CreateIfNotExistsAsync(ShareClient shareClient, string directoryName, ILogger logger)
+        {
+            return await CreateIfNotExistsAsync(shareClient, directoryName, logger, configureOptions: null);
+        }
+
+        /// <summary>
+        /// Creates a temporary directory share on an Azure Storage file share resource.
+        /// </summary>
+        /// <param name="shareClient">The client to interact with the Azure File share resource.</param>
+        /// <param name="directoryName">The name of the directory to create on the file share.</param>
+        /// <param name="logger">The logger instance to write diagnostic traces during the lifetime of the fixture.</param>
+        /// <param name="configureOptions">The additional options to manipulate the behavior of the test fixture during its lifetime.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="shareClient"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="directoryName"/> is blank.</exception>
+        public static async Task<TemporaryShareDirectory> CreateIfNotExistsAsync(
+            ShareClient shareClient,
+            string directoryName,
+            ILogger logger,
+            Action<TemporaryShareDirectoryOptions> configureOptions)
+        {
+            ArgumentNullException.ThrowIfNull(shareClient);
+            ArgumentException.ThrowIfNullOrWhiteSpace(directoryName);
+
+            ShareDirectoryClient dirClient = shareClient.GetDirectoryClient(directoryName);
+            return await CreateIfNotExistsAsync(dirClient, logger, configureOptions);
+        }
+
+        /// <summary>
+        /// Creates a temporary directory share on an Azure Storage file share resource.
+        /// </summary>
+        /// <param name="directoryClient">The client to interact with the directory share in the Azure File share resource.</param>
+        /// <param name="logger">The logger instance to write diagnostic traces during the lifetime of the fixture.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="directoryClient"/> is <c>null</c>.</exception>
+        public static async Task<TemporaryShareDirectory> CreateIfNotExistsAsync(ShareDirectoryClient directoryClient, ILogger logger)
+        {
+            return await CreateIfNotExistsAsync(directoryClient, logger, configureOptions: null);
+        }
+
+        /// <summary>
+        /// Creates a temporary directory share on an Azure Storage file share resource.
+        /// </summary>
+        /// <param name="directoryClient">The client to interact with the directory share in the Azure File share resource.</param>
+        /// <param name="logger">The logger instance to write diagnostic traces during the lifetime of the fixture.</param>
+        /// <param name="configureOptions">The additional options to manipulate the behavior of the test fixture during its lifetime.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="directoryClient"/> is <c>null</c>.</exception>
+        public static async Task<TemporaryShareDirectory> CreateIfNotExistsAsync(
+            ShareDirectoryClient directoryClient,
+            ILogger logger,
+            Action<TemporaryShareDirectoryOptions> configureOptions)
+        {
+            ArgumentNullException.ThrowIfNull(directoryClient);
+            logger ??= NullLogger.Instance;
+
+            var options = new TemporaryShareDirectoryOptions();
+            configureOptions?.Invoke(options);
+
+            if (await directoryClient.ExistsAsync())
+            {
+                logger.LogTrace("[Test:Setup] Use already existing Azure File share directory '{DirectoryName}' at '{AccountName}/{DirectoryPath}'", directoryClient.Name, directoryClient.AccountName, directoryClient.Path);
+                await CleanDirectoryOnSetupAsync(directoryClient, options, logger);
+
+                return new TemporaryShareDirectory(directoryClient, createdByUs: false, options, logger);
+            }
+
+            try
+            {
+                logger.LogTrace("[Test:Setup] Create new Azure File share directory '{DirectoryName}' at '{AccountName}/{DirectoryPath}'", directoryClient.Name, directoryClient.AccountName, directoryClient.Path);
+                await directoryClient.CreateAsync();
+            }
+            catch (RequestFailedException exception) when (exception.ErrorCode == ShareErrorCode.ShareNotFound)
+            {
+                throw new DriveNotFoundException(
+                    $"[Test:Setup] Cannot create a new Azure File share directory '{directoryClient.Name}' at '{directoryClient.AccountName}/{directoryClient.Path}' " +
+                    $"because the share '{directoryClient.ShareName}' does not exists in account '{directoryClient.AccountName}'; " +
+                    $"please make sure to use an existing Azure File share to create a temporary directory test fixture",
+                    exception);
+            }
+
+            return new TemporaryShareDirectory(directoryClient, createdByUs: true, options, logger);
+        }
+
+        private static async Task CleanDirectoryOnSetupAsync(ShareDirectoryClient directoryClient, TemporaryShareDirectoryOptions options, ILogger logger)
+        {
+            if (options.OnSetup.Items is OnSetupDirectoryShare.LeaveExisted)
+            {
+                return;
+            }
+
+            if (options.OnSetup.Items is OnSetupDirectoryShare.CleanIfExisted)
+            {
+                await DeleteAllDirectoryContentsAsync(directoryClient, TestFixture.Setup, logger);
+            }
+            else if (options.OnSetup.Items is OnSetupDirectoryShare.CleanIfMatched)
+            {
+                await DeleteDirectoryContentsAsync(directoryClient, options.OnSetup.IsMatch, TestFixture.Setup, logger);
+            }
+        }
+
+        /// <summary>
+        /// Uploads a file temporary to this directory share.
+        /// </summary>
+        /// <remarks>
+        ///     Any files uploaded here will be deleted when the <see cref="TemporaryShareDirectory"/> is disposed.
+        /// </remarks>
+        /// <param name="fileName">The name of the file to upload to the share directory.</param>
+        /// <param name="fileContents">The contents of the file to upload to the share directory.</param>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="fileName"/> is blank.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="fileContents"/> is <c>null</c>.</exception>
+        public async Task UploadFileAsync(string fileName, Stream fileContents)
+        {
+            _files.Add(await TemporaryShareFile.CreateIfNotExistsAsync(Client, fileName, fileContents, _logger));
+        }
+
+        /// <summary>
+        /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources asynchronously.
+        /// </summary>
+        /// <returns>A task that represents the asynchronous dispose operation.</returns>
+        public async ValueTask DisposeAsync()
+        {
+            await using var disposables = new DisposableCollection(_logger);
+            disposables.AddRange(_files);
+
+            if (_createdByUs)
+            {
+                await DeleteAllDirectoryContentsAsync(Client, TestFixture.Teardown, _logger);
+
+                disposables.Add(AsyncDisposable.Create(async () =>
+                {
+                    _logger.LogTrace("[Test:Teardown] Delete Azure File share directory '{DirectoryName}' at '{AccountName}/{DirectoryPath}'", Client.Name, Client.AccountName, Client.Path);
+                    await Client.DeleteAsync();
+                }));
+            }
+            else
+            {
+                await CleanDirectoryOnTeardownAsync();
+            }
+
+            GC.SuppressFinalize(this);
+        }
+
+        private async Task CleanDirectoryOnTeardownAsync()
+        {
+            if (_options.OnTeardown.Items is OnTeardownDirectoryShare.CleanIfCreated)
+            {
+                return;
+            }
+
+            if (_options.OnTeardown.Items is OnTeardownDirectoryShare.CleanAll)
+            {
+                await DeleteAllDirectoryContentsAsync(Client, TestFixture.Teardown, _logger);
+            }
+            else if (_options.OnTeardown.Items is OnTeardownDirectoryShare.CleanIfMatched)
+            {
+                await DeleteDirectoryContentsAsync(Client, _options.OnTeardown.IsMatch, TestFixture.Teardown, _logger);
+            }
+        }
+
+        private enum TestFixture { Setup, Teardown }
+
+        private static async Task DeleteDirectoryContentsAsync(
+            ShareDirectoryClient current,
+            Func<ShareFileItem, bool> shouldDeleteItem,
+            TestFixture state,
+            ILogger logger)
+        {
+            await using var disposables = new DisposableCollection(logger);
+
+            disposables.Add(AsyncDisposable.Create(async () =>
+            {
+                await current.ForceCloseAllHandlesAsync(recursive: true);
+
+                await foreach (ShareFileItem item in current.GetFilesAndDirectoriesAsync())
+                {
+                    if (item.IsDirectory)
+                    {
+                        ShareDirectoryClient sub = current.GetSubdirectoryClient(item.Name);
+                        if (shouldDeleteItem(item))
+                        {
+                            await DeleteAllDirectoryContentsAsync(sub, state, logger);
+
+                            logger.LogTrace("[Test:{State}] Delete Azure File share directory '{DirectoryName}' at '{AccountName}/{DirectoryPath}'", state, sub.Name, sub.AccountName, sub.Path);
+                            await sub.DeleteIfExistsAsync();
+                        }
+                        else
+                        {
+                            await DeleteDirectoryContentsAsync(sub, shouldDeleteItem, state, logger);
+                        }
+                    }
+                    else if (shouldDeleteItem(item))
+                    {
+                        ShareFileClient file = current.GetFileClient(item.Name);
+
+                        logger.LogTrace("[Test:{State}] Delete Azure File share item '{FileName}' at '{AccountName}/{FilePath}'", state, file.Name, file.AccountName, file.Path);
+                        await file.DeleteIfExistsAsync();
+                    }
+                }
+            }));
+        }
+
+        private static async Task DeleteAllDirectoryContentsAsync(ShareDirectoryClient current, TestFixture state, ILogger logger)
+        {
+            await DeleteDirectoryContentsAsync(current, shouldDeleteItem: _ => true, state, logger);
+        }
+    }
+}

--- a/src/Arcus.Testing.Storage.File.Share/TemporaryShareDirectory.cs
+++ b/src/Arcus.Testing.Storage.File.Share/TemporaryShareDirectory.cs
@@ -298,7 +298,7 @@ namespace Arcus.Testing
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="fileContents"/> is <c>null</c>.</exception>
         public async Task UploadFileAsync(string fileName, Stream fileContents)
         {
-            _files.Add(await TemporaryShareFile.CreateIfNotExistsAsync(Client, fileName, fileContents, _logger));
+            _files.Add(await TemporaryShareFile.UpsertFileAsync(Client, fileName, fileContents, _logger));
         }
 
         /// <summary>

--- a/src/Arcus.Testing.Storage.File.Share/TemporaryShareFile.cs
+++ b/src/Arcus.Testing.Storage.File.Share/TemporaryShareFile.cs
@@ -10,7 +10,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 namespace Arcus.Testing
 {
     /// <summary>
-    /// Represents a temporary file share on an Azure Storage file share directory.
+    /// Represents a file that is temporary available on an Azure Storage file share directory.
     /// </summary>
     public class TemporaryShareFile : IAsyncDisposable
     {
@@ -36,7 +36,7 @@ namespace Arcus.Testing
         public ShareFileClient Client { get; }
 
         /// <summary>
-        /// Creates a temporary file on an Azure Storage file share directory.
+        /// Creates a new or replace an existing file on an Azure Storage file share directory.
         /// </summary>
         /// <remarks>
         ///     Make sure that the <paramref name="fileContents"/>'s <see cref="Stream.Length"/> is accessible,
@@ -48,21 +48,17 @@ namespace Arcus.Testing
         /// <param name="logger">The instance to log diagnostic traces during the lifetime of the fixture.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="directoryClient"/> or the <paramref name="fileContents"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="fileName"/> is blank.</exception>
-        public static async Task<TemporaryShareFile> CreateIfNotExistsAsync(
-            ShareDirectoryClient directoryClient,
-            string fileName,
-            Stream fileContents,
-            ILogger logger)
+        public static async Task<TemporaryShareFile> UpsertFileAsync(ShareDirectoryClient directoryClient, string fileName, Stream fileContents, ILogger logger)
         {
             ArgumentNullException.ThrowIfNull(directoryClient);
             ArgumentException.ThrowIfNullOrWhiteSpace(fileName);
 
             ShareFileClient fileClient = directoryClient.GetFileClient(fileName);
-            return await CreateIfNotExistsAsync(fileClient, fileContents, logger);
+            return await UpsertFileAsync(fileClient, fileContents, logger);
         }
 
         /// <summary>
-        /// Creates a temporary file on an Azure Storage file share directory.
+        /// Creates a new or replace an existing file on an Azure Storage file share directory.
         /// </summary>
         /// <remarks>
         ///     Make sure that the <paramref name="fileStream"/>'s <see cref="Stream.Length"/> is accessible,
@@ -72,10 +68,7 @@ namespace Arcus.Testing
         /// <param name="fileStream">The contents of the file to upload to the share directory.</param>
         /// <param name="logger">The instance to log diagnostic traces during the lifetime of the fixture.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="fileClient"/> or the <paramref name="fileStream"/> is <c>null</c>.</exception>
-        public static async Task<TemporaryShareFile> CreateIfNotExistsAsync(
-            ShareFileClient fileClient,
-            Stream fileStream,
-            ILogger logger)
+        public static async Task<TemporaryShareFile> UpsertFileAsync(ShareFileClient fileClient, Stream fileStream, ILogger logger)
         {
             ArgumentNullException.ThrowIfNull(fileClient);
             ArgumentNullException.ThrowIfNull(fileStream);

--- a/src/Arcus.Testing.Storage.File.Share/TemporaryShareFile.cs
+++ b/src/Arcus.Testing.Storage.File.Share/TemporaryShareFile.cs
@@ -36,7 +36,7 @@ namespace Arcus.Testing
         public ShareFileClient Client { get; }
 
         /// <summary>
-        /// Creates a new or replace an existing file on an Azure Storage file share directory.
+        /// Creates a new or replaces an existing file on an Azure Storage file share directory.
         /// </summary>
         /// <remarks>
         ///     Make sure that the <paramref name="fileContents"/>'s <see cref="Stream.Length"/> is accessible,
@@ -58,7 +58,7 @@ namespace Arcus.Testing
         }
 
         /// <summary>
-        /// Creates a new or replace an existing file on an Azure Storage file share directory.
+        /// Creates a new or replaces an existing file on an Azure Storage file share directory.
         /// </summary>
         /// <remarks>
         ///     Make sure that the <paramref name="fileStream"/>'s <see cref="Stream.Length"/> is accessible,

--- a/src/Arcus.Testing.Storage.File.Share/TemporaryShareFile.cs
+++ b/src/Arcus.Testing.Storage.File.Share/TemporaryShareFile.cs
@@ -1,0 +1,152 @@
+﻿using System;
+using System.IO;
+using System.Threading.Tasks;
+using Azure;
+using Azure.Storage.Files.Shares;
+using Azure.Storage.Files.Shares.Models;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Arcus.Testing
+{
+    /// <summary>
+    /// Represents a temporary file share on an Azure Storage file share directory.
+    /// </summary>
+    public class TemporaryShareFile : IAsyncDisposable
+    {
+        private readonly (Stream stream, long length) _original;
+        private readonly ILogger _logger;
+
+        private TemporaryShareFile(
+            ShareFileClient client,
+            (Stream stream, long length) original,
+            ILogger logger)
+        {
+            ArgumentNullException.ThrowIfNull(client);
+
+            _original = original;
+            _logger = logger ?? NullLogger.Instance;
+
+            Client = client;
+        }
+
+        /// <summary>
+        /// Gets the client to interact with the temporary stored Azure Storage file share currently in storage.
+        /// </summary>
+        public ShareFileClient Client { get; }
+
+        /// <summary>
+        /// Creates a temporary file on an Azure Storage file share directory.
+        /// </summary>
+        /// <remarks>
+        ///     Make sure that the <paramref name="fileContents"/>'s <see cref="Stream.Length"/> is accessible,
+        ///     so the appropriate size can be set on the file share.
+        /// </remarks>
+        /// <param name="directoryClient">The client to interact with the share directory to upload to file to.</param>
+        /// <param name="fileName">The name of the file to upload to the share directory.</param>
+        /// <param name="fileContents">The contents of the file to upload to the share directory.</param>
+        /// <param name="logger">The instance to log diagnostic traces during the lifetime of the fixture.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="directoryClient"/> or the <paramref name="fileContents"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="fileName"/> is blank.</exception>
+        public static async Task<TemporaryShareFile> CreateIfNotExistsAsync(
+            ShareDirectoryClient directoryClient,
+            string fileName,
+            Stream fileContents,
+            ILogger logger)
+        {
+            ArgumentNullException.ThrowIfNull(directoryClient);
+            ArgumentException.ThrowIfNullOrWhiteSpace(fileName);
+
+            ShareFileClient fileClient = directoryClient.GetFileClient(fileName);
+            return await CreateIfNotExistsAsync(fileClient, fileContents, logger);
+        }
+
+        /// <summary>
+        /// Creates a temporary file on an Azure Storage file share directory.
+        /// </summary>
+        /// <remarks>
+        ///     Make sure that the <paramref name="fileStream"/>'s <see cref="Stream.Length"/> is accessible,
+        ///     so the appropriate size can be set on the file share.
+        /// </remarks>
+        /// <param name="fileClient">The client to interact with the share file to upload to file to.</param>
+        /// <param name="fileStream">The contents of the file to upload to the share directory.</param>
+        /// <param name="logger">The instance to log diagnostic traces during the lifetime of the fixture.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="fileClient"/> or the <paramref name="fileStream"/> is <c>null</c>.</exception>
+        public static async Task<TemporaryShareFile> CreateIfNotExistsAsync(
+            ShareFileClient fileClient,
+            Stream fileStream,
+            ILogger logger)
+        {
+            ArgumentNullException.ThrowIfNull(fileClient);
+            ArgumentNullException.ThrowIfNull(fileStream);
+            logger ??= NullLogger.Instance;
+
+            if (await fileClient.ExistsAsync())
+            {
+                logger.LogTrace("[Test:Setup] Replace already existing Azure File share file '{FileName}' in directory '{AccountName}/{FilePath}'", fileClient.Name, fileClient.AccountName, fileClient.Path);
+
+                ShareFileDownloadInfo result = await fileClient.DownloadAsync();
+                await fileClient.CreateAsync(fileStream.Length);
+                await fileClient.UploadAsync(fileStream);
+
+                return new TemporaryShareFile(fileClient, (result.Content, result.ContentLength), logger);
+            }
+
+            try
+            {
+                logger.LogTrace("[Test:Setup] Upload Azure File share file '{FileName}' in directory '{AccountName}/{FilePath}'", fileClient.Name, fileClient.AccountName, fileClient.Path);
+                await fileClient.CreateAsync(fileStream.Length);
+                await fileClient.UploadAsync(fileStream);
+            }
+            catch (RequestFailedException exception) when (exception.ErrorCode == ShareErrorCode.ShareNotFound)
+            {
+                throw new DriveNotFoundException(
+                    $"[Test:Setup] Cannot upload a new Azure File share file '{fileClient.Name}' at '{fileClient.AccountName}/{fileClient.Path}' " +
+                    $"because the share '{fileClient.ShareName}' does not exists in account '{fileClient.AccountName}'; " +
+                    $"please make sure to use an existing Azure File share to create a temporary file test fixture",
+                    exception);
+            }
+            catch (RequestFailedException exception) when (exception.ErrorCode == ShareErrorCode.ParentNotFound)
+            {
+                throw new DirectoryNotFoundException(
+                    $"[Test:Setup] Cannot upload a new Azure share file '{fileClient.Name}' at '{fileClient.AccountName}/{fileClient.Path}' " +
+                    $"because the parent directory does not exists in account '{fileClient.AccountName}'; " +
+                    $"please make sure to use an existing Azure File share directory to create a temporary file test fixture",
+                    exception);
+            }
+
+            return new TemporaryShareFile(fileClient, original: (null, length: -1), logger);
+        }
+
+        /// <summary>
+        /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources asynchronously.
+        /// </summary>
+        /// <returns>A task that represents the asynchronous dispose operation.</returns>
+        public async ValueTask DisposeAsync()
+        {
+            await using var disposables = new DisposableCollection(_logger);
+
+            if (_original.stream is null)
+            {
+                disposables.Add(AsyncDisposable.Create(async () =>
+                {
+                    _logger.LogTrace("[Test:Teardown] Delete Azure File share file '{FileName}' in directory '{AccountName}/{DirectoryName}'", Client.Name, Client.AccountName, Client.Path);
+                    await Client.DeleteIfExistsAsync();
+                }));
+            }
+            else
+            {
+                disposables.Add(AsyncDisposable.Create(async () =>
+                {
+                    _logger.LogTrace("[Test:Teardown] Replace Azure File share file '{FileName}' with original contents in directory '{AccountName}/{DirectoryName}'", Client.Name, Client.AccountName, Client.Path);
+                    await Client.CreateAsync(_original.length);
+                    await Client.UploadAsync(_original.stream);
+
+                    await _original.stream.DisposeAsync();
+                }));
+            }
+
+            GC.SuppressFinalize(this);
+        }
+    }
+}

--- a/src/Arcus.Testing.Tests.Integration/Arcus.Testing.Tests.Integration.csproj
+++ b/src/Arcus.Testing.Tests.Integration/Arcus.Testing.Tests.Integration.csproj
@@ -25,6 +25,7 @@
     <ProjectReference Include="..\Arcus.Testing.Messaging.ServiceBus\Arcus.Testing.Messaging.ServiceBus.csproj" />
     <ProjectReference Include="..\Arcus.Testing.Storage.Blob\Arcus.Testing.Storage.Blob.csproj" />
     <ProjectReference Include="..\Arcus.Testing.Storage.Cosmos\Arcus.Testing.Storage.Cosmos.csproj" />
+    <ProjectReference Include="..\Arcus.Testing.Storage.File.Share\Arcus.Testing.Storage.File.Share.csproj" />
     <ProjectReference Include="..\Arcus.Testing.Storage.Table\Arcus.Testing.Storage.Table.csproj" />
     <ProjectReference Include="..\Arcus.Testing.Tests.Core\Arcus.Testing.Tests.Core.csproj" />
   </ItemGroup>

--- a/src/Arcus.Testing.Tests.Integration/Storage/TemporaryShareDirectoryTests.cs
+++ b/src/Arcus.Testing.Tests.Integration/Storage/TemporaryShareDirectoryTests.cs
@@ -1,0 +1,387 @@
+﻿using System;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using Arcus.Testing.Tests.Integration.Storage.Configuration;
+using Azure.Storage.Files.Shares;
+using Azure.Storage.Files.Shares.Models;
+using Azure.Storage.Files.Shares.Specialized;
+using Bogus;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+using Xunit.Abstractions;
+using DirClient = Azure.Storage.Files.Shares.ShareDirectoryClient;
+using FileClient = Azure.Storage.Files.Shares.ShareFileClient;
+
+namespace Arcus.Testing.Tests.Integration.Storage
+{
+    public class TemporaryShareDirectoryTests : IntegrationTest
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TemporaryShareDirectoryTests"/> class.
+        /// </summary>
+        public TemporaryShareDirectoryTests(ITestOutputHelper outputWriter) : base(outputWriter)
+        {
+        }
+
+        [Fact]
+        public async Task CreateTempDirWithCleanAllOnSetup_ForExistingDir_RemovesAllItemsFromDirectoryUponCreation()
+        {
+            // Arrange
+            await using var share = await GivenFileShareAsync();
+
+            DirClient dir = await share.WhenDirectoryAvailableAsync();
+            FileClient file = await share.WhenFileAvailableAsync(dir);
+            DirClient subDir = await share.WhenDirectoryAvailableAsync(dir);
+            FileClient subFile = await share.WhenFileAvailableAsync(subDir);
+
+            // Act
+            await WhenTempDirCreatedAsync(dir, options =>
+            {
+                options.OnSetup.CleanAllItems();
+            });
+
+            // Assert
+            await share.ShouldHaveDirectoriesAsync(dir);
+
+            await share.ShouldNotHaveFilesAsync(file, subFile);
+            await share.ShouldNotHaveDirectoriesAsync(subDir);
+        }
+
+        [Fact]
+        public async Task CreateTempDirWithCleanAllOnTeardown_ForExistingDir_RemovesAllItemsFromDirectoryUponDisposal()
+        {
+            // Arrange
+            await using var share = await GivenFileShareAsync();
+
+            DirClient dir = await share.WhenDirectoryAvailableAsync();
+
+            FileClient fileBefore = await share.WhenFileAvailableAsync(dir);
+            DirClient subDirBefore = await share.WhenDirectoryAvailableAsync(dir);
+            FileClient subFileBefore = await share.WhenFileAvailableAsync(subDirBefore);
+
+            // Act
+            TemporaryShareDirectory temp = await WhenTempDirCreatedAsync(dir, options =>
+            {
+                options.OnTeardown.CleanAllItems();
+            });
+
+            // Assert
+            await share.ShouldHaveDirectoriesAsync(dir);
+            await share.ShouldHaveFilesAsync(fileBefore, subFileBefore);
+
+            FileClient fileAfter = await share.WhenFileAvailableAsync(temp.Client);
+            DirClient subDirAfter = await share.WhenDirectoryAvailableAsync(temp.Client);
+            FileClient subFileAfter = await share.WhenFileAvailableAsync(subDirAfter);
+
+            await temp.DisposeAsync();
+
+            await share.ShouldNotHaveFilesAsync(fileBefore, subFileBefore, fileAfter, subFileAfter);
+            await share.ShouldNotHaveDirectoriesAsync(subDirBefore, subDirAfter);
+            await share.ShouldHaveDirectoriesAsync(dir);
+        }
+
+        [Fact]
+        public async Task CreateTempDirWithCleanMatched_ForExistingDir_RemovesAllMatchingItems()
+        {
+            // Arrange
+            await using var share = await GivenFileShareAsync();
+
+            DirClient dir = await share.WhenDirectoryAvailableAsync();
+
+            FileClient fileMatchedBefore = await share.WhenFileAvailableAsync(dir);
+            DirClient subDirNotMatchedBefore = await share.WhenDirectoryAvailableAsync(dir);
+            DirClient subDirMatchedBefore = await share.WhenDirectoryAvailableAsync(dir);
+            FileClient fileImplicitMatchedBefore = await share.WhenFileAvailableAsync(subDirMatchedBefore);
+
+            // Act
+            TemporaryShareDirectory temp = await WhenTempDirCreatedAsync(dir, options =>
+            {
+                options.OnSetup.CleanMatchingItems(f => f.Name == fileMatchedBefore.Name)
+                               .CleanMatchingItems(f => f.Name == subDirMatchedBefore.Name);
+            });
+
+            // Assert
+            await share.ShouldHaveDirectoriesAsync(dir, subDirNotMatchedBefore);
+            await share.ShouldNotHaveFilesAsync(fileMatchedBefore, fileImplicitMatchedBefore);
+            await share.ShouldNotHaveDirectoriesAsync(subDirMatchedBefore);
+
+            FileClient fileMatchedAfter = await share.WhenFileAvailableAsync(dir);
+            DirClient subDirNotMatchedAfter = await share.WhenDirectoryAvailableAsync(dir);
+            DirClient subDirMatchedAfter = await share.WhenDirectoryAvailableAsync(dir);
+            FileClient fileImplicitMatchedAfter = await share.WhenFileAvailableAsync(subDirMatchedAfter);
+
+            temp.OnTeardown.CleanMatchingItems(f => f.Name == fileMatchedAfter.Name)
+                           .CleanMatchingItems(f => f.Name == subDirMatchedAfter.Name);
+
+            await temp.DisposeAsync();
+
+            await share.ShouldHaveDirectoriesAsync(dir, subDirNotMatchedAfter);
+            await share.ShouldNotHaveFilesAsync(fileMatchedAfter, fileImplicitMatchedAfter);
+            await share.ShouldNotHaveDirectoriesAsync(subDirMatchedAfter);
+        }
+
+        [Fact]
+        public async Task CreateTempDir_ForExistingDir_LeaveDirectoryAfterLifetimeFixture()
+        {
+            // Arrange
+            await using var share = await GivenFileShareAsync();
+
+            DirClient dir = await share.WhenDirectoryAvailableAsync();
+            FileClient fileBefore = await share.WhenFileAvailableAsync(dir);
+            FileClient fileSelf = share.WhenFileUnavailable(dir);
+
+            // Act
+            TemporaryShareDirectory temp = await WhenTempDirCreatedAsync(dir);
+
+            // Assert
+            await share.ShouldHaveDirectoriesAsync(dir);
+
+            await temp.WhenFileFileUploadAsync(fileSelf);
+            FileClient fileAfter = await share.WhenFileAvailableAsync(temp.Client);
+            DirClient subDirAfter = await share.WhenDirectoryAvailableAsync(temp.Client);
+            FileClient subFileAfter = await share.WhenFileAvailableAsync(subDirAfter);
+
+            await temp.DisposeAsync();
+
+            await share.ShouldNotHaveFilesAsync(fileSelf);
+            await share.ShouldHaveFilesAsync(fileAfter, subFileAfter, fileBefore);
+            await share.ShouldHaveDirectoriesAsync(dir, subDirAfter);
+        }
+
+        [Fact]
+        public async Task CreateTempDir_OnExistingShare_TemporaryCreateDirectoryOnShareDuringLifetimeFixture()
+        {
+            // Arrange
+            await using var share = await GivenFileShareAsync();
+
+            DirClient dir = share.WhenDirectoryUnavailable();
+            FileClient file = share.WhenFileUnavailable(dir);
+
+            // Act
+            TemporaryShareDirectory temp = await WhenTempDirCreatedAsync(dir);
+
+            // Assert
+            await share.ShouldHaveDirectoriesAsync(dir);
+
+            await share.WhenFileAvailableAsync(temp.Client);
+            await temp.WhenFileFileUploadAsync(file);
+            await share.WhenFileAvailableAsync(await share.WhenDirectoryAvailableAsync(temp.Client));
+
+            await temp.DisposeAsync();
+
+            await share.ShouldNotHaveFilesAsync(file);
+            await share.ShouldNotHaveDirectoriesAsync(dir);
+        }
+
+        [Fact]
+        public async Task CreateTempDir_OnNonExistingShare_FailsWithNotFound()
+        {
+            // Arrange
+            await using var fileShare = await GivenFileShareAsync();
+
+            ShareClient share = fileShare.WhenShareUnavailable();
+            DirClient dir = fileShare.WhenDirectoryUnavailable(share);
+
+            // Act / Assert
+            await Assert.ThrowsAsync<DriveNotFoundException>(
+                () => WhenTempDirCreatedAsync(dir));
+        }
+
+        private async Task<TemporaryShareDirectory> WhenTempDirCreatedAsync(DirClient dir, Action<TemporaryShareDirectoryOptions> configureOptions = null)
+        {
+            TemporaryShareDirectory temp;
+            if (Bogus.Random.Bool())
+            {
+                ShareClient shareClient = dir.GetParentShareClient();
+                temp = configureOptions is null
+                    ? await TemporaryShareDirectory.CreateIfNotExistsAsync(shareClient, dir.Name, Logger)
+                    : await TemporaryShareDirectory.CreateIfNotExistsAsync(shareClient, dir.Name, Logger, configureOptions);
+            }
+            else
+            {
+                temp = configureOptions is null
+                    ? await TemporaryShareDirectory.CreateIfNotExistsAsync(dir, Logger)
+                    : await TemporaryShareDirectory.CreateIfNotExistsAsync(dir, Logger, configureOptions);
+            }
+
+            Assert.Equal(dir.Name, temp.Client.Name);
+            Assert.Equal(dir.AccountName, temp.Client.AccountName);
+
+            return temp;
+        }
+
+        private async Task<FileShareTestContext> GivenFileShareAsync()
+        {
+            return await FileShareTestContext.GivenAvailableAsync(Configuration, Logger);
+        }
+    }
+
+    internal static class TempShareDirExtensions
+    {
+        private static readonly Faker Bogus = new();
+
+        internal static async Task WhenFileFileUploadAsync(this TemporaryShareDirectory dir, FileClient file)
+        {
+            await using var fileContents = new MemoryStream(Encoding.UTF8.GetBytes(Bogus.Lorem.Sentence()));
+            await dir.UploadFileAsync(file.Name, fileContents);
+        }
+    }
+
+    internal class FileShareTestContext : IAsyncDisposable
+    {
+        private readonly ShareClient _share;
+        private readonly ShareServiceClient _service;
+        private readonly ILogger _logger;
+
+        private static readonly Faker Bogus = new();
+
+        private FileShareTestContext(
+            ShareServiceClient service,
+            ShareClient share,
+            ILogger logger)
+        {
+            _service = service;
+            _share = share;
+            _logger = logger ?? NullLogger.Instance;
+        }
+
+        public static async Task<FileShareTestContext> GivenAvailableAsync(TestConfig configuration, ILogger logger)
+        {
+            StorageAccount account = configuration.GetStorageAccount();
+
+            var service = new ShareServiceClient(account.ConnectionString);
+
+            string shareName = $"share-{Guid.NewGuid().ToString()[..10]}";
+            ShareClient share = service.GetShareClient(shareName);
+
+            logger.LogTrace("[Test:Setup] Create new Azure File share '{ShareName}' in account '{AccountName}'", share.Name, share.AccountName);
+            await share.CreateIfNotExistsAsync();
+
+            return new FileShareTestContext(service, share, logger);
+        }
+
+        public ShareClient WhenShareUnavailable()
+        {
+            string shareName = $"share-{Guid.NewGuid().ToString()[..10]}";
+            ShareClient share = _service.GetShareClient(shareName);
+            return share;
+        }
+
+        public async Task<DirClient> WhenDirectoryAvailableAsync()
+        {
+            DirClient sub = WhenDirectoryUnavailable();
+
+            _logger.LogTrace("[Test] Create new Azure File share directory '{DirectoryName}' at '{DirectoryPath}'", sub.Name, sub.Path);
+            await sub.CreateIfNotExistsAsync();
+
+            return sub;
+        }
+
+        public async Task<DirClient> WhenDirectoryAvailableAsync(DirClient dirClient)
+        {
+            DirClient sub = WhenDirectoryUnavailable(dirClient);
+
+            _logger.LogTrace("[Test] Create new Azure File share directory '{DirectoryName}' at '{DirectoryPath}'", sub.Name, sub.Path);
+            await sub.CreateIfNotExistsAsync();
+
+            return sub;
+        }
+
+        public DirClient WhenDirectoryUnavailable()
+        {
+            return WhenDirectoryUnavailable(_share);
+        }
+
+        public FileClient WhenFileUnavailable(DirClient dirClient)
+        {
+            return dirClient.GetFileClient($"file-{Guid.NewGuid().ToString()[..10]}");
+        }
+
+        public DirClient WhenDirectoryUnavailable(ShareClient dirClient)
+        {
+            string directoryName = $"dir-{Guid.NewGuid().ToString()[..10]}";
+            DirClient sub = dirClient.GetDirectoryClient(directoryName);
+
+            return sub;
+        }
+
+        public DirClient WhenDirectoryUnavailable(DirClient dirClient)
+        {
+            string directoryName = $"dir-{Guid.NewGuid().ToString()[..10]}";
+            DirClient sub = dirClient.GetSubdirectoryClient(directoryName);
+
+            return sub;
+        }
+
+        public async Task<FileClient> WhenFileAvailableAsync(DirClient directoryClient)
+        {
+            string fileName = $"file-{Guid.NewGuid().ToString()[..10]}";
+            string fileContents = Bogus.Lorem.Sentence();
+            _logger.LogTrace("[Test] Upload new Azure File share item '{FileName}' in directory '{AccountName}/{DirectoryPath}'", fileName, directoryClient.AccountName, directoryClient.Path);
+
+            await using var contents = BinaryData.FromString(fileContents).ToStream();
+            FileClient fileClient = await directoryClient.CreateFileAsync(fileName, contents.Length);
+            await fileClient.UploadAsync(contents);
+
+            return fileClient;
+        }
+
+        public async Task ShouldHaveDirectoriesAsync(params DirClient[] directories)
+        {
+            foreach (DirClient dir in directories)
+            {
+                Assert.True(await dir.ExistsAsync(), $"Azure File share directory '{dir.Name}' should be available on share '{dir.ShareName}', but it wasn't");
+            }
+        }
+
+        public async Task ShouldHaveFilesAsync(params FileClient[] files)
+        {
+            foreach (var file in files)
+            {
+                Assert.True(await file.ExistsAsync(), $"Azure File share file '{file.Name}' should be available on share '{file.ShareName}', but it wasn't");
+            }
+        }
+
+        public async Task<BinaryData> ShouldHaveFileAsync(FileClient file)
+        {
+            await ShouldHaveFilesAsync(file);
+            using ShareFileDownloadInfo fileInfo = await file.DownloadAsync();
+
+            var data = await BinaryData.FromStreamAsync(fileInfo.Content);
+            return data;
+        }
+
+        public async Task ShouldNotHaveFilesAsync(params FileClient[] files)
+        {
+            foreach (var file in files)
+            {
+                Assert.False(await file.ExistsAsync(), $"Azure File share file '{file.Name}' should not be available on share '{file.ShareName}', but it was");
+            }
+        }
+
+        public async Task ShouldNotHaveDirectoriesAsync(params DirClient[] directories)
+        {
+            foreach (var dir in directories)
+            {
+                Assert.False(await dir.ExistsAsync(), $"Azure File share directory '{dir.Name}' should not be available on share '{dir.ShareName}', but it was");
+            }
+        }
+
+        /// <summary>
+        /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources asynchronously.
+        /// </summary>
+        /// <returns>A task that represents the asynchronous dispose operation.</returns>
+        public async ValueTask DisposeAsync()
+        {
+            await using var disposables = new DisposableCollection(_logger);
+
+            disposables.Add(AsyncDisposable.Create(async () =>
+            {
+                _logger.LogTrace("[Test:Teardown] Fallback remove Azure File share '{ShareName}' in account '{AccountName}'", _share.Name, _share.AccountName);
+                await _share.DeleteIfExistsAsync();
+            }));
+        }
+    }
+}

--- a/src/Arcus.Testing.Tests.Integration/Storage/TemporaryShareDirectoryTests.cs
+++ b/src/Arcus.Testing.Tests.Integration/Storage/TemporaryShareDirectoryTests.cs
@@ -225,7 +225,7 @@ namespace Arcus.Testing.Tests.Integration.Storage
         internal static async Task WhenFileFileUploadAsync(this TemporaryShareDirectory dir, FileClient file)
         {
             await using var fileContents = new MemoryStream(Encoding.UTF8.GetBytes(Bogus.Lorem.Sentence()));
-            await dir.UploadFileAsync(file.Name, fileContents);
+            await dir.UpsertFileAsync(file.Name, fileContents);
         }
     }
 

--- a/src/Arcus.Testing.Tests.Integration/Storage/TemporaryShareFileTests.cs
+++ b/src/Arcus.Testing.Tests.Integration/Storage/TemporaryShareFileTests.cs
@@ -1,0 +1,186 @@
+﻿using System;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using Arcus.Testing.Tests.Integration.Storage.Configuration;
+using Azure.Identity;
+using Azure.Storage.Files.Shares;
+using Azure.Storage.Files.Shares.Models;
+using Xunit;
+using Xunit.Abstractions;
+using DirClient = Azure.Storage.Files.Shares.ShareDirectoryClient;
+using FileClient = Azure.Storage.Files.Shares.ShareFileClient;
+
+namespace Arcus.Testing.Tests.Integration.Storage
+{
+    public class TemporaryShareFileTests : IntegrationTest
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TemporaryShareFileTests"/> class.
+        /// </summary>
+        public TemporaryShareFileTests(ITestOutputHelper outputWriter) : base(outputWriter)
+        {
+        }
+
+        [Fact]
+        public async Task UploadNewTempFile_OnExistingDir_TemporaryStoresFileOnDirDuringLifetimeFixture()
+        {
+            // Arrange
+            await using var share = await GivenFileShareAsync();
+
+            DirClient dir = await share.WhenDirectoryAvailableAsync();
+            FileClient file = share.WhenFileUnavailable(dir);
+            await using Stream expected = CreateFileContents();
+
+            // Act
+            TemporaryShareFile temp = await WhenFileCreatedAsync(file, expected);
+
+            // Assert
+            BinaryData actual = await share.ShouldHaveFileAsync(file);
+            AssertEqualContents(expected, actual);
+
+            await temp.DisposeAsync();
+            await share.ShouldNotHaveFilesAsync(file);
+        }
+
+        [Fact]
+        public async Task UploadTempFile_OnExistingDirWithAlreadyStoredFile_TemporaryReplacesFileOnDirDuringLifetimeFixture()
+        {
+            // Arrange
+            await using var share = await GivenFileShareAsync();
+
+            DirClient dir = await share.WhenDirectoryAvailableAsync();
+            FileClient file = await share.WhenFileAvailableAsync(dir);
+            BinaryData originalContents = await share.ShouldHaveFileAsync(file);
+
+            await using Stream newContents = CreateFileContents();
+
+            // Act
+            TemporaryShareFile temp = await WhenFileCreatedAsync(file, newContents);
+
+            // Assert
+            BinaryData actualBefore = await share.ShouldHaveFileAsync(file);
+            AssertEqualContents(newContents, actualBefore);
+
+            await temp.DisposeAsync();
+
+            BinaryData actualAfter = await share.ShouldHaveFileAsync(file);
+            AssertEqualContents(originalContents, actualAfter);
+        }
+
+        private static void AssertEqualContents(Stream expectedStream, BinaryData actual)
+        {
+            expectedStream.Position = 0;
+            BinaryData expected = BinaryData.FromStream(expectedStream);
+
+            AssertEqualContents(actual, expected);
+        }
+
+        private static void AssertEqualContents(BinaryData actual, BinaryData expected)
+        {
+            Assert.False(actual.ToMemory().IsEmpty, "actual share file contents are empty");
+            Assert.Equal(expected.ToString(), actual.ToString());
+        }
+
+        [Fact]
+        public async Task UploadTempFile_OnNonExistingDir_FailsWithNotFound()
+        {
+            // Arrange
+            await using var share = await GivenFileShareAsync();
+
+            DirClient dir = share.WhenDirectoryUnavailable();
+            FileClient file = share.WhenFileUnavailable(dir);
+
+            await using Stream fileContents = CreateFileContents();
+
+            // Act / Assert
+            await Assert.ThrowsAsync<DirectoryNotFoundException>(
+                () => WhenFileCreatedAsync(file, fileContents));
+        }
+
+        [Fact]
+        public async Task UploadTempFile_OnNonExistingShare_FailsWithNotFound()
+        {
+            // Arrange
+            await using var share = await GivenFileShareAsync();
+
+            ShareClient client = share.WhenShareUnavailable();
+            DirClient dir = share.WhenDirectoryUnavailable(client);
+            FileClient file = share.WhenFileUnavailable(dir);
+
+            await using Stream fileContents = CreateFileContents();
+
+            // Act / Assert
+            await Assert.ThrowsAsync<DriveNotFoundException>(
+                () => WhenFileCreatedAsync(file, fileContents));
+        }
+
+        private static Stream CreateFileContents()
+        {
+            return new MemoryStream(Encoding.UTF8.GetBytes(Bogus.Lorem.Sentence()));
+        }
+
+        private async Task<TemporaryShareFile> WhenFileCreatedAsync(FileClient client, Stream fileStream)
+        {
+            var temp = await TemporaryShareFile.CreateIfNotExistsAsync(client, fileStream, Logger);
+
+            Assert.Equal(client.Name, temp.Client.Name);
+            return temp;
+        }
+
+        private async Task<FileShareTestContext> GivenFileShareAsync()
+        {
+            return await FileShareTestContext.GivenAvailableAsync(Configuration, Logger);
+        }
+
+        [Fact]
+        public async Task UploadFileShare_ToExistingDirectory_TemporaryOverridesFileContentsDuringLifetimeFixture()
+        {
+            // Arrange
+            StorageAccount account = Configuration.GetStorageAccount();
+
+            var service = new ShareServiceClient(
+                new Uri($"https://{account.Name}.file.core.windows.net/"),
+                new ClientSecretCredential(ServicePrincipal.TenantId, ServicePrincipal.ClientId, ServicePrincipal.ClientSecret));
+
+            service = new ShareServiceClient(account.ConnectionString);
+
+            string shareName = Guid.NewGuid().ToString();
+            var share = service.GetShareClient(shareName);
+            await share.CreateAsync();
+
+            string directoryName = Guid.NewGuid().ToString();
+            ShareDirectoryClient directoryClient = share.GetDirectoryClient(directoryName);
+            await directoryClient.CreateAsync();
+
+            string fileName = Guid.NewGuid().ToString();
+            FileClient fileClient = directoryClient.GetFileClient(fileName);
+            using Stream originalContents = new MemoryStream(Encoding.UTF8.GetBytes("123"));
+            await fileClient.CreateAsync(originalContents.Length);
+
+            try
+            {
+                await fileClient.UploadAsync(originalContents);
+
+                using Stream fileContents = new MemoryStream(Encoding.UTF8.GetBytes("456"));
+                var temp = await TemporaryShareFile.CreateIfNotExistsAsync(directoryClient, fileName, fileContents, Logger);
+
+                Assert.Equal("456", await DownloadFileShareContentsAsStringAsync(fileClient));
+                await temp.DisposeAsync();
+                Assert.Equal("123", await DownloadFileShareContentsAsStringAsync(fileClient));
+            }
+            finally
+            {
+                await share.DeleteIfExistsAsync();
+            }
+        }
+
+        private static async Task<string> DownloadFileShareContentsAsStringAsync(FileClient fileClient)
+        {
+            ShareFileDownloadInfo actual = await fileClient.DownloadAsync();
+            using var reader = new StreamReader(actual.Content);
+            string actualTxt = await reader.ReadToEndAsync();
+            return actualTxt;
+        }
+    }
+}

--- a/src/Arcus.Testing.sln
+++ b/src/Arcus.Testing.sln
@@ -48,6 +48,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Messaging", "Messaging", "{4992B48D-3C17-45A9-979B-B79CE1E987CB}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Arcus.Testing.Storage.File.Share", "Arcus.Testing.Storage.File.Share\Arcus.Testing.Storage.File.Share.csproj", "{4988575F-A1BA-4990-A7AD-F48303B51C62}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -108,6 +110,10 @@ Global
 		{74AB9F6E-791F-4609-96BD-15420C25AA72}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{74AB9F6E-791F-4609-96BD-15420C25AA72}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{74AB9F6E-791F-4609-96BD-15420C25AA72}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4988575F-A1BA-4990-A7AD-F48303B51C62}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4988575F-A1BA-4990-A7AD-F48303B51C62}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4988575F-A1BA-4990-A7AD-F48303B51C62}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4988575F-A1BA-4990-A7AD-F48303B51C62}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -125,6 +131,7 @@ Global
 		{4F199527-761E-4F8A-AB44-8DE8D030518F} = {4992B48D-3C17-45A9-979B-B79CE1E987CB}
 		{54A67E0F-270B-4979-9E72-C68EA8222F89} = {FA2E21E0-953E-4B84-9C47-C4F0A3833E4E}
 		{74AB9F6E-791F-4609-96BD-15420C25AA72} = {FA2E21E0-953E-4B84-9C47-C4F0A3833E4E}
+		{4988575F-A1BA-4990-A7AD-F48303B51C62} = {FA2E21E0-953E-4B84-9C47-C4F0A3833E4E}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {E5382820-51FF-4B00-92BE-C78E80EA0841}


### PR DESCRIPTION
Adds the initial test fixtures for the Azure File share storage:
* `TemporaryShareDirectory`: to temporary create a directory on the share;
* `TemporaryShareFile`: to temporary create a file on the directory.

Closes #249 