### PR TITLE
chore(core): use sub-directory in dir-not-found exception

### DIFF
--- a/src/Arcus.Testing.Core/ResourceDirectory.cs
+++ b/src/Arcus.Testing.Core/ResourceDirectory.cs
@@ -150,7 +150,7 @@ namespace Arcus.Testing
                     Environment.NewLine +
                     $"Search pattern: {searchPattern}" +
                     Environment.NewLine +
-                    $"Resource directory: {CurrentDirectory.Path.FullName}");
+                    $"Resource directory: {Path.FullName}");
             }
 
             if (files.Length > 1)
@@ -161,7 +161,7 @@ namespace Arcus.Testing
                     Environment.NewLine +
                     $"Search pattern: {searchPattern}" +
                     Environment.NewLine +
-                    $"Resource directory: {CurrentDirectory.Path.FullName}");
+                    $"Resource directory: {Path.FullName}");
             }
 
             return files[0];


### PR DESCRIPTION
When throwing a `DirectoryNotFoundException` on a sub-resource directory, only the root directory path was included.

This PR includes the sub-directory path for better defect localization.
Closes #373 