### PR TITLE
fix(assert.csv): ignore column name/index during load

### DIFF
--- a/src/Arcus.Testing.Assert/AssertCsv.cs
+++ b/src/Arcus.Testing.Assert/AssertCsv.cs
@@ -90,6 +90,12 @@ namespace Arcus.Testing
         internal IReadOnlyCollection<int> IgnoredColumnIndexes => _ignoredColumnIndexes;
 
         /// <summary>
+        /// Determines whether a given <paramref name="headerName"/> at <paramref name="columnIndex"/>
+        /// is allowed to be included in the CSV.
+        /// </summary>
+        internal bool IsColumnIncluded(string headerName, int columnIndex) => !IgnoredColumns.Contains(headerName) && !IgnoredColumnIndexes.Contains(columnIndex);
+
+        /// <summary>
         /// Gets or sets the separator character to be used when determining CSV columns in the loaded table, default: ; (semicolon).
         /// </summary>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="value"/> is blank.</exception>
@@ -212,6 +218,37 @@ namespace Arcus.Testing
         /// Gets or sets the format in which the different input documents will be shown in the failure report (default: <see cref="ReportFormat.Vertical"/>).
         /// </summary>
         public ReportFormat ReportFormat { get; set; } = ReportFormat.Vertical;
+
+        /// <summary>
+        /// Gets the <c>string</c> representation of the current options during <see cref="AssertCsv.Load(string,Action{AssertCsvOptions})"/>.
+        /// </summary>
+        internal string ToStringForLoad()
+        {
+            string optionsDescription =
+                $"Options: {Environment.NewLine}" +
+                $"\t- separator: {Separator}{Environment.NewLine}" +
+                $"\t- escape: {Escape}{Environment.NewLine}" +
+                $"\t- quote: {Quote}{Environment.NewLine}" +
+                $"\t- ignored column names [{string.Join(", ", IgnoredColumns)}]{Environment.NewLine}" +
+                $"\t- ignored column indexes [{string.Join(", ", IgnoredColumnIndexes)}]";
+
+            return optionsDescription;
+        }
+
+        /// <summary>
+        /// Gets the <c>string</c> representation of the current options during <see cref="AssertCsv.Equal(CsvTable,CsvTable,Action{AssertCsvOptions})"/>.
+        /// </summary>
+        internal string ToStringForEqual()
+        {
+            string optionsDescription =
+                $"Options: {Environment.NewLine}" +
+                $"\t- ignored columns: [{string.Join(", ", IgnoredColumns)}]{Environment.NewLine}" +
+                $"\t- ignored column indexes: [{string.Join(", ", IgnoredColumnIndexes)}]{Environment.NewLine}" +
+                $"\t- column order: {ColumnOrder}{Environment.NewLine}" +
+                $"\t- row order: {RowOrder}";
+
+            return optionsDescription;
+        }
     }
 
     /// <summary>
@@ -256,7 +293,7 @@ namespace Arcus.Testing
             var expected = CsvTable.Load(expectedCsv, options);
             var actual = CsvTable.Load(actualCsv, options);
 
-            Equal(expected, actual, configureOptions);
+            Equal(expected, actual, options);
         }
 
         /// <summary>
@@ -291,22 +328,18 @@ namespace Arcus.Testing
             var options = new AssertCsvOptions();
             configureOptions?.Invoke(options);
 
-            CsvDifference diff = FindFirstDifference(
-                expected,
-                actual,
-                options);
+            Equal(expected.ApplyOptions(options), actual.ApplyOptions(options), options);
+        }
 
+        private static void Equal(CsvTable expected, CsvTable actual, AssertCsvOptions options)
+        {
+            CsvDifference diff = FindFirstDifference(expected, actual, options);
             if (diff != null)
             {
                 string expectedCsv = diff.ExpectedDiff != null && options.ReportScope is ReportScope.Limited ? diff.ExpectedDiff : expected.ToString();
                 string actualCsv = diff.ActualDiff != null && options.ReportScope is ReportScope.Limited ? diff.ActualDiff : actual.ToString();
 
-                string optionsDescription =
-                    $"Options: {Environment.NewLine}" +
-                    $"\t- ignored columns: [{string.Join($"{options.Separator} ", options.IgnoredColumns)}]{Environment.NewLine}" +
-                    $"\t- ignored column indexes: [{string.Join($"{options.Separator} ", options.IgnoredColumnIndexes)}]{Environment.NewLine}" +
-                    $"\t- column order: {options.ColumnOrder}{Environment.NewLine}" +
-                    $"\t- row order: {options.RowOrder}";
+                string optionsDescription = options.ToStringForEqual();
 
                 throw new EqualAssertionException(
                     ReportBuilder.ForMethod(EqualMethodName, "expected and actual CSV contents do not match")
@@ -486,11 +519,6 @@ namespace Arcus.Testing
                     CsvCell expectedCell = expectedCells.ElementAt(col),
                             actualCell = actualCells.ElementAt(col);
 
-                    if (options.IgnoredColumnIndexes.Contains(col) || options.IgnoredColumns.Contains(expectedCell.HeaderName))
-                    {
-                        continue;
-                    }
-
                     if (!expectedCell.Equals(actualCell))
                     {
                         return shouldIgnoreOrder
@@ -615,28 +643,25 @@ namespace Arcus.Testing
             _originalCsv = originalCsv;
             _options = options;
 
+            if (Array.Exists(headerNames, h => h is null))
+            {
+                throw new CsvException("Cannot parse the incoming header names as one or more header names is 'null'");
+            }
+
+            if (rows.Any(r => r is null))
+            {
+                throw new CsvException("Cannot parse the incoming rows as one or more rows is 'null'");
+            }
+
+            if (rows.Any(r => r.Cells.Count != headerNames.Length))
+            {
+                throw new CsvException($"Cannot parse the incoming header names and rows to a valid CSV table as not all rows matches the header count of {headerNames.Length}");
+            }
+
             HeaderNames = headerNames;
             Rows = rows;
             RowCount = rows.Length;
             ColumnCount = headerNames.Length;
-
-            if (Array.Exists(headerNames, h => h is null))
-            {
-                throw new CsvException(
-                    "Cannot parse the incoming header names as one or more header names is 'null'");
-            }
-
-            if (Rows.Any(r => r is null))
-            {
-                throw new CsvException(
-                    "Cannot parse the incoming rows as one or more rows is 'null'");
-            }
-
-            if (Rows.Any(r => r.Cells.Count != headerNames.Length))
-            {
-                throw new CsvException(
-                    $"Cannot parse the incoming header names and rows to a valid CSV table as not all rows matches the header count of {headerNames.Length}");
-            }
         }
 
         internal AssertCsvHeader Header => _options.Header;
@@ -675,48 +700,13 @@ namespace Arcus.Testing
             ArgumentException.ThrowIfNullOrWhiteSpace(csv);
             ArgumentNullException.ThrowIfNull(options);
 
-            string[][] rawLines = SplitCsv(csv, options);
-            EnsureAllRowsSameLength(csv, rawLines, options);
+            string[][] allLines = SplitCsv(csv, options);
+            (string[] headerNames, string[][] rowLines) = SubtractHeaderNames(allLines, options);
 
-            string[] headerNames;
-            if (options.Header is AssertCsvHeader.Present)
-            {
-                headerNames = rawLines[0];
-                rawLines = rawLines.Skip(1).ToArray();
-            }
-            else
-            {
-                headerNames = Enumerable.Range(0, rawLines[0].Length).Select(i => $"Col #{i}").ToArray();
-            }
+            CsvRow[] allRows = ParseCsvRows(rowLines, headerNames, options);
+            (string[] includedHeaderNames, CsvRow[] includedRows) = FilterIncludedColumns(headerNames, allRows, options);
 
-            CsvRow[] rows = ParseCsvRows(rawLines, headerNames, options);
-            return new CsvTable(headerNames, rows, csv, options);
-        }
-
-
-        /// <summary>
-        /// Parse the incoming <paramref name="rowLines"/> into <see cref="CsvRow"/>s.
-        /// </summary>
-        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="rowLines"/> or the <paramref name="headerNames"/> is <c>null</c></exception>
-        /// <exception cref="ArgumentOutOfRangeException">Thrown when the <paramref name="rowLines"/> and <paramref name="headerNames"/> index count does not match.</exception>
-        protected static CsvRow[] ParseCsvRows(string[][] rowLines, string[] headerNames, AssertCsvOptions options)
-        {
-            ArgumentNullException.ThrowIfNull(rowLines);
-            ArgumentNullException.ThrowIfNull(headerNames);
-            options ??= new AssertCsvOptions();
-
-            CsvRow[] rows = rowLines.Select((rawRow, rowNumber) =>
-            {
-                CsvCell[] cells = rawRow.Select((cellValue, columnNumber) =>
-                {
-                    string headerName = headerNames[columnNumber];
-                    return new CsvCell(headerName, columnNumber, rowNumber, cellValue, options);
-                }).ToArray();
-
-                return new CsvRow(cells, rowNumber, options);
-            }).ToArray();
-
-            return rows;
+            return new CsvTable(includedHeaderNames, includedRows.ToArray(), csv, options);
         }
 
         private static string[][] SplitCsv(string csv, AssertCsvOptions options)
@@ -761,9 +751,56 @@ namespace Arcus.Testing
                 yield return builder.ToString();
             }
 
-            return csv.Split(options.NewLine, StringSplitOptions.RemoveEmptyEntries)
-                      .Select(row => SplitCsvRow(row).ToArray())
-                      .ToArray();
+            var rawLines =
+                csv.Split(options.NewLine, StringSplitOptions.RemoveEmptyEntries)
+                   .Select(row => SplitCsvRow(row).ToArray())
+                   .ToArray();
+
+            EnsureAllRowsSameLength(csv, rawLines, options);
+            return rawLines;
+        }
+
+        private static (string[] headerNames, string[][] rowLines) SubtractHeaderNames(string[][] rawLines, AssertCsvOptions options)
+        {
+            string[] headerNames;
+            string[][] rowLines = rawLines;
+
+            if (options.Header is AssertCsvHeader.Present)
+            {
+                headerNames = rawLines[0];
+                rowLines = rawLines.Skip(1).ToArray();
+            }
+            else
+            {
+                headerNames = Enumerable.Range(0, rawLines[0].Length).Select(i => $"Col #{i}").ToArray();
+            }
+
+            return (headerNames, rowLines);
+        }
+
+        /// <summary>
+        /// Parse the incoming <paramref name="rowLines"/> into <see cref="CsvRow"/>s.
+        /// </summary>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="rowLines"/> or the <paramref name="headerNames"/> is <c>null</c></exception>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when the <paramref name="rowLines"/> and <paramref name="headerNames"/> index count does not match.</exception>
+        protected static CsvRow[] ParseCsvRows(string[][] rowLines, string[] headerNames, AssertCsvOptions options)
+        {
+            ArgumentNullException.ThrowIfNull(rowLines);
+            ArgumentNullException.ThrowIfNull(headerNames);
+            options ??= new AssertCsvOptions();
+
+            CsvRow[] rows = rowLines.Select((rawRow, rowNumber) =>
+            {
+                CsvCell[] cells = rawRow.Select((cellValue, columnNumber) =>
+                {
+                    string headerName = headerNames[columnNumber];
+                    return new CsvCell(headerName, columnNumber, rowNumber, cellValue, options);
+                }).ToArray();
+
+                return new CsvRow(cells, rowNumber, options);
+            }).ToArray();
+
+            return rows;
         }
 
         private static void EnsureAllRowsSameLength(string csv, string[][] rawRows, AssertCsvOptions options)
@@ -779,11 +816,7 @@ namespace Arcus.Testing
                                       .Select(row => $"\t - {row.Count()} row(s) with {row.Key} columns")
                                       .Aggregate((x, y) => x + Environment.NewLine + y);
 
-                string optionsDescription =
-                    $"Options: {Environment.NewLine}" +
-                    $"\t- separator: {options.Separator}{Environment.NewLine}" +
-                    $"\t- escape: {options.Escape}{Environment.NewLine}" +
-                    $"\t- quote: {options.Quote}";
+                string optionsDescription = options.ToStringForLoad();
 
                 throw new CsvException(
                     ReportBuilder.ForMethod(LoadMethodName, "cannot correctly load the CSV contents as not all rows in the CSV table has the same amount of columns")
@@ -793,6 +826,30 @@ namespace Arcus.Testing
                                  .AppendInput(csv)
                                  .ToString());
             }
+        }
+
+        /// <summary>
+        /// Applies the additional user options provided via the <see cref="AssertCsv.Equal(CsvTable,CsvTable,Action{AssertCsvOptions})"/> to the current loaded CSV.
+        /// </summary>
+        internal CsvTable ApplyOptions(AssertCsvOptions optionsViaEqual)
+        {
+            (string[] includedHeaderNames, CsvRow[] includedRows) = FilterIncludedColumns(HeaderNames, Rows, optionsViaEqual);
+            return new CsvTable(includedHeaderNames, includedRows, _originalCsv, _options);
+        }
+
+        private static (string[] includedHeaderNames, CsvRow[] includedRows) FilterIncludedColumns(
+            IReadOnlyCollection<string> headerNames,
+            IReadOnlyCollection<CsvRow> allRows,
+            AssertCsvOptions options)
+        {
+            var includedHeaderNames = headerNames.Where(options.IsColumnIncluded).ToArray();
+            var includedRows = allRows.Select(row =>
+            {
+                return row.WithCells(row.Cells.Where(c => includedHeaderNames.Contains(c.HeaderName)));
+
+            }).ToArray();
+
+            return (includedHeaderNames, includedRows);
         }
 
         /// <summary>
@@ -837,7 +894,7 @@ namespace Arcus.Testing
         /// <summary>
         /// Initializes a new instance of the <see cref="CsvRow" /> class.
         /// </summary>
-        internal CsvRow(CsvCell[] cells, int rowNumber, AssertCsvOptions options)
+        internal CsvRow(IReadOnlyCollection<CsvCell> cells, int rowNumber, AssertCsvOptions options)
         {
             ArgumentNullException.ThrowIfNull(cells);
             ArgumentNullException.ThrowIfNull(options);
@@ -857,6 +914,11 @@ namespace Arcus.Testing
         /// Gets the index where the row resides within the <see cref="CsvTable"/>.
         /// </summary>
         public int RowNumber { get; }
+
+        /// <summary>
+        /// Creates a new <see cref="CsvRow"/> with a new set of CSV <paramref name="cells"/>.
+        /// </summary>
+        internal CsvRow WithCells(IEnumerable<CsvCell> cells) => new(cells.ToArray(), RowNumber, _options);
 
         /// <summary>
         /// Order the cells of each row in the passed <paramref name="rows"/>, a.k.a. horizontal ordering.
@@ -882,9 +944,7 @@ namespace Arcus.Testing
 
             return rows.OrderBy(r =>
             {
-                string[] line = r.Cells.Where(c => !options.IgnoredColumns.Contains(c.HeaderName) && !options.IgnoredColumnIndexes.Contains(c.ColumnNumber))
-                                       .Select(c => c.Value)
-                                       .ToArray();
+                string[] line = r.Cells.Select(c => c.Value).ToArray();
                 return string.Join(options.Separator, line);
             }).ToArray();
         }

--- a/src/Arcus.Testing.Tests.Core/Assert_/Fixture/TestCsv.cs
+++ b/src/Arcus.Testing.Tests.Core/Assert_/Fixture/TestCsv.cs
@@ -44,6 +44,8 @@ namespace Arcus.Testing.Tests.Core.Assert_.Fixture
             HeaderNames = headerNames;
             ColumnCount = options.ColumnCount;
             RowCount = options.RowCount;
+
+            IgnoredIndex = Bogus.PickRandom(Enumerable.Range(0, ColumnCount).ToArray());
         }
 
         /// <summary>
@@ -79,7 +81,7 @@ namespace Arcus.Testing.Tests.Core.Assert_.Fixture
         /// <summary>
         /// Gets the index of a column that should be ignored during the assertion.
         /// </summary>
-        public int IgnoredIndex => Bogus.PickRandom(Enumerable.Range(0, ColumnCount).ToArray());
+        public int IgnoredIndex { get; }
 
         /// <summary>
         /// Generate a new <see cref="TestCsv"/> model.
@@ -115,12 +117,14 @@ namespace Arcus.Testing.Tests.Core.Assert_.Fixture
         /// <summary>
         /// Adds a new random column to the CSV table.
         /// </summary>
-        public void AddColumn(string headerName = null)
+        public string AddColumn(string headerName = null)
         {
             string columnName = headerName ?? CreateColumnName();
             List<string> newColumn = GenerateColumn(RowCount).Prepend(columnName).ToList();
             _columns.Insert(Bogus.Random.Int(0, _columns.Count - 1), newColumn);
             ColumnCount++;
+
+            return columnName;
         }
 
         private static string CreateColumnName()


### PR DESCRIPTION
The `AssertCsv.Equal` only used the `IgnoredColumn(Indexe)s` during the equalization of CSV contents. Because of this, expected/actual combinations with different column counts still failed, even though the column was set to 'ignored'.

This PR moves the 'ignore column' functionality to the `AssertCsv.Load`. This means that the `CsvTable` is already 'filtered out' using the ignored columns.