### PR TITLE
chore(cosmos): introduce 'upsert doc/item' renaming

### DIFF
--- a/docs/preview/03-Features/04-Azure/04-Storage/02-cosmos.mdx
+++ b/docs/preview/03-Features/04-Azure/04-Storage/02-cosmos.mdx
@@ -39,14 +39,14 @@ IMongoCollection<Shipment> client = collection.GetCollectionClient<Shipment>();
 
 > 🎖️ Overloads are available that takes in the `IMongoDatabase` for custom authentication mechanisms. By default, it uses the [`DefaultAzureCredential`](https://learn.microsoft.com/en-us/dotnet/api/azure.identity.defaultazurecredential).
 
-Inserting documents in the collection can also be done via the test fixture. It always make sure that any inserted documents are removed afterwards.
+Upserting documents in the collection can also be done via the test fixture. It always make sure that any upserted documents are removed (if new) or reverted (if existing) afterwards.
 
 ```csharp
 using Arcus.Testing;
 
 await using TemporaryMongoDbCollection collection = ...
 
-await collection.InsertDocumentAsync(new Shipment { BoatName = "The Alice"  });
+await collection.UpsertDocumentAsync(new Shipment { BoatName = "The Alice"  });
 ```
 
 #### Customization
@@ -76,16 +76,16 @@ await TemporaryMongoDbCollection.CreateIfNotExistsAsync(..., options =>
     // Options related to when the test fixture is teared down.
     // --------------------------------------------------------
 
-    // (Default) Delete all MongoDb documents that were inserted by the test fixture.
-    options.OnTeardown.CleanCreatedDocuments();
+    // (Default) Delete/Revert all MongoDb documents that were upserted by the test fixture.
+    options.OnTeardown.CleanUpsertedDocuments();
 
     // Delete all MongoDb documents upon the test fixture disposal,
-    // even if the test fixture didn't inserted them.
+    // even if the test fixture didn't upserted them.
     options.OnTeardown.CleanAllDocuments();
 
     // Delete all MongoDb documents that matches any of the configured filters,
-    // upon the test fixture disposal, even if the test fixture didn't inserted them.
-    // ⚠️ MongoDb documents inserted by the test fixture will always be deleted, regardless of the configured filters.
+    // upon the test fixture disposal, even if the test fixture didn't upserted them.
+    // ⚠️ MongoDb documents upserted by the test fixture will be deleted/reverted, even if the documents don't match the configured filters.
     options.OnTeardown.CleanMatchingDocuments(
       Builders<Shipment>.Filter.Eq(s => s.BoatName, "The Alice"));
 
@@ -98,7 +98,7 @@ await using TemporaryMongoDbCollection collection = ...
 collection.OnTeardown.CleanAllDocuments();
 ```
 
-> 🎖️ The `TemporaryMongoDbCollection` will always remove any MongoDb documents that were inserted via the temporary collection itself with the `collection.InsertDocumentAsync`. This follows the 'clean environment' testing principal that any test should not leave any state it created behind after the test has run.
+> 🎖️ The `TemporaryMongoDbCollection` will always remove/revert any MongoDb documents that were upserted via the temporary collection itself with the `collection.UpsertDocumentAsync`. This follows the 'clean environment' testing principal that any test should not leave any state it created behind after the test has run.
 
 ### Temporary MongoDb document
 The `TemporaryMongoDbDocument` provides a solution when the integration test requires a document during the test run. A MongoDb document is created upon the setup of the test fixture and is deleted again when the test fixture is disposed.
@@ -115,7 +115,7 @@ ResourceIdentifier cosmosDbAccountResourceId =
 
 var shipment = new Shipment { BoatName = "The Alice" };
 
-await using var document = await TemporaryMongoDbDocument.InsertIfNotExistsAsync(
+await using var document = await TemporaryMongoDbDocument.UpsertDocumentAsync(
     cosmosDbAccountResourceId,
     "<database-name>",
     "<collection-name>",
@@ -164,14 +164,14 @@ Container client = container.Client;
 
 > 🎖️ Overloads are available for custom authentication mechanisms. By default, it uses the [`DefaultAzureCredential`](https://learn.microsoft.com/en-us/dotnet/api/azure.identity.defaultazurecredential).
 
-Inserting items in the container can also be done via the test fixture. It always make sure that any inserted items are removed afterwards.
+Upserting items in the container can also be done via the test fixture. It always make sure that any upserted items are removed (if new) or reverted (if existing) afterwards.
 
 ```csharp
 using Arcus.Testing;
 
 await using TemporaryNoSqlContainer container = ...
 
-await container.AddItemAsync(new Shipment { Id = "123", BoatName = "The Alice" });
+await container.UpsertItemAsync(new Shipment { Id = "123", BoatName = "The Alice" });
 ```
 
 #### Customization
@@ -199,16 +199,16 @@ await TemporaryNoSqlContainer.CreateIfNotExistsAsync(..., options =>
     // Options related to when the test fixture is teared down.
     // --------------------------------------------------------
 
-    // (Default) Delete all NoSql items that were inserted by the test fixture.
-    options.OnTeardown.CleanCreatedItems();
+    // (Default) Delete/Revert all NoSql items that were upserted by the test fixture.
+    options.OnTeardown.CleanUpsertedItems();
 
     // Delete all NoSql items upon the test fixture disposal,
-    // even if the test fixture didn't inserted them.
+    // even if the test fixture didn't upserted them.
     options.OnTeardown.CleanAllItems();
 
     // Delete all NoSql items that matches any of the configured filters,
-    // upon the test fixture disposal, even if the test fixture didn't inserted them.
-    // ⚠️ NoSql items inserted by the test fixture will always be deleted, regardless of the configured filters.
+    // upon the test fixture disposal, even if the test fixture didn't upserted them.
+    // ⚠️ NoSql items upserted by the test fixture will be deleted/reverted, even if the items don't match the configured filters.
     options.OnTeardown.CleanMatchingItems((NoSqlItem item) => item.Id == "123"); 
     options.OnTeardown.CleanMatchingItems((Shipment item) => item.BoatName == "The Alice");
 });
@@ -219,7 +219,7 @@ await using TemporaryNoSqlContainer container = ...
 container.OnTeardown.CleanAllItems();
 ```
 
-> 🎖️ The `TemporaryNoSqlContainer` will always remove any NoSql items that were inserted via the temporary container itself with the `container.AddItemAsync`. This follows the 'clean environment' testing principal that any test should not leave any state it created behind after the test has run.
+> 🎖️ The `TemporaryNoSqlContainer` will always remove/revert any NoSql items that were upserted via the temporary container itself with the `container.UpsertItemAsync`. This follows the 'clean environment' testing principal that any test should not leave any state it created behind after the test has run.
 
 ### Temporary NoSql item
 The `TemporaryNoSqlItem` provides a solution when the integration test requires a item during the test run. A NoSql item is created upon the setup of the test fixture and is deleted again when the test fixture is disposed.
@@ -233,7 +233,7 @@ Container containerClient = ...
 
 var shipment = new Shipment { Id = "123", BoatName = "The Alice" };
 
-await using var item = await TemporaryNoSqlItem.InsertIfNotExistsAsync(
+await using var item = await TemporaryNoSqlItem.UpsertItemAsync(
     containerClient, shipment, logger);
 
 string itemId = item.Id;

--- a/src/Arcus.Testing.Storage.Cosmos/TemporaryMongoDbCollection.cs
+++ b/src/Arcus.Testing.Storage.Cosmos/TemporaryMongoDbCollection.cs
@@ -149,7 +149,7 @@ namespace Arcus.Testing
         /// </summary>
         /// <remarks>
         ///     The matching of documents only happens on MongoDb documents that were created outside the scope of the test fixture.
-        ///     All documents created by the test fixture will be deleted upon disposal, regardless of the filters.
+        ///     All documents created by the test fixture will be deleted or reverted upon disposal, even if the documents do not match of the filters.
         ///     This follows the 'clean environment' principle where the test fixture should clean up after itself and not linger around any state it created.
         /// </remarks>
         /// <typeparam name="TDocument">The type of the documents in the MongoDb collection.</typeparam>
@@ -166,7 +166,7 @@ namespace Arcus.Testing
         /// </summary>
         /// <remarks>
         ///     The matching of documents only happens on MongoDb documents that were created outside the scope of the test fixture.
-        ///     All documents created by the test fixture will be deleted upon disposal, regardless of the filters.
+        ///     All documents created by the test fixture will be deleted or reverted upon disposal, even if the documents do not match one of the filters.
         ///     This follows the 'clean environment' principle where the test fixture should clean up after itself and not linger around any state it created.
         /// </remarks>
         /// <typeparam name="TDocument">The type of the documents in the MongoDb collection.</typeparam>

--- a/src/Arcus.Testing.Storage.Cosmos/TemporaryMongoDbCollection.cs
+++ b/src/Arcus.Testing.Storage.Cosmos/TemporaryMongoDbCollection.cs
@@ -125,7 +125,8 @@ namespace Arcus.Testing
         }
 
         /// <summary>
-        /// (default for cleaning documents) Configures the <see cref="TemporaryMongoDbCollection"/> to only delete the MongoDb documents upon disposal
+        /// (default for cleaning documents) Configures the <see cref="TemporaryMongoDbCollection"/> to only delete or revert the MongoDb documents upon disposal
+
         /// if the document was upserted by the test fixture (using <see cref="TemporaryMongoDbCollection.UpsertDocumentAsync{TDocument}"/>).
         /// </summary>
         public OnTeardownMongoDbCollectionOptions CleanUpsertedDocuments()

--- a/src/Arcus.Testing.Storage.Cosmos/TemporaryMongoDbCollection.cs
+++ b/src/Arcus.Testing.Storage.Cosmos/TemporaryMongoDbCollection.cs
@@ -126,7 +126,6 @@ namespace Arcus.Testing
 
         /// <summary>
         /// (default for cleaning documents) Configures the <see cref="TemporaryMongoDbCollection"/> to only delete or revert the MongoDb documents upon disposal
-
         /// if the document was upserted by the test fixture (using <see cref="TemporaryMongoDbCollection.UpsertDocumentAsync{TDocument}"/>).
         /// </summary>
         public OnTeardownMongoDbCollectionOptions CleanUpsertedDocuments()

--- a/src/Arcus.Testing.Storage.Cosmos/TemporaryMongoDbCollection.cs
+++ b/src/Arcus.Testing.Storage.Cosmos/TemporaryMongoDbCollection.cs
@@ -20,7 +20,7 @@ namespace Arcus.Testing
     /// <summary>
     /// Represents the available options when the <see cref="TemporaryMongoDbCollection"/> is deleted.
     /// </summary>
-    internal enum OnTeardownMongoDbCollection { CleanIfCreated = 0, CleanAll, CleanIfMatched }
+    internal enum OnTeardownMongoDbCollection { CleanIfUpserted = 0, CleanAll, CleanIfMatched }
 
     /// <summary>
     /// Represents the available options when creating a <see cref="TemporaryMongoDbCollection"/>.
@@ -116,11 +116,21 @@ namespace Arcus.Testing
 
         /// <summary>
         /// (default for cleaning documents) Configures the <see cref="TemporaryMongoDbCollection"/> to only delete the MongoDb documents upon disposal
-        /// if the document was inserted by the test fixture (using <see cref="TemporaryMongoDbCollection.AddDocumentAsync{TDocument}"/>).
+        /// if the document was inserted by the test fixture (using <see cref="TemporaryMongoDbCollection.UpsertDocumentAsync{TDocument}"/>).
         /// </summary>
+        [Obsolete("Will be removed in v3, please use the " + nameof(CleanUpsertedDocuments) + "instead that provides exactly the same functionality")]
         public OnTeardownMongoDbCollectionOptions CleanCreatedDocuments()
         {
-            Documents = OnTeardownMongoDbCollection.CleanIfCreated;
+            return CleanUpsertedDocuments();
+        }
+
+        /// <summary>
+        /// (default for cleaning documents) Configures the <see cref="TemporaryMongoDbCollection"/> to only delete the MongoDb documents upon disposal
+        /// if the document was upserted by the test fixture (using <see cref="TemporaryMongoDbCollection.UpsertDocumentAsync{TDocument}"/>).
+        /// </summary>
+        public OnTeardownMongoDbCollectionOptions CleanUpsertedDocuments()
+        {
+            Documents = OnTeardownMongoDbCollection.CleanIfUpserted;
             return this;
         }
 
@@ -189,7 +199,7 @@ namespace Arcus.Testing
         /// <summary>
         /// Gets the additional options to manipulate the deletion of the <see cref="TemporaryMongoDbCollection"/>.
         /// </summary>
-        public OnTeardownMongoDbCollectionOptions OnTeardown { get; } = new OnTeardownMongoDbCollectionOptions().CleanCreatedDocuments();
+        public OnTeardownMongoDbCollectionOptions OnTeardown { get; } = new OnTeardownMongoDbCollectionOptions().CleanUpsertedDocuments();
     }
 
     /// <summary>
@@ -200,7 +210,7 @@ namespace Arcus.Testing
         private readonly bool _createdByUs;
         private readonly IMongoDatabase _database;
         private readonly TemporaryMongoDbCollectionOptions _options;
-        private readonly Collection<IAsyncDisposable> _documents = new();
+        private readonly Collection<IAsyncDisposable> _documents = [];
         private readonly ILogger _logger;
 
         private TemporaryMongoDbCollection(
@@ -391,12 +401,28 @@ namespace Arcus.Testing
         /// <typeparam name="TDocument">The type of the document in the MongoDb collection.</typeparam>
         /// <param name="document">The document to upload to the MongoDb collection.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="document"/> is <c>null</c>.</exception>
+        [Obsolete("Will be removed in v3, please use the " + nameof(UpsertDocumentAsync) + "instead that provides exactly the same functionality")]
         public async Task AddDocumentAsync<TDocument>(TDocument document)
+        {
+            await UpsertDocumentAsync(document);
+        }
+
+        /// <summary>
+        /// Adds a new or replaces an existing document in the Azure MongoDb collection (a.k.a. UPSERT).
+        /// </summary>
+        /// <remarks>
+        ///     ⚡ Any items upserted via this call will always be deleted (if new) or reverted (if existing)
+        ///     when the <see cref="TemporaryMongoDbCollection"/> is disposed.
+        /// </remarks>
+        /// <typeparam name="TDocument">The type of the document in the MongoDb collection.</typeparam>
+        /// <param name="document">The document to upload to the MongoDb collection.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="document"/> is <c>null</c>.</exception>
+        public async Task UpsertDocumentAsync<TDocument>(TDocument document)
         {
             ArgumentNullException.ThrowIfNull(document);
 
             IMongoCollection<TDocument> collection = GetCollectionClient<TDocument>();
-            _documents.Add(await TemporaryMongoDbDocument.InsertIfNotExistsAsync(collection, document, _logger));
+            _documents.Add(await TemporaryMongoDbDocument.UpsertDocumentAsync(collection, document, _logger));
         }
 
         /// <summary>
@@ -429,7 +455,7 @@ namespace Arcus.Testing
 
         private async Task CleanCollectionOnTeardownAsync()
         {
-            if (_options.OnTeardown.Documents is OnTeardownMongoDbCollection.CleanIfCreated)
+            if (_options.OnTeardown.Documents is OnTeardownMongoDbCollection.CleanIfUpserted)
             {
                 return;
             }

--- a/src/Arcus.Testing.Storage.Cosmos/TemporaryMongoDbDocument.cs
+++ b/src/Arcus.Testing.Storage.Cosmos/TemporaryMongoDbDocument.cs
@@ -69,7 +69,54 @@ namespace Arcus.Testing
         /// <param name="logger">The logger to write diagnostic information during the lifetime of the MongoDb document.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="cosmosDbResourceId"/> or <paramref name="document"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="databaseName"/> or the <paramref name="collectionName"/> is blank.</exception>
+        [Obsolete("Will be removed in v3, please use the " + nameof(UpsertDocumentAsync) + "instead that provides exactly the same functionality")]
         public static async Task<TemporaryMongoDbDocument> InsertIfNotExistsAsync<TDocument>(
+            ResourceIdentifier cosmosDbResourceId,
+            string databaseName,
+            string collectionName,
+            TDocument document,
+            ILogger logger)
+            where TDocument : class
+        {
+            return await UpsertDocumentAsync(cosmosDbResourceId, databaseName, collectionName, document, logger);
+        }
+
+        /// <summary>
+        /// Inserts a temporary document to an Azure Cosmos MongoDb collection.
+        /// </summary>
+        /// <param name="collection">The collection client to interact with the MongoDb collection.</param>
+        /// <param name="document">The document that should be temporarily inserted into the MongoDb collection.</param>
+        /// <param name="logger">The logger to write diagnostic information during the lifetime of the MongoDb document.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="collection"/> or the <paramref name="document"/> is <c>null</c>.</exception>
+        [Obsolete("Will be removed in v3, please use the " + nameof(UpsertDocumentAsync) + "instead that provides exactly the same functionality")]
+        public static async Task<TemporaryMongoDbDocument> InsertIfNotExistsAsync<TDocument>(IMongoCollection<TDocument> collection, TDocument document, ILogger logger)
+        {
+            return await UpsertDocumentAsync(collection, document, logger);
+        }
+
+        /// <summary>
+        /// Creates a new or replaces an existing document in an Azure Cosmos MongoDb collection.
+        /// </summary>
+        /// <remarks>
+        ///     ⚡ Document will be deleted (if new) or reverted (if existing) when the <see cref="TemporaryMongoDbDocument"/> is disposed.
+        /// </remarks>
+        /// <param name="cosmosDbResourceId">
+        ///   <para>The resource ID pointing towards the Azure Cosmos account.</para>
+        ///   <para>The resource ID can be constructed with the <see cref="CosmosDBAccountResource.CreateResourceIdentifier"/>:</para>
+        ///   <example>
+        ///     <code>
+        ///       ResourceIdentifier cosmosDbAccountResourceId =
+        ///           CosmosDBAccountResource.CreateResourceIdentifier("&lt;subscription-id&gt;", "&lt;resource-group&gt;", "&lt;account-name&gt;");
+        ///     </code>
+        ///   </example>
+        /// </param>
+        /// <param name="databaseName">The name of the MongoDb database in which the collection resides where the document should be created.</param>
+        /// <param name="collectionName">The name of the MongoDb collection in which the document should be created.</param>
+        /// <param name="document">The document that should be temporarily inserted into the MongoDb collection.</param>
+        /// <param name="logger">The logger to write diagnostic information during the lifetime of the MongoDb document.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="cosmosDbResourceId"/> or <paramref name="document"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="databaseName"/> or the <paramref name="collectionName"/> is blank.</exception>
+        public static async Task<TemporaryMongoDbDocument> UpsertDocumentAsync<TDocument>(
             ResourceIdentifier cosmosDbResourceId,
             string databaseName,
             string collectionName,
@@ -87,17 +134,20 @@ namespace Arcus.Testing
             IMongoDatabase database = client.GetDatabase(databaseName);
             IMongoCollection<TDocument> collection = database.GetCollection<TDocument>(collectionName);
 
-            return await InsertIfNotExistsAsync(collection, document, logger);
+            return await UpsertDocumentAsync(collection, document, logger);
         }
 
         /// <summary>
-        /// Inserts a temporary document to an Azure Cosmos MongoDb collection.
+        /// Creates a new or replaces an existing document in an Azure Cosmos MongoDb collection.
         /// </summary>
+        /// <remarks>
+        ///     ⚡ Document will be deleted (if new) or reverted (if existing) when the <see cref="TemporaryMongoDbDocument"/> is disposed.
+        /// </remarks>
         /// <param name="collection">The collection client to interact with the MongoDb collection.</param>
         /// <param name="document">The document that should be temporarily inserted into the MongoDb collection.</param>
         /// <param name="logger">The logger to write diagnostic information during the lifetime of the MongoDb document.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="collection"/> or the <paramref name="document"/> is <c>null</c>.</exception>
-        public static async Task<TemporaryMongoDbDocument> InsertIfNotExistsAsync<TDocument>(IMongoCollection<TDocument> collection, TDocument document, ILogger logger)
+        public static async Task<TemporaryMongoDbDocument> UpsertDocumentAsync<TDocument>(IMongoCollection<TDocument> collection, TDocument document, ILogger logger)
         {
             ArgumentNullException.ThrowIfNull(collection);
             ArgumentNullException.ThrowIfNull(document);

--- a/src/Arcus.Testing.Storage.Cosmos/TemporaryNoSqlContainer.cs
+++ b/src/Arcus.Testing.Storage.Cosmos/TemporaryNoSqlContainer.cs
@@ -183,7 +183,6 @@ namespace Arcus.Testing
 
         /// <summary>
         /// (default for cleaning items) Configures the <see cref="TemporaryNoSqlContainer"/> to only delete or revert the NoSql items upon disposal
-
         /// if the item was upserted by the test fixture (using <see cref="TemporaryNoSqlContainer.UpsertItemAsync{TItem}"/>).
         /// </summary>
         public OnTeardownNoSqlContainerOptions CleanUpsertedItems()

--- a/src/Arcus.Testing.Storage.Cosmos/TemporaryNoSqlContainer.cs
+++ b/src/Arcus.Testing.Storage.Cosmos/TemporaryNoSqlContainer.cs
@@ -28,7 +28,7 @@ namespace Arcus.Testing
     /// <summary>
     /// Represents the available options when the <see cref="TemporaryNoSqlContainer"/> is deleted.
     /// </summary>
-    internal enum OnTeardownNoSqlContainer { CleanIfCreated = 0, CleanAll, CleanIfMatched }
+    internal enum OnTeardownNoSqlContainer { CleanIfUpserted = 0, CleanAll, CleanIfMatched }
 
     /// <summary>
     /// Represents a generic dictionary-like type which defines an arbitrary set of properties on a NoSql item as key-value pairs.
@@ -66,7 +66,7 @@ namespace Arcus.Testing
     /// </summary>
     public class OnSetupNoSqlContainerOptions
     {
-        private readonly List<Func<CosmosClient, NoSqlItem, bool>> _filters = new();
+        private readonly List<Func<CosmosClient, NoSqlItem, bool>> _filters = [];
 
         /// <summary>
         /// Gets the configurable setup option on what to do with existing NoSql items in the Azure NoSql container upon the test fixture creation.
@@ -164,7 +164,7 @@ namespace Arcus.Testing
     /// </summary>
     public class OnTeardownNoSqlContainerOptions
     {
-        private readonly List<Func<CosmosClient, NoSqlItem, bool>> _filters = new();
+        private readonly List<Func<CosmosClient, NoSqlItem, bool>> _filters = [];
 
         /// <summary>
         /// Gets the configurable setup option on what to do with existing NoSql items in the Azure NoSql container upon the test fixture deletion.
@@ -173,11 +173,21 @@ namespace Arcus.Testing
 
         /// <summary>
         /// (default for cleaning items) Configures the <see cref="TemporaryNoSqlContainer"/> to only delete the NoSql items upon disposal
-        /// if the item was inserted by the test fixture (using <see cref="TemporaryNoSqlContainer.AddItemAsync{TItem}"/>).
+        /// if the item was upserted by the test fixture (using <see cref="TemporaryNoSqlContainer.AddItemAsync{TItem}"/>).
         /// </summary>
+        [Obsolete("Will be removed in v3, please use " + nameof(CleanUpsertedItems) + " instead that provides exactly the same on-teardown functionality")]
         public OnTeardownNoSqlContainerOptions CleanCreatedItems()
         {
-            Items = OnTeardownNoSqlContainer.CleanIfCreated;
+            return CleanUpsertedItems();
+        }
+
+        /// <summary>
+        /// (default for cleaning items) Configures the <see cref="TemporaryNoSqlContainer"/> to only delete the NoSql items upon disposal
+        /// if the item was upserted by the test fixture (using <see cref="TemporaryNoSqlContainer.UpsertItemAsync{TItem}"/>).
+        /// </summary>
+        public OnTeardownNoSqlContainerOptions CleanUpsertedItems()
+        {
+            Items = OnTeardownNoSqlContainer.CleanIfUpserted;
             return this;
         }
 
@@ -275,7 +285,7 @@ namespace Arcus.Testing
         /// <summary>
         /// Gets the additional options to manipulate the deletion of the <see cref="TemporaryNoSqlContainer"/>.
         /// </summary>
-        public OnTeardownNoSqlContainerOptions OnTeardown { get; } = new OnTeardownNoSqlContainerOptions().CleanCreatedItems();
+        public OnTeardownNoSqlContainerOptions OnTeardown { get; } = new OnTeardownNoSqlContainerOptions().CleanUpsertedItems();
     }
 
     /// <summary>
@@ -286,7 +296,7 @@ namespace Arcus.Testing
         private readonly CosmosDBSqlContainerResource _container;
         private readonly CosmosClient _resourceClient;
         private readonly bool _createdByUs;
-        private readonly Collection<IAsyncDisposable> _items = new();
+        private readonly Collection<IAsyncDisposable> _items = [];
         private readonly TemporaryNoSqlContainerOptions _options;
         private readonly ILogger _logger;
 
@@ -593,10 +603,25 @@ namespace Arcus.Testing
         /// <typeparam name="T">The custom NoSql model.</typeparam>
         /// <param name="item">The item to create in the NoSql container.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="item"/> is <c>null</c>.</exception>
+        [Obsolete("Will be removed in v3, please use the " + nameof(UpsertItemAsync) + "instead that provides exactly the same functionality")]
         public async Task AddItemAsync<T>(T item)
         {
+            await UpsertItemAsync(item);
+        }
+
+        /// <summary>
+        /// Adds a new or replaces an existing NoSql item in the Azure NoSql container (a.k.a. UPSERT).
+        /// </summary>
+        /// <remarks>
+        ///     ⚡ Any items upserted via this call will always be deleted (if new) or reverted (if existing)
+        ///     when the <see cref="TemporaryNoSqlContainer"/> is disposed.
+        /// </remarks>
+        /// <param name="item">The item to create in the NoSql container.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="item"/> is <c>null</c>.</exception>
+        public async Task UpsertItemAsync<TItem>(TItem item)
+        {
             ArgumentNullException.ThrowIfNull(item);
-            _items.Add(await TemporaryNoSqlItem.InsertIfNotExistsAsync(Client, item, _logger));
+            _items.Add(await TemporaryNoSqlItem.UpsertItemAsync(Client, item, _logger));
         }
 
         /// <summary>
@@ -628,7 +653,7 @@ namespace Arcus.Testing
 
         private async Task CleanContainerOnTeardownAsync(DisposableCollection disposables)
         {
-            if (_options.OnTeardown.Items is OnTeardownNoSqlContainer.CleanIfCreated)
+            if (_options.OnTeardown.Items is OnTeardownNoSqlContainer.CleanIfUpserted)
             {
                 return;
             }

--- a/src/Arcus.Testing.Storage.Cosmos/TemporaryNoSqlContainer.cs
+++ b/src/Arcus.Testing.Storage.Cosmos/TemporaryNoSqlContainer.cs
@@ -182,7 +182,8 @@ namespace Arcus.Testing
         }
 
         /// <summary>
-        /// (default for cleaning items) Configures the <see cref="TemporaryNoSqlContainer"/> to only delete the NoSql items upon disposal
+        /// (default for cleaning items) Configures the <see cref="TemporaryNoSqlContainer"/> to only delete or revert the NoSql items upon disposal
+
         /// if the item was upserted by the test fixture (using <see cref="TemporaryNoSqlContainer.UpsertItemAsync{TItem}"/>).
         /// </summary>
         public OnTeardownNoSqlContainerOptions CleanUpsertedItems()

--- a/src/Arcus.Testing.Storage.Cosmos/TemporaryNoSqlContainer.cs
+++ b/src/Arcus.Testing.Storage.Cosmos/TemporaryNoSqlContainer.cs
@@ -207,7 +207,7 @@ namespace Arcus.Testing
         /// </summary>
         /// <remarks>
         ///     The matching of items only happens on NoSql items that were created outside the scope of the test fixture.
-        ///     All items created by the test fixture will be deleted upon disposal, regardless of the filters.
+        ///     All items created by the test fixture will be deleted or reverted upon disposal, even if the items do not match one of the filters.
         ///     This follows the 'clean environment' principle where the test fixture should clean up after itself and not linger around any state it created.
         /// </remarks>
         /// <param name="filters">The filters  to match NoSql items that should be removed.</param>
@@ -234,7 +234,7 @@ namespace Arcus.Testing
         /// </summary>
         /// <remarks>
         ///     The matching of items only happens on NoSql items that were created outside the scope of the test fixture.
-        ///     All items created by the test fixture will be deleted upon disposal, regardless of the filters.
+        ///     All items upserted by the test fixture will be deleted or reverted upon disposal, even if the items do not match one of the filters.
         ///     This follows the 'clean environment' principle where the test fixture should clean up after itself and not linger around any state it created.
         /// </remarks>
         /// <typeparam name="TItem">The custom type of the NoSql item.</typeparam>

--- a/src/Arcus.Testing.Storage.Cosmos/TemporaryNoSqlItem.cs
+++ b/src/Arcus.Testing.Storage.Cosmos/TemporaryNoSqlItem.cs
@@ -62,7 +62,23 @@ namespace Arcus.Testing
         /// <param name="item">The item to temporary create in the NoSql container.</param>
         /// <param name="logger">The logger instance to write diagnostic information during the lifetime of the test fixture.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="container"/> is <c>null</c>.</exception>
+        [Obsolete("Will be removed in v3.0, please use the " + nameof(UpsertItemAsync) + " instead which provides the exact same functionality")]
         public static async Task<TemporaryNoSqlItem> InsertIfNotExistsAsync<TItem>(Container container, TItem item, ILogger logger)
+        {
+            return await UpsertItemAsync(container, item, logger);
+        }
+
+        /// <summary>
+        /// Creates a new or replaces an existing NoSql item in an Azure Cosmos NoSql container.
+        /// </summary>
+        /// <remarks>
+        ///     ⚡ Item will be deleted (if new) or reverted (if existing) when the <see cref="TemporaryNoSqlItem"/> is disposed.
+        /// </remarks>
+        /// <param name="container">The NoSql container where a temporary item should be created.</param>
+        /// <param name="item">The item to temporary create in the NoSql container.</param>
+        /// <param name="logger">The logger instance to write diagnostic information during the lifetime of the test fixture.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="container"/> is <c>null</c>.</exception>
+        public static async Task<TemporaryNoSqlItem> UpsertItemAsync<TItem>(Container container, TItem item, ILogger logger)
         {
             ArgumentNullException.ThrowIfNull(container);
             logger ??= NullLogger.Instance;
@@ -92,7 +108,7 @@ namespace Arcus.Testing
         {
             logger.LogTrace("[Test:Setup] Try replacing Azure Cosmos NoSql '{ItemType}' item '{ItemId}' in container '{DatabaseName}/{ContainerName}'...", typeof(TItem).Name, itemId, container.Database.Id, container.Id);
             ItemResponse<TItem> response = await container.ReadItemAsync<TItem>(itemId, partitionKey);
-            
+
             CosmosSerializer serializer = container.Database.Client.ClientOptions.Serializer;
             if (serializer is null)
             {
@@ -142,7 +158,7 @@ namespace Arcus.Testing
                 {
                     _logger.LogDebug("[Test:Teardown] Delete Azure Cosmos NoSql '{ItemType}' item '{ItemId}' in container '{DatabaseName}/{ContainerName}'", _itemType.Name, Id, _container.Database.Id, _container.Id);
                     using ResponseMessage response = await _container.DeleteItemStreamAsync(Id, PartitionKey);
-                    
+
                     if (!response.IsSuccessStatusCode && response.StatusCode != HttpStatusCode.NotFound)
                     {
                         throw new RequestFailedException(
@@ -157,7 +173,7 @@ namespace Arcus.Testing
                 {
                     _logger.LogDebug("[Test:Teardown] Revert replaced Azure Cosmos NoSql '{ItemType}' item '{ItemId}' in container '{DatabaseName}/{ContainerName}'", _itemType.Name, Id, _container.Database.Id, _container.Id);
                     using ResponseMessage response = await _container.ReplaceItemStreamAsync(_originalItemStream, Id, PartitionKey);
-                    
+
                     if (!response.IsSuccessStatusCode)
                     {
                         throw new RequestFailedException(


### PR DESCRIPTION
Let's already introduce the new `Upsert[Item/Document]Async` in the `.Cosmos` package for v2, so that the v3 feature documentation is already pointing to the new ones.

Relates to #378 