### PR TITLE
chore(table): introduce 'upsert entity' renaming

### DIFF
--- a/docs/preview/03-Features/04-Azure/04-Storage/01-storage-account.mdx
+++ b/docs/preview/03-Features/04-Azure/04-Storage/01-storage-account.mdx
@@ -143,7 +143,7 @@ TableClient client = table.Client;
 
 > 🎖️ Overloads are available to fully control the authentication mechanism to Azure Table storage. By default, it uses the [`DefaultAzureCredential`](https://learn.microsoft.com/en-us/dotnet/api/azure.identity.defaultazurecredential).
 
-Adding entities to the table can also be done via the test fixture. It always make sure that any added entities will be removed afterwards upon disposal.
+Upserting entities to the table can also be done via the test fixture. It always make sure that any added entities will be removed/reverted afterwards upon disposal.
 
 ```csharp
 using Arcus.Testing;
@@ -151,7 +151,7 @@ using Arcus.Testing;
 await using TemporaryTable table = ...
 
 ITableEntity myEntity = ...
-await table.AddEntityAsync(myEntity);
+await table.UpsertEntityAsync(myEntity);
 ```
 
 ### Customization
@@ -181,8 +181,8 @@ await TemporaryTable.CreateIfNotExistsAsync(..., options =>
     // --------------------------------------------------------
 
     // (Default for cleaning entities)
-    // Delete Azure Table entities upon the test fixture disposal that were added by the fixture.
-    options.OnTeardown.CleanCreatedEntities();
+    // Delete/Revert Azure Table entities upon the test fixture disposal that were upserted by the fixture.
+    options.OnTeardown.CleanUpsertedEntities();
 
     // Delete all Azure Table entities upon the test fixture disposal, 
     // even if the test fixture didn't added them.
@@ -190,7 +190,7 @@ await TemporaryTable.CreateIfNotExistsAsync(..., options =>
 
     // Delete additional Azure Table entities that matches any of the configured filters, 
     // upon the test fixture disposal.
-    // ⚠️ Entities added by the test fixture itself will always be deleted.
+    // ⚠️ Entities upserted by the test fixture itself always be deleted/reverted, even if the entities do not match one of the filters.
     options.OnTeardown.CleanMatchingEntities((TableEntity entity) => entity["Test"] = "Value");
 });
 
@@ -200,17 +200,19 @@ await using TemporaryTable table = ...
 table.OnTeardown.CleanAllEntities();
 ```
 
-> 🎖️ The `TemporaryTable` will always remove any Azure Table entities that were added on the temporary table  itself with the `table.AddEntityAsync`. This follows the 'clean environment' testing principal that any test should not leave any state it created behind after the test has run.
+> 🎖️ The `TemporaryTable` will always remove/revert any Azure Table entities that were upserted on the temporary table itself with the `table.UpsertEntityAsync`. This follows the 'clean environment' testing principal that any test should not leave any state it created behind after the test has run.
 
 ## Temporary Table entity
 The `TemporaryTableEntity` provides a solution when the integration test requires data (table) during the test run. An Azure Table entity is added upon the setup of the test fixture and is deleted again when the test fixture is disposed.
+
+> ⚡ When the entity already existed (already an entity with a same configured entity row and partition key), then the test fixture will revert to the original content of the entity upon the test fixture disposal.
 
 ```csharp
 using Arcus.Testing;
 
 ITableEntity entity = ...
 
-await using var entity = await TemporaryTableEntity.AddIfNotExistsAsync(
+await using var entity = await TemporaryTableEntity.UpsertEntityAsync(
     "<account-name>", "<table-name>", entity, logger);
 ```
 

--- a/src/Arcus.Testing.Storage.Table/TemporaryTable.cs
+++ b/src/Arcus.Testing.Storage.Table/TemporaryTable.cs
@@ -20,14 +20,14 @@ namespace Arcus.Testing
     /// <summary>
     /// Represents the available options when the <see cref="TemporaryTable"/> is deleted.
     /// </summary>
-    internal enum OnTeardownTable { CleanIfCreated = 0, CleanAll, CleanIfMatched }
+    internal enum OnTeardownTable { CleanIfUpserted = 0, CleanAll, CleanIfMatched }
 
     /// <summary>
     /// Represents the available options when creating a <see cref="TemporaryTable"/>.
     /// </summary>
     public class OnSetupTemporaryTableOptions
     {
-        private readonly List<Func<TableEntity, bool>> _filters = new();
+        private readonly List<Func<TableEntity, bool>> _filters = [];
 
         /// <summary>
         /// Gets the configurable setup option on what to do with existing entities in the Azure Table upon the test fixture creation.
@@ -92,7 +92,7 @@ namespace Arcus.Testing
     /// </summary>
     public class OnTeardownTemporaryTableOptions
     {
-        private readonly List<Func<TableEntity, bool>> _filters = new();
+        private readonly List<Func<TableEntity, bool>> _filters = [];
 
         /// <summary>
         /// Gets the configurable setup option on what to do with existing entities in the Azure Table upon the test fixture deletion.
@@ -101,11 +101,21 @@ namespace Arcus.Testing
 
         /// <summary>
         /// (default for cleaning documents) Configures the <see cref="TemporaryTable"/> to only delete the Azure Table entities upon disposal
-        /// if the document was inserted by the test fixture (using <see cref="TemporaryTable.AddEntityAsync{TEntity}"/>).
+        /// if the document was inserted by the test fixture (using <see cref="TemporaryTable.UpsertEntityAsync{TEntity}"/>).
         /// </summary>
+        [Obsolete("Will be removed in v3.0, please use the " + nameof(CleanUpsertedEntities) + " instead that provides exactly the same functionality")]
         public OnTeardownTemporaryTableOptions CleanCreatedEntities()
         {
-            Entities = OnTeardownTable.CleanIfCreated;
+            return CleanUpsertedEntities();
+        }
+
+        /// <summary>
+        /// (default for cleaning documents) Configures the <see cref="TemporaryTable"/> to only delete or revert the Azure Table entities upon disposal
+        /// if the document was upserted by the test fixture (using <see cref="TemporaryTable.UpsertEntityAsync{TEntity}"/>).
+        /// </summary>
+        public OnTeardownTemporaryTableOptions CleanUpsertedEntities()
+        {
+            Entities = OnTeardownTable.CleanIfUpserted;
             return this;
         }
 
@@ -124,7 +134,7 @@ namespace Arcus.Testing
         /// </summary>
         /// <remarks>
         ///     The matching of documents only happens on entities that were created outside the scope of the test fixture.
-        ///     All items created by the test fixture will be deleted upon disposal, regardless of the filters.
+        ///     All items created by the test fixture will be deleted or reverted upon disposal, regardless of the filters.
         ///     This follows the 'clean environment' principle where the test fixture should clean up after itself and not linger around any state it created.
         /// </remarks>
         /// <param name="filters">The filters  to match entities that should be removed.</param>
@@ -167,7 +177,7 @@ namespace Arcus.Testing
         /// <summary>
         /// Gets the additional options to manipulate the deletion of the <see cref="TemporaryTable"/>.
         /// </summary>
-        public OnTeardownTemporaryTableOptions OnTeardown { get; } = new OnTeardownTemporaryTableOptions().CleanCreatedEntities();
+        public OnTeardownTemporaryTableOptions OnTeardown { get; } = new OnTeardownTemporaryTableOptions().CleanUpsertedEntities();
     }
 
     /// <summary>
@@ -178,7 +188,7 @@ namespace Arcus.Testing
         private const int NotFound = 404;
 
         private readonly bool _createdByUs;
-        private readonly Collection<TemporaryTableEntity> _entities = new();
+        private readonly Collection<TemporaryTableEntity> _entities = [];
         private readonly TemporaryTableOptions _options;
         private readonly ILogger _logger;
 
@@ -320,16 +330,7 @@ namespace Arcus.Testing
             {
                 await foreach (TableEntity item in tableClient.QueryAsync<TableEntity>(_ => true))
                 {
-                    logger.LogDebug("[Test:Setup] Delete Azure Table entity (rowKey: '{RowKey}', partitionKey: '{PartitionKey}') from table '{AccountName}/{TableName}'", item.RowKey, item.PartitionKey, tableClient.AccountName, tableClient.Name);
-                    using Response response = await tableClient.DeleteEntityAsync(item);
-
-                    if (response.IsError && response.Status != NotFound)
-                    {
-                        throw new RequestFailedException(
-                            $"[Test:Setup] Failed to delete Azure Table entity (rowKey: '{item.RowKey}', partitionKey: '{item.PartitionKey}') from table {tableClient.AccountName}/{tableClient.Name}' " +
-                            $"since the delete operation responded with a failure: {response.Status} {(HttpStatusCode) response.Status}",
-                            new RequestFailedException(response));
-                    }
+                    await DeleteEntityOnSetupAsync(tableClient, item, logger);
                 }
             }
             else if (options.OnSetup.Entities is OnSetupTable.CleanIfMatched)
@@ -340,16 +341,7 @@ namespace Arcus.Testing
                 {
                     if (options.OnSetup.IsMatch(item))
                     {
-                        logger.LogDebug("[Test:Setup] Delete Azure Table entity (rowKey: '{RowKey}', partitionKey: '{PartitionKey}') from table '{AccountName}/{TableName}'", item.RowKey, item.PartitionKey, tableClient.AccountName, tableClient.Name);
-                        using Response response = await tableClient.DeleteEntityAsync(item);
-
-                        if (response.IsError && response.Status != NotFound)
-                        {
-                            throw new RequestFailedException(
-                                $"[Test:Setup] Failed to delete Azure Table entity (rowKey: '{item.RowKey}', partitionKey: '{item.PartitionKey}') from table {tableClient.AccountName}/{tableClient.Name}' " +
-                                $"since the delete operation responded with a failure: {response.Status} {(HttpStatusCode) response.Status}",
-                                new RequestFailedException(response));
-                        }
+                        await DeleteEntityOnSetupAsync(tableClient, item, logger);
                     }
                 }
             }
@@ -361,10 +353,26 @@ namespace Arcus.Testing
         /// <typeparam name="TEntity">A custom model type that implements <see cref="ITableEntity" /> or an instance of <see cref="TableEntity" />.</typeparam>
         /// <param name="entity">The entity to temporary add to the table.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="entity"/> is <c>null</c>.</exception>
+        [Obsolete("Will be removed in v3.0, please use the " + nameof(UpsertEntityAsync) + " instead that provides exactly the same functionality")]
         public async Task AddEntityAsync<TEntity>(TEntity entity) where TEntity : class, ITableEntity
         {
+            await UpsertEntityAsync(entity);
+        }
+
+        /// <summary>
+        /// Adds a new or replaces an existing item in the Azure Table (a.k.a. UPSERT).
+        /// </summary>
+        /// <remarks>
+        ///     ⚡ Any entities upserted via this call will always be deleted (if new) or reverted (if existing) when the <see cref="TemporaryTable"/> is disposed.
+        ///     Existing entities are found based on their <see cref="ITableEntity.PartitionKey" /> and <see cref="ITableEntity.RowKey" />.
+        /// </remarks>
+        /// <typeparam name="TEntity">A custom model type that implements <see cref="ITableEntity" /> or an instance of <see cref="TableEntity" />.</typeparam>
+        /// <param name="entity">The entity to temporary add to the table.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="entity"/> is <c>null</c>.</exception>
+        public async Task UpsertEntityAsync<TEntity>(TEntity entity) where TEntity : class, ITableEntity
+        {
             ArgumentNullException.ThrowIfNull(entity);
-            _entities.Add(await TemporaryTableEntity.AddIfNotExistsAsync(Client, entity, _logger));
+            _entities.Add(await TemporaryTableEntity.UpsertEntityAsync(Client, entity, _logger));
         }
 
         /// <summary>
@@ -399,7 +407,7 @@ namespace Arcus.Testing
 
         private async Task CleanTableUponTeardownAsync(DisposableCollection disposables)
         {
-            if (_options.OnTeardown.Entities is OnTeardownTable.CleanIfCreated)
+            if (_options.OnTeardown.Entities is OnTeardownTable.CleanIfUpserted)
             {
                 return;
             }
@@ -408,42 +416,44 @@ namespace Arcus.Testing
             {
                 await foreach (TableEntity item in Client.QueryAsync<TableEntity>(_ => true))
                 {
-                    disposables.Add(AsyncDisposable.Create(async () =>
-                    {
-                        _logger.LogDebug("[Test:Teardown] Delete Azure Table entity (rowKey: '{RowKey}', partitionKey: '{PartitionKey}') from table '{AccountName}/{TableName}'", item.RowKey, item.PartitionKey, Client.AccountName, Client.Name);
-                        using Response response = await Client.DeleteEntityAsync(item);
-
-                        if (response.IsError && response.Status != NotFound)
-                        {
-                            throw new RequestFailedException(
-                                $"[Test:Teardown] Failed to delete Azure Table entity (rowKey: '{item.RowKey}', partitionKey: '{item.PartitionKey}') from table {Client.AccountName}/{Client.Name}' " +
-                                $"since the delete operation responded with a failure: {response.Status} {(HttpStatusCode) response.Status}",
-                                new RequestFailedException(response));
-                        }
-                    }));
+                    disposables.Add(AsyncDisposable.Create(() => DeleteEntityOnTeardownAsync(item)));
                 }
             }
             else if (_options.OnTeardown.Entities is OnTeardownTable.CleanIfMatched)
             {
+#pragma warning disable S3267 // Sonar recommends LINQ on loops, but Microsoft has no Async LINQ built-in, besides the additional/outdated `System.Linq.Async` package.
                 await foreach (TableEntity item in Client.QueryAsync<TableEntity>(_ => true))
+#pragma warning restore S3267
                 {
-                    disposables.Add(AsyncDisposable.Create(async () =>
+                    if (_options.OnTeardown.IsMatch(item))
                     {
-                        if (_options.OnTeardown.IsMatch(item))
-                        {
-                            _logger.LogDebug("[Test:Teardown] Delete Azure Table entity (rowKey: '{RowKey}', partitionKey: '{PartitionKey}') from table '{AccountName}/{TableName}'", item.RowKey, item.PartitionKey, Client.AccountName, Client.Name);
-                            using Response response = await Client.DeleteEntityAsync(item);
-
-                            if (response.IsError && response.Status != NotFound)
-                            {
-                                throw new RequestFailedException(
-                                    $"[Test:Teardown] Failed to delete Azure Table entity (rowKey: '{item.RowKey}', partitionKey: '{item.PartitionKey}') from table {Client.AccountName}/{Client.Name}' " +
-                                    $"since the delete operation responded with a failure: {response.Status} {(HttpStatusCode) response.Status}",
-                                    new RequestFailedException(response));
-                            }
-                        }
-                    }));
+                        disposables.Add(AsyncDisposable.Create(() => DeleteEntityOnTeardownAsync(item)));
+                    }
                 }
+            }
+        }
+
+        private static async Task DeleteEntityOnSetupAsync(TableClient client, TableEntity entity, ILogger logger)
+        {
+            await DeleteEntityAsync(client, entity, "[Test:Setup]", logger);
+        }
+
+        private async Task DeleteEntityOnTeardownAsync(TableEntity entity)
+        {
+            await DeleteEntityAsync(Client, entity, "[Test:Teardown]", _logger);
+        }
+
+        private static async Task DeleteEntityAsync(TableClient client, TableEntity entity, string testOperation, ILogger logger)
+        {
+            logger.LogDebug("{TestOperation} Delete Azure Table entity (rowKey: '{RowKey}', partitionKey: '{PartitionKey}') from table '{AccountName}/{TableName}'", testOperation, entity.RowKey, entity.PartitionKey, client.AccountName, client.Name);
+            using Response response = await client.DeleteEntityAsync(entity);
+
+            if (response.IsError && response.Status != NotFound)
+            {
+                throw new RequestFailedException(
+                    $"{testOperation} Failed to delete Azure Table entity (rowKey: '{entity.RowKey}', partitionKey: '{entity.PartitionKey}') from table {client.AccountName}/{client.Name}' " +
+                    $"since the delete operation responded with a failure: {response.Status} {(HttpStatusCode) response.Status}",
+                    new RequestFailedException(response));
             }
         }
     }

--- a/src/Arcus.Testing.Storage.Table/TemporaryTableEntity.cs
+++ b/src/Arcus.Testing.Storage.Table/TemporaryTableEntity.cs
@@ -50,7 +50,46 @@ namespace Arcus.Testing
         /// <param name="logger">The logger instance to write diagnostic information during the lifetime of the test fixture.</param>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="accountName"/> or the <paramref name="tableName"/> is blank.</exception>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="entity"/> is <c>null</c>.</exception>
+        [Obsolete("Will be removed in v3.0, please use the " + nameof(UpsertEntityAsync) + " instead which provides exactly the same functionality")]
         public static async Task<TemporaryTableEntity> AddIfNotExistsAsync<TEntity>(
+            string accountName,
+            string tableName,
+            TEntity entity,
+            ILogger logger)
+            where TEntity : class, ITableEntity
+        {
+            return await UpsertEntityAsync(accountName, tableName, entity, logger);
+        }
+
+        /// <summary>
+        /// Creates a temporary entity in an Azure Table.
+        /// </summary>
+        /// <typeparam name="TEntity">A custom model type that implements <see cref="ITableEntity" /> or an instance of <see cref="TableEntity" />.</typeparam>
+        /// <param name="client">The client to interact with the Azure Table resource.</param>
+        /// <param name="entity">The entity to add to the Azure Table.</param>
+        /// <param name="logger">The logger instance to write diagnostic information during the lifetime of the test fixture.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="client"/> or the <paramref name="entity"/> is <c>null</c>.</exception>
+        [Obsolete("Will be removed in v3.0, please use the " + nameof(UpsertEntityAsync) + " instead which provides exactly the same functionality")]
+        public static async Task<TemporaryTableEntity> AddIfNotExistsAsync<TEntity>(TableClient client, TEntity entity, ILogger logger) where TEntity : class, ITableEntity
+        {
+            return await UpsertEntityAsync(client, entity, logger);
+        }
+
+        /// <summary>
+        /// Creates a new or replaces an existing entity in an Azure Table.
+        /// </summary>
+        /// <remarks>
+        ///     Based on the entity's <see cref="ITableEntity.PartitionKey" /> and <see cref="ITableEntity.RowKey" />,
+        ///     an existing entity will be replaced or a new entity will be created.
+        /// </remarks>
+        /// <typeparam name="TEntity">A custom model type that implements <see cref="ITableEntity" /> or an instance of <see cref="TableEntity" />.</typeparam>
+        /// <param name="accountName">The name of the Azure Storage account where the table for the entity is located.</param>
+        /// <param name="tableName">The name of the Azure Table where the table entity should be added.</param>
+        /// <param name="entity">The entity to add to the Azure Table.</param>
+        /// <param name="logger">The logger instance to write diagnostic information during the lifetime of the test fixture.</param>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="accountName"/> or the <paramref name="tableName"/> is blank.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="entity"/> is <c>null</c>.</exception>
+        public static async Task<TemporaryTableEntity> UpsertEntityAsync<TEntity>(
             string accountName,
             string tableName,
             TEntity entity,
@@ -63,18 +102,22 @@ namespace Arcus.Testing
             var tableEndpoint = new Uri($"https://{accountName}.table.core.windows.net");
             var tableClient = new TableClient(tableEndpoint, tableName, new DefaultAzureCredential());
 
-            return await AddIfNotExistsAsync<TEntity>(tableClient, entity, logger);
+            return await UpsertEntityAsync(tableClient, entity, logger);
         }
 
         /// <summary>
-        /// Creates a temporary entity in an Azure Table.
+        /// Creates a new or replaces an existing entity in an Azure Table.
         /// </summary>
+        /// <remarks>
+        ///     Based on the entity's <see cref="ITableEntity.PartitionKey" /> and <see cref="ITableEntity.RowKey" />,
+        ///     an existing entity will be replaced or a new entity will be created.
+        /// </remarks>
         /// <typeparam name="TEntity">A custom model type that implements <see cref="ITableEntity" /> or an instance of <see cref="TableEntity" />.</typeparam>
         /// <param name="client">The client to interact with the Azure Table resource.</param>
         /// <param name="entity">The entity to add to the Azure Table.</param>
         /// <param name="logger">The logger instance to write diagnostic information during the lifetime of the test fixture.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="client"/> or the <paramref name="entity"/> is <c>null</c>.</exception>
-        public static async Task<TemporaryTableEntity> AddIfNotExistsAsync<TEntity>(TableClient client, TEntity entity, ILogger logger) where TEntity : class, ITableEntity
+        public static async Task<TemporaryTableEntity> UpsertEntityAsync<TEntity>(TableClient client, TEntity entity, ILogger logger) where TEntity : class, ITableEntity
         {
             ArgumentNullException.ThrowIfNull(client);
             ArgumentNullException.ThrowIfNull(entity);
@@ -88,7 +131,7 @@ namespace Arcus.Testing
             if (entityExists.HasValue)
             {
                 ITableEntity originalEntity = entityExists.Value;
-                
+
                 logger.LogDebug("[Test:Setup] Replace already existing Azure Table entity '{EntityType}' (rowKey: '{RowKey}', partitionKey: '{PartitionKey}') in table '{AccountName}/{TableName}'", entityType.Name, entity.RowKey, entity.PartitionKey, client.AccountName, client.Name);
                 using Response response = await client.UpsertEntityAsync(entity, TableUpdateMode.Replace);
 
@@ -116,7 +159,7 @@ namespace Arcus.Testing
                         new RequestFailedException(response));
                 }
 
-                return new TemporaryTableEntity(client, entityType, createdByUs: true, entity, logger); 
+                return new TemporaryTableEntity(client, entityType, createdByUs: true, entity, logger);
             }
         }
 


### PR DESCRIPTION
Let's already introduce the new 'upsert entity' renaming for v2.0, so that the new feature documentation already points to the right methods.

Relates to #378 