### PR TITLE
fix(docs): Update invalid package name for CosmosDb

### DIFF
--- a/docs/preview/03-Features/04-Azure/04-Storage/02-cosmos.mdx
+++ b/docs/preview/03-Features/04-Azure/04-Storage/02-cosmos.mdx
@@ -2,7 +2,7 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
 # CosmosDb
-The `Arcus.Testing.Storage.CosmosDb` package provides test fixtures to Azure CosmosDb storage. By using the common test practices 'clean environment', it provides a temporary collections and documents.
+The `Arcus.Testing.Storage.Cosmos` package provides test fixtures to Azure CosmosDb storage. By using the common test practices 'clean environment', it provides a temporary collections and documents.
 
 ## Installation
 The following functionality is available when installing this package:


### PR DESCRIPTION
Rename from `Arcus.Testing.Storage.CosmosDb`  to `Arcus.Testing.Storage.Cosmos` package