### PR TITLE
chore(blob): introduce 'upsert blob' renaming

### DIFF
--- a/docs/preview/03-Features/04-Azure/04-Storage/01-storage-account.mdx
+++ b/docs/preview/03-Features/04-Azure/04-Storage/01-storage-account.mdx
@@ -32,19 +32,19 @@ await using var container = await TemporaryBlobContainer.CreateIfNotExistsAsync(
 BlobContainerClient client = container.Client;
 ```
 
-Uploading blobs to the container can also be done via the test fixture. It always make sure that any uploaded blobs will be removed afterwards.
+Uploading blobs to the container can also be done via the test fixture. It always make sure that any uploaded blobs will be removed afterwards. If the blob file already exists, it replaces the contents and reverts this replacement when the container test fixture disposes. (a.k.a. UPSERT).
 
 ```csharp
 using Arcus.Testing;
 
 await using TemporaryBlobContainer container = ...
 
-BlobClient client = await container.UploadBlobAsync(
+BlobClient client = await container.UpsertBlobFileAsync(
     "<blob-name>", BinaryData.FromString("<blob-content>"));
 ```
 
 ### Customization
-The setup and teardown process of the temporary container is configurable. **By default, it always removes any resources that it was responsible for creating.**
+The setup and teardown process of the temporary container is configurable. **By default, it always removes/reverts any resources that it was responsible for creating/replacing.**
 
 ```csharp
 using Arcus.Testing;
@@ -54,15 +54,15 @@ await TemporaryBlobContainer.CreateIfNotExistsAsync(..., options =>
     // Options related to when the test fixture is set up.
     // ---------------------------------------------------
 
-    // (Default) Leaves all Azure Blobs untouched that already existed,
+    // (Default) Leaves all Azure Blob files untouched that already existed,
     // upon the test fixture creation, when there was already an Azure Blob container available.
     options.OnSetup.LeaveAllBlobs();
 
-    // Delete all Azure Blobs upon the test fixture creation, 
+    // Delete all Azure Blob files upon the test fixture creation, 
     // when there was already an Azure Blob container available.
     options.OnSetup.CleanAllBlobs();
 
-    // Delete Azure Blobs that matches any of the configured filters, 
+    // Delete Azure Blob files that matches any of the configured filters, 
     // upon the test fixture creation, when there was already an Azure Blob container available.
     options.OnSetup.CleanMatchingBlobs((BlobItem blob) => blob.Name.StartsWith("test-"));
 
@@ -70,21 +70,21 @@ await TemporaryBlobContainer.CreateIfNotExistsAsync(..., options =>
     // --------------------------------------------------------
 
     // (Default for cleaning blobs)
-    // Delete Azure Blobs upon the test fixture disposal that were uploaded by the fixture.
-    options.OnTeardown.CleanCreatedBlobs();
+    // Delete/revert Azure Blob files upon the test fixture disposal that were upserted by the fixture.
+    options.OnTeardown.CleanUpsertedBlobs();
 
-    // Delete all Azure Blobs upon the test fixture disposal, 
+    // Delete all Azure Blob files upon the test fixture disposal, 
     // even if the test fixture didn't uploaded them.
     options.OnTeardown.CleanAllBlobs();
 
-    // Delete additional Azure Blobs that matches any of the configured filters, 
+    // Delete additional Azure Blob files that matches any of the configured filters, 
     // upon the test fixture disposal.
-    // ⚠️ Blobs uploaded by the test fixture itself will always be deleted.
+    // ⚠️ Blob files upserted by the test fixture itself will always be deleted/reverted.
     options.OnTeardown.CleanMatchingBlobs((BlobItem blob) => blob.Name.StartsWith("test-"));
 
     // (Default for deleting container)
     // Delete Azure Blob container if the test fixture created the container.
-    options.OnTeardown.DeleteCreatedContainer();
+    options.OnTeardown.DeleteCreatedContainer();S
 
     // Delete Azure Blob container regardless if the test fixture created the container or not.
     options.OnTeardown.DeleteExistingContainer();
@@ -93,7 +93,7 @@ await TemporaryBlobContainer.CreateIfNotExistsAsync(..., options =>
 // `OnTeardown` is also still available after the temporary container is created:
 await using TemporaryBlobContainer container = ...
 
-container.OnTeardown.CleanAllBlobs();
+container.OnTeardown.CleanMatchingBlobs(...);
 ```
 
 > 🎖️ The `TemporaryBlobContainer` will always remove any Azure Blobs that were uploaded on the temporary container itself with the `container.UploadBlobAsync`. This follows the 'clean environment' testing principal that any test should not leave any state it created behind after the test has run.

--- a/docs/preview/03-Features/04-Azure/04-Storage/01-storage-account.mdx
+++ b/docs/preview/03-Features/04-Azure/04-Storage/01-storage-account.mdx
@@ -99,12 +99,12 @@ container.OnTeardown.CleanMatchingBlobs(...);
 > 🎖️ The `TemporaryBlobContainer` will always remove any Azure Blobs that were uploaded on the temporary container itself with the `container.UploadBlobAsync`. This follows the 'clean environment' testing principal that any test should not leave any state it created behind after the test has run.
 
 ## Temporary Blob file
-The `TemporaryBlobFile` provides a solution when the integration test requires data (blob) during the test run. An Azure Blob file is created upon the setup of the test fixture and is deleted again when the test fixture is disposed.
+The `TemporaryBlobFile` provides a solution when the integration test requires data (blob) during the test run. An Azure Blob file is created (if new) or replaced (if existing) upon the setup of the test fixture and is deleted (if new) or reverted (if exsiting) again when the test fixture is disposed.
 
 ```csharp
 using Arcus.Testing;
 
-await using var file = await TemporaryBlobFile.UploadIfNotExistsAsync(
+await using var file = await TemporaryBlobFile.UpsertFileAsync(
     blobContainerUri: new Uri("<blob-container-uri">),
     blobName: "<blob-name>",
     blobContent: BinaryData.FromString("<blob-content">),

--- a/src/Arcus.Testing.Storage.Blob/TemporaryBlobContainer.cs
+++ b/src/Arcus.Testing.Storage.Blob/TemporaryBlobContainer.cs
@@ -115,7 +115,7 @@ namespace Arcus.Testing
 
         /// <summary>
         /// (default for cleaning blobs) Configures the <see cref="TemporaryBlobContainer"/> to only delete the Azure Blobs upon disposal
-        /// if the blob was upserted by the test fixture (using <see cref="TemporaryBlobContainer.UpsertBlobFileAsync(string, BinaryData)"/>).
+        /// if the blob was upserted by the test fixture (using <see cref="TemporaryBlobContainer.UpsertBlobFileAsync"/>).
         /// </summary>
         [Obsolete("Will be removed in v3, please use " + nameof(CleanUpsertedBlobs) + " instead that provides exactly the same on-teardown functionality")]
         public OnTeardownBlobContainerOptions CleanCreatedBlobs()
@@ -125,7 +125,7 @@ namespace Arcus.Testing
 
         /// <summary>
         /// (default for cleaning blobs) Configures the <see cref="TemporaryBlobContainer"/> to only delete the Azure Blobs upon disposal
-        /// if the blob was upserted by the test fixture (using <see cref="TemporaryBlobContainer.UpsertBlobFileAsync(string, BinaryData)"/>).
+        /// if the blob was upserted by the test fixture (using <see cref="TemporaryBlobContainer.UpsertBlobFileAsync"/>).
         /// </summary>
         public OnTeardownBlobContainerOptions CleanUpsertedBlobs()
         {
@@ -355,7 +355,7 @@ namespace Arcus.Testing
         /// <param name="blobContent">The content of the blob to upload.</param>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="blobName"/> is blank.</exception>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="blobContent"/> is <c>null</c>.</exception>
-        [Obsolete("Will be removed in v3, please use the " + nameof(UpsertBlobFileAsync) + " instead that provides exactly the same functionality")]
+        [Obsolete("Will be removed in v3, please use the " + nameof(UpsertBlobFileAsync) + "instead that provides exactly the same functionality")]
         public async Task<BlobClient> UploadBlobAsync(string blobName, BinaryData blobContent)
         {
             return await UpsertBlobFileAsync(blobName, blobContent);
@@ -365,7 +365,7 @@ namespace Arcus.Testing
         /// Uploads a new or replaces an existing blob in the Azure Blob container (a.k.a. UPSERT).
         /// </summary>
         /// <remarks>
-        ///     Any blob files upserted via this call will always be deleted (if new) or reverted (if existing)
+        ///     ⚡ Any blob files upserted via this call will always be deleted (if new) or reverted (if existing)
         ///     when the <see cref="TemporaryBlobContainer"/> is disposed.
         /// </remarks>
         /// <param name="blobName">The name of the blob to upload.</param>
@@ -378,7 +378,7 @@ namespace Arcus.Testing
             ArgumentNullException.ThrowIfNull(blobContent);
 
             BlobClient blobClient = Client.GetBlobClient(blobName);
-            _blobs.Add(await TemporaryBlobFile.UploadIfNotExistsAsync(blobClient, blobContent, _logger));
+            _blobs.Add(await TemporaryBlobFile.UpsertFileAsync(blobClient, blobContent, _logger));
 
             return blobClient;
         }

--- a/src/Arcus.Testing.Storage.Blob/TemporaryBlobFile.cs
+++ b/src/Arcus.Testing.Storage.Blob/TemporaryBlobFile.cs
@@ -48,33 +48,6 @@ namespace Arcus.Testing
         public BlobClient Client { get; }
 
         /// <summary>
-        /// Creates a new or replaces an existing Azure Blob file in an Azure Blob container.
-        /// </summary>
-        /// <remarks>
-        ///     <para>⚡ Uses <see cref="DefaultAzureCredential"/> to authenticate with Azure Blob storage.</para>
-        ///     <para>⚡ File will be deleted (if new) or reverted (if existing) when the <see cref="TemporaryBlobFile"/> is disposed.</para>
-        /// </remarks>
-        /// <param name="blobContainerUri">
-        ///     A <see cref="BlobContainerClient.Uri" /> referencing the blob container that includes the name of the account and the name of the container.
-        ///     This is likely to be similar to "https://{account_name}.blob.core.windows.net/{container_name}".
-        /// </param>
-        /// <param name="blobName">The name of the blob to upload.</param>
-        /// <param name="blobContent">The content of the blob to upload.</param>
-        /// <param name="logger">The logger to write diagnostic messages during the upload process.</param>
-        /// <exception cref="ArgumentException">Thrown when the <paramref name="blobContainerUri"/> or the <paramref name="blobName"/> is blank.</exception>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="blobContainerUri"/> or the <paramref name="blobContent"/> is <c>null</c>.</exception>
-        public static async Task<TemporaryBlobFile> UpsertFileAsync(Uri blobContainerUri, string blobName, BinaryData blobContent, ILogger logger)
-        {
-            ArgumentNullException.ThrowIfNull(blobContainerUri);
-            ArgumentException.ThrowIfNullOrWhiteSpace(blobName);
-
-            var containerClient = new BlobContainerClient(blobContainerUri, new DefaultAzureCredential());
-            BlobClient blobClient = containerClient.GetBlobClient(blobName);
-
-            return await UpsertFileAsync(blobClient, blobContent, logger);
-        }
-
-        /// <summary>
         /// Uploads a temporary blob to the Azure Blob container.
         /// </summary>
         /// <remarks>
@@ -93,6 +66,19 @@ namespace Arcus.Testing
         public static async Task<TemporaryBlobFile> UploadIfNotExistsAsync(Uri blobContainerUri, string blobName, BinaryData blobContent, ILogger logger)
         {
             return await UpsertFileAsync(blobContainerUri, blobName, blobContent, logger);
+        }
+
+        /// <summary>
+        /// Uploads a temporary blob to the Azure Blob container.
+        /// </summary>
+        /// <param name="blobClient">The Azure Blob client to interact with Azure Blob storage.</param>
+        /// <param name="blobContent">The content of the blob to upload.</param>
+        /// <param name="logger">The logger to write diagnostic messages during the upload process.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="blobClient"/> or the <paramref name="blobContent"/> is <c>null</c>.</exception>
+        [Obsolete("Will be removed in v3.0, please use the " + nameof(UpsertFileAsync) + " instead which provides the exact same functionality")]
+        public static async Task<TemporaryBlobFile> UploadIfNotExistsAsync(BlobClient blobClient, BinaryData blobContent, ILogger logger)
+        {
+            return await UpsertFileAsync(blobClient, blobContent, logger);
         }
 
         /// <summary>
@@ -118,15 +104,29 @@ namespace Arcus.Testing
         }
 
         /// <summary>
-        /// Uploads a temporary blob to the Azure Blob container.
+        /// Creates a new or replaces an existing Azure Blob file in an Azure Blob container.
         /// </summary>
-        /// <param name="blobClient">The Azure Blob client to interact with Azure Blob storage.</param>
+        /// <remarks>
+        ///     <para>⚡ Uses <see cref="DefaultAzureCredential"/> to authenticate with Azure Blob storage.</para>
+        ///     <para>⚡ File will be deleted (if new) or reverted (if existing) when the <see cref="TemporaryBlobFile"/> is disposed.</para>
+        /// </remarks>
+        /// <param name="blobContainerUri">
+        ///     <para>The <see cref="BlobContainerClient.Uri" /> referencing the blob container that includes the name of the account and the name of the container.</para>
+        ///     <para>This is likely to be similar to <a href="">https://{account_name}.blob.core.windows.net/{container_name}</a>.</para>
+        /// </param>
+        /// <param name="blobName">The name of the blob to upload.</param>
         /// <param name="blobContent">The content of the blob to upload.</param>
         /// <param name="logger">The logger to write diagnostic messages during the upload process.</param>
-        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="blobClient"/> or the <paramref name="blobContent"/> is <c>null</c>.</exception>
-        [Obsolete("Will be removed in v3.0, please use the " + nameof(UpsertFileAsync) + " instead which provides the exact same functionality")]
-        public static async Task<TemporaryBlobFile> UploadIfNotExistsAsync(BlobClient blobClient, BinaryData blobContent, ILogger logger)
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="blobContainerUri"/> or the <paramref name="blobName"/> is blank.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="blobContainerUri"/> or the <paramref name="blobContent"/> is <c>null</c>.</exception>
+        public static async Task<TemporaryBlobFile> UpsertFileAsync(Uri blobContainerUri, string blobName, BinaryData blobContent, ILogger logger)
         {
+            ArgumentNullException.ThrowIfNull(blobContainerUri);
+            ArgumentException.ThrowIfNullOrWhiteSpace(blobName);
+
+            var containerClient = new BlobContainerClient(blobContainerUri, new DefaultAzureCredential());
+            BlobClient blobClient = containerClient.GetBlobClient(blobName);
+
             return await UpsertFileAsync(blobClient, blobContent, logger);
         }
 

--- a/src/Arcus.Testing.Storage.Blob/TemporaryBlobFile.cs
+++ b/src/Arcus.Testing.Storage.Blob/TemporaryBlobFile.cs
@@ -48,6 +48,33 @@ namespace Arcus.Testing
         public BlobClient Client { get; }
 
         /// <summary>
+        /// Creates a new or replaces an existing Azure Blob file in an Azure Blob container.
+        /// </summary>
+        /// <remarks>
+        ///     <para>⚡ Uses <see cref="DefaultAzureCredential"/> to authenticate with Azure Blob storage.</para>
+        ///     <para>⚡ File will be deleted (if new) or reverted (if existing) when the <see cref="TemporaryBlobFile"/> is disposed.</para>
+        /// </remarks>
+        /// <param name="blobContainerUri">
+        ///     A <see cref="BlobContainerClient.Uri" /> referencing the blob container that includes the name of the account and the name of the container.
+        ///     This is likely to be similar to "https://{account_name}.blob.core.windows.net/{container_name}".
+        /// </param>
+        /// <param name="blobName">The name of the blob to upload.</param>
+        /// <param name="blobContent">The content of the blob to upload.</param>
+        /// <param name="logger">The logger to write diagnostic messages during the upload process.</param>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="blobContainerUri"/> or the <paramref name="blobName"/> is blank.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="blobContainerUri"/> or the <paramref name="blobContent"/> is <c>null</c>.</exception>
+        public static async Task<TemporaryBlobFile> UpsertFileAsync(Uri blobContainerUri, string blobName, BinaryData blobContent, ILogger logger)
+        {
+            ArgumentNullException.ThrowIfNull(blobContainerUri);
+            ArgumentException.ThrowIfNullOrWhiteSpace(blobName);
+
+            var containerClient = new BlobContainerClient(blobContainerUri, new DefaultAzureCredential());
+            BlobClient blobClient = containerClient.GetBlobClient(blobName);
+
+            return await UpsertFileAsync(blobClient, blobContent, logger);
+        }
+
+        /// <summary>
         /// Uploads a temporary blob to the Azure Blob container.
         /// </summary>
         /// <remarks>
@@ -62,15 +89,32 @@ namespace Arcus.Testing
         /// <param name="logger">The logger to write diagnostic messages during the upload process.</param>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="blobContainerUri"/> or the <paramref name="blobName"/> is blank.</exception>
         /// <exception cref="ArgumentNullException">Thrown when <paramref name="blobContainerUri"/> or the <paramref name="blobContent"/> is <c>null</c>.</exception>
+        [Obsolete("Will be removed in v3.0, please use the " + nameof(UpsertFileAsync) + " instead which provides the exact same functionality")]
         public static async Task<TemporaryBlobFile> UploadIfNotExistsAsync(Uri blobContainerUri, string blobName, BinaryData blobContent, ILogger logger)
         {
-            ArgumentNullException.ThrowIfNull(blobContainerUri);
-            ArgumentException.ThrowIfNullOrWhiteSpace(blobName);
+            return await UpsertFileAsync(blobContainerUri, blobName, blobContent, logger);
+        }
 
-            var containerClient = new BlobContainerClient(blobContainerUri, new DefaultAzureCredential());
-            BlobClient blobClient = containerClient.GetBlobClient(blobName);
+        /// <summary>
+        /// Creates a new or replaces an existing Azure Blob file in an Azure Blob container.
+        /// </summary>
+        /// <remarks>
+        ///     <para>⚡ Uses <see cref="DefaultAzureCredential"/> to authenticate with Azure Blob storage.</para>
+        ///     <para>⚡ File will be deleted (if new) or reverted (if existing) when the <see cref="TemporaryBlobFile"/> is disposed.</para>
+        /// </remarks>
+        /// <param name="blobClient">The Azure Blob client to interact with Azure Blob storage.</param>
+        /// <param name="blobContent">The content of the blob to upload.</param>
+        /// <param name="logger">The logger to write diagnostic messages during the upload process.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="blobClient"/> or the <paramref name="blobContent"/> is <c>null</c>.</exception>
+        public static async Task<TemporaryBlobFile> UpsertFileAsync(BlobClient blobClient, BinaryData blobContent, ILogger logger)
+        {
+            ArgumentNullException.ThrowIfNull(blobClient);
+            ArgumentNullException.ThrowIfNull(blobContent);
+            logger ??= NullLogger.Instance;
 
-            return await UploadIfNotExistsAsync(blobClient, blobContent, logger);
+            (bool createdByUs, BinaryData originalData) = await EnsureBlobContentCreatedAsync(blobClient, blobContent, logger);
+
+            return new TemporaryBlobFile(blobClient, createdByUs, originalData, logger);
         }
 
         /// <summary>
@@ -80,15 +124,10 @@ namespace Arcus.Testing
         /// <param name="blobContent">The content of the blob to upload.</param>
         /// <param name="logger">The logger to write diagnostic messages during the upload process.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="blobClient"/> or the <paramref name="blobContent"/> is <c>null</c>.</exception>
+        [Obsolete("Will be removed in v3.0, please use the " + nameof(UpsertFileAsync) + " instead which provides the exact same functionality")]
         public static async Task<TemporaryBlobFile> UploadIfNotExistsAsync(BlobClient blobClient, BinaryData blobContent, ILogger logger)
         {
-            ArgumentNullException.ThrowIfNull(blobClient);
-            ArgumentNullException.ThrowIfNull(blobContent);
-            logger ??= NullLogger.Instance;
-
-            (bool createdByUs, BinaryData originalData) = await EnsureBlobContentCreatedAsync(blobClient, blobContent, logger);
-
-            return new TemporaryBlobFile(blobClient, createdByUs, originalData, logger);
+            return await UpsertFileAsync(blobClient, blobContent, logger);
         }
 
         private static async Task<(bool createdByUs, BinaryData originalData)> EnsureBlobContentCreatedAsync(

--- a/src/Arcus.Testing.Tests.Integration/Integration/DataFactory/Fixture/TemporaryDataFactoryDataFlow.cs
+++ b/src/Arcus.Testing.Tests.Integration/Integration/DataFactory/Fixture/TemporaryDataFactoryDataFlow.cs
@@ -352,7 +352,7 @@ namespace Arcus.Testing.Tests.Integration.Integration.DataFactory.Fixture
             filePath = Path.Combine(filePath, RandomizeWith("input") + fileExtension);
 
             _logger.LogTrace("Upload {FileType} file to DataFlow source: {FileContents} with path: {filePath}", _dataType, expected, filePath);
-            await _sourceContainer.UploadBlobAsync(
+            await _sourceContainer.UpsertBlobFileAsync(
                 filePath,
                 BinaryData.FromString(expected));
         }

--- a/src/Arcus.Testing.Tests.Integration/Storage/TemporaryBlobContainerTests.cs
+++ b/src/Arcus.Testing.Tests.Integration/Storage/TemporaryBlobContainerTests.cs
@@ -27,7 +27,7 @@ namespace Arcus.Testing.Tests.Integration.Storage
             TemporaryBlobContainer container = await WhenTempContainerCreatedAsync(context, client);
             await context.ShouldStoreBlobContainerAsync(client);
 
-            string blobCreatedByUs = await UpsertBlobFileAsync(context, container);
+            string blobCreatedByUs = await UpsertBlobFileAsync3(context, container);
 
             // Act
             await container.DisposeAsync();
@@ -47,7 +47,7 @@ namespace Arcus.Testing.Tests.Integration.Storage
             TemporaryBlobContainer container = await WhenTempContainerCreatedAsync(context, client);
 
             await context.ShouldStoreBlobContainerAsync(client);
-            string blobCreatedByUs = await UpsertBlobFileAsync(context, container);
+            string blobCreatedByUs = await UpsertBlobFileAsync3(context, container);
 
             // Act
             await container.DisposeAsync();
@@ -75,7 +75,7 @@ namespace Arcus.Testing.Tests.Integration.Storage
             // Assert
             await context.ShouldDeleteBlobFileAsync(containerClient, blobOutsideOurScope.Name);
 
-            string blobCreatedByUs = await UpsertBlobFileAsync(context, container);
+            string blobCreatedByUs = await UpsertBlobFileAsync3(context, container);
             await container.DisposeAsync();
             await context.ShouldDeleteBlobFileAsync(containerClient, blobCreatedByUs);
 
@@ -123,7 +123,7 @@ namespace Arcus.Testing.Tests.Integration.Storage
             {
                 options.OnTeardown.CleanMatchingBlobs(blob => blob.Name == matchingBlob.Name);
             });
-            string blobCreatedByUs = await UpsertBlobFileAsync(context, container);
+            string blobCreatedByUs = await UpsertBlobFileAsync3(context, container);
 
             // Act
             await container.DisposeAsync();
@@ -201,7 +201,7 @@ namespace Arcus.Testing.Tests.Integration.Storage
             {
                 options.OnTeardown.CleanAllBlobs();
             });
-            string blobCreatedByUs = await UpsertBlobFileAsync(context, container);
+            string blobCreatedByUs = await UpsertBlobFileAsync3(context, container);
 
 
             // Act
@@ -232,7 +232,7 @@ namespace Arcus.Testing.Tests.Integration.Storage
             await context.ShouldDeleteBlobContainerAsync(client);
         }
 
-        private static async Task<string> UpsertBlobFileAsync(BlobStorageTestContext context, TemporaryBlobContainer container)
+        private static async Task<string> UpsertBlobFileAsync3(BlobStorageTestContext context, TemporaryBlobContainer container)
         {
             string blobName = $"test-{Guid.NewGuid()}";
             BlobClient client = await container.UpsertBlobFileAsync(blobName, context.CreateBlobContent());

--- a/src/Arcus.Testing.Tests.Integration/Storage/TemporaryBlobContainerTests.cs
+++ b/src/Arcus.Testing.Tests.Integration/Storage/TemporaryBlobContainerTests.cs
@@ -27,7 +27,7 @@ namespace Arcus.Testing.Tests.Integration.Storage
             TemporaryBlobContainer container = await WhenTempContainerCreatedAsync(context, client);
             await context.ShouldStoreBlobContainerAsync(client);
 
-            string blobCreatedByUs = await UpsertBlobFileAsync3(context, container);
+            string blobCreatedByUs = await UpsertBlobFileAsync(context, container);
 
             // Act
             await container.DisposeAsync();
@@ -47,7 +47,7 @@ namespace Arcus.Testing.Tests.Integration.Storage
             TemporaryBlobContainer container = await WhenTempContainerCreatedAsync(context, client);
 
             await context.ShouldStoreBlobContainerAsync(client);
-            string blobCreatedByUs = await UpsertBlobFileAsync3(context, container);
+            string blobCreatedByUs = await UpsertBlobFileAsync(context, container);
 
             // Act
             await container.DisposeAsync();
@@ -75,7 +75,7 @@ namespace Arcus.Testing.Tests.Integration.Storage
             // Assert
             await context.ShouldDeleteBlobFileAsync(containerClient, blobOutsideOurScope.Name);
 
-            string blobCreatedByUs = await UpsertBlobFileAsync3(context, container);
+            string blobCreatedByUs = await UpsertBlobFileAsync(context, container);
             await container.DisposeAsync();
             await context.ShouldDeleteBlobFileAsync(containerClient, blobCreatedByUs);
 
@@ -123,7 +123,7 @@ namespace Arcus.Testing.Tests.Integration.Storage
             {
                 options.OnTeardown.CleanMatchingBlobs(blob => blob.Name == matchingBlob.Name);
             });
-            string blobCreatedByUs = await UpsertBlobFileAsync3(context, container);
+            string blobCreatedByUs = await UpsertBlobFileAsync(context, container);
 
             // Act
             await container.DisposeAsync();
@@ -201,7 +201,7 @@ namespace Arcus.Testing.Tests.Integration.Storage
             {
                 options.OnTeardown.CleanAllBlobs();
             });
-            string blobCreatedByUs = await UpsertBlobFileAsync3(context, container);
+            string blobCreatedByUs = await UpsertBlobFileAsync(context, container);
 
 
             // Act
@@ -232,7 +232,7 @@ namespace Arcus.Testing.Tests.Integration.Storage
             await context.ShouldDeleteBlobContainerAsync(client);
         }
 
-        private static async Task<string> UpsertBlobFileAsync3(BlobStorageTestContext context, TemporaryBlobContainer container)
+        private static async Task<string> UpsertBlobFileAsync(BlobStorageTestContext context, TemporaryBlobContainer container)
         {
             string blobName = $"test-{Guid.NewGuid()}";
             BlobClient client = await container.UpsertBlobFileAsync(blobName, context.CreateBlobContent());

--- a/src/Arcus.Testing.Tests.Integration/Storage/TemporaryBlobContainerTests.cs
+++ b/src/Arcus.Testing.Tests.Integration/Storage/TemporaryBlobContainerTests.cs
@@ -244,7 +244,7 @@ namespace Arcus.Testing.Tests.Integration.Storage
             BlobContainerClient client,
             Action<TemporaryBlobContainerOptions> configureOptions = null)
         {
-#pragma warning disable S3358 // Sonar suggests extracting nested condition, but that will create the container twice + does not help with  readability.
+#pragma warning disable S3358 // Sonar suggests extracting nested condition, but that will create the container twice + does not help with readability.
 
             TemporaryBlobContainer temp = configureOptions is null
                 ? Bogus.Random.Bool()

--- a/src/Arcus.Testing.Tests.Integration/Storage/TemporaryBlobContainerTests.cs
+++ b/src/Arcus.Testing.Tests.Integration/Storage/TemporaryBlobContainerTests.cs
@@ -27,7 +27,7 @@ namespace Arcus.Testing.Tests.Integration.Storage
             TemporaryBlobContainer container = await WhenTempContainerCreatedAsync(context, client);
             await context.ShouldStoreBlobContainerAsync(client);
 
-            string blobCreatedByUs = await UploadBlobAsync(context, container);
+            string blobCreatedByUs = await UpsertBlobFileAsync(context, container);
 
             // Act
             await container.DisposeAsync();
@@ -47,7 +47,7 @@ namespace Arcus.Testing.Tests.Integration.Storage
             TemporaryBlobContainer container = await WhenTempContainerCreatedAsync(context, client);
 
             await context.ShouldStoreBlobContainerAsync(client);
-            string blobCreatedByUs = await UploadBlobAsync(context, container);
+            string blobCreatedByUs = await UpsertBlobFileAsync(context, container);
 
             // Act
             await container.DisposeAsync();
@@ -75,7 +75,7 @@ namespace Arcus.Testing.Tests.Integration.Storage
             // Assert
             await context.ShouldDeleteBlobFileAsync(containerClient, blobOutsideOurScope.Name);
 
-            string blobCreatedByUs = await UploadBlobAsync(context, container);
+            string blobCreatedByUs = await UpsertBlobFileAsync(context, container);
             await container.DisposeAsync();
             await context.ShouldDeleteBlobFileAsync(containerClient, blobCreatedByUs);
 
@@ -123,7 +123,7 @@ namespace Arcus.Testing.Tests.Integration.Storage
             {
                 options.OnTeardown.CleanMatchingBlobs(blob => blob.Name == matchingBlob.Name);
             });
-            string blobCreatedByUs = await UploadBlobAsync(context, container);
+            string blobCreatedByUs = await UpsertBlobFileAsync(context, container);
 
             // Act
             await container.DisposeAsync();
@@ -201,7 +201,7 @@ namespace Arcus.Testing.Tests.Integration.Storage
             {
                 options.OnTeardown.CleanAllBlobs();
             });
-            string blobCreatedByUs = await UploadBlobAsync(context, container);
+            string blobCreatedByUs = await UpsertBlobFileAsync(context, container);
 
 
             // Act
@@ -232,10 +232,10 @@ namespace Arcus.Testing.Tests.Integration.Storage
             await context.ShouldDeleteBlobContainerAsync(client);
         }
 
-        private static async Task<string> UploadBlobAsync(BlobStorageTestContext context, TemporaryBlobContainer container)
+        private static async Task<string> UpsertBlobFileAsync(BlobStorageTestContext context, TemporaryBlobContainer container)
         {
             string blobName = $"test-{Guid.NewGuid()}";
-            BlobClient client = await container.UploadBlobAsync(blobName, context.CreateBlobContent());
+            BlobClient client = await container.UpsertBlobFileAsync(blobName, context.CreateBlobContent());
             return client.Name;
         }
 


### PR DESCRIPTION
Rename 'create/upload' functionality to use 'upsert' instead for a better communication on when Azure Blob files are uploaded/replaced/reverted.
* `container.UploadBlobAsync` ➡️ `container.UpsertBlobFileAsync`
* `options.OnTeardown.CleanCreatedBlobs()` ➡️ `options.OnTeardown.CleanUpsertedBlobs()`
* `TemporaryBlobFile.UploadIfNotExistsAsync` ➡️ `TemporaryBlobFile.UpsertFileAsync`

👀 This is already prepared for v3, so that the migration guide v2-v3 can already reference the new `.UpsertFileAsync` instead of the old one. See also PR: #389

Relates to #378 