### PR TITLE
feat(contrib): finalize internal/external contribution setup+docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ The integration tests make use of real Azure resources, which means that the tes
    The tests use [`DefaultAzureCredential`](https://learn.microsoft.com/en-us/dotnet/api/azure.identity.defaultazurecredential) to authenticate themselves, which means that you can use your logged-in VisualStudio/AzureCLI user to run the tests locally.
 
 3. Add the necessary **Azure resources** for your test: </br>
-   There exists a [`/build/templates/test-resources.bicep`](https://github.com/arcus-azure/arcus.testing/blob/main/build/templates/test-resources.bicep) file that let's you deploy all the necessary Azure resources that are required to run *all* the tests.
+   The file [`/build/templates/test-resources.bicep`](https://github.com/arcus-azure/arcus.testing/blob/main/build/templates/test-resources.bicep) allows you deploy all the necessary Azure resources that are required to run *all* the tests.
     * 💡 Usually, you don't need to run *all* the tests locally. Arcus Testing is very flexible and modular. If you're working on something, like **Azure Blob Storage**-related, than you only need an **Azure Storage Account**.
     
     * ⚠️ Make sure that you have enough rights on your Azure resources to do CRUD operations (ex. the **Azure Blob Storage** tests require [`Storage Blob Data Contributor`](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles/storage#storage-blob-data-contributor)-rights.)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ The integration tests make use of real Azure resources, which means that the tes
     
     * ⚠️ Make sure that you have enough rights on your Azure resources to do CRUD operations (ex. the **Azure Blob Storage** tests require [`Storage Blob Data Contributor`](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles/storage#storage-blob-data-contributor)-rights.)
 
-4. Add an `appsettings.local.json` file to your integration test project - this file gets ignored by Git: </br>
+4. Add an `appsettings.local.json` file to your integration test project - this file is ignored in Git by default: </br>
    The local file needs to have the names of your **Azure resources**. If you deployed an **Azure Storage Account**, then you the file will look like this:
    ```json
    {

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ The integration tests make use of real Azure resources, which means that the tes
 
 3. Add the necessary **Azure resources** for your test: </br>
    The file [`/build/templates/test-resources.bicep`](https://github.com/arcus-azure/arcus.testing/blob/main/build/templates/test-resources.bicep) allows you deploy all the necessary Azure resources that are required to run *all* the tests.
-    * 💡 Usually, you don't need to run *all* the tests locally. Arcus Testing is very flexible and modular. If you're working on something, like **Azure Blob Storage**-related, than you only need an **Azure Storage Account**.
+    * 💡 Usually, you don't need to run *all* the tests locally. Arcus Testing is very flexible and modular. If you're working on something, like **Azure Blob Storage**-related, then you only need an **Azure Storage Account**.
     
     * ⚠️ Make sure that you have enough rights on your Azure resources to do CRUD operations (ex. the **Azure Blob Storage** tests require [`Storage Blob Data Contributor`](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles/storage#storage-blob-data-contributor)-rights.)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ The integration tests make use of real Azure resources, which means that the tes
 1. Make sure you have an **active Azure subscription**.
 
 2. Set up a **valid managed identity connection**: </br>
-   The tests uses [`DefaultAzureCredential`](https://learn.microsoft.com/en-us/dotnet/api/azure.identity.defaultazurecredential) to authenticate themselves, which means that you can use your logged-in VisualStudio/AzureCLI user to run the tests locally.
+   The tests use [`DefaultAzureCredential`](https://learn.microsoft.com/en-us/dotnet/api/azure.identity.defaultazurecredential) to authenticate themselves, which means that you can use your logged-in VisualStudio/AzureCLI user to run the tests locally.
 
 3. Add the necessary **Azure resources** for your test: </br>
    There exists a [`/build/templates/test-resources.bicep`](https://github.com/arcus-azure/arcus.testing/blob/main/build/templates/test-resources.bicep) file that let's you deploy all the necessary Azure resources that are required to run *all* the tests.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,54 @@
+# Contributing to Arcus Testing
+> 🎉 First off, **thank you** for taking the time to contribute! </br>
+> We're really glad you're reading this.
+
+This guide helps with newcomers to contribute effectively to Arcus Testing.
+
+* **🐞 I found a bug!** </br>
+Great Scott! Please [report the problem](https://github.com/arcus-azure/arcus.testing/issues/new/choose) so we can have a look, or if you're up to it: you can always fix it yourself and [submit a PR]().
+
+* **❔ I have a question or an idea** </br>
+[GitHub discussions](https://github.com/arcus-azure/arcus.testing/discussions/new/choose) is the place to host discussions, questions or ideas related to anything available in the codebase. Ideas can always be transformed in workable [GitHub issues](https://github.com/arcus-azure/arcus.testing/issues) once the team decides to place this on the roadmap.
+
+* **👷‍♀️ I want to work** </br>
+Have a look at our [good first issues](https://github.com/arcus-azure/arcus.testing/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22good%20first%20issue%22) to get you started on something easy. Please comment on the issue, so we can assign you to it.
+
+## Submitting a PR
+When you submit a new pull request, please make sure that:
+* 📦 it **packages everything** related to the feature/bug
+* 🧪 it **proofs using tests** the feature/bugfix (both unit & integration tests are available to run locally)
+* 🌐 it **updates the documentation**, if necessary (changes should happen in the `/docs/preview/` folder)
+
+## FAQ
+<details>
+<summary>How to run the integration tests locally?</summary>
+The integration tests make use of real Azure resources, which means that the the test suite need to be aware of what resources you want to use locally.
+
+> 👉 If you're a [Codit](http://codit.eu/) employee, we can also provide you with a ready-to-use `appsettings.local.json` that allows for you to run the tests locally.
+
+1. Make sure you have an **active Azure subscription**.
+
+2. Set up a **valid managed identity connection**: </br>
+   The tests uses [`DefaultAzureCredential`](https://learn.microsoft.com/en-us/dotnet/api/azure.identity.defaultazurecredential) to authenticate themselves, which means that you can use your logged-in VisualStudio/AzureCLI user to run the tests locally.
+
+3. Add the necessary **Azure resources** for your test: </br>
+   There exists a [`/build/templates/test-resources.bicep`](https://github.com/arcus-azure/arcus.testing/blob/main/build/templates/test-resources.bicep) file that let's you deploy all the necessary Azure resources that are required to run *all* the tests.
+    * 💡 Usually, you don't need to run *all* the tests locally. Arcus Testing is very flexible and modular. If you're working on something, like **Azure Blob Storage**-related, than you only need an **Azure Storage Account**.
+    
+    * ⚠️ Make sure that you have enough rights on your Azure resources to do CRUD operations (ex. the **Azure Blob Storage** tests require [`Storage Blob Data Contributor`](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles/storage#storage-blob-data-contributor)-rights.)
+
+4. Add an `appsettings.local.json` file to your integration test project - this file gets ignored by Git: </br>
+   The local file needs to have the names of your **Azure resources**. If you deployed an **Azure Storage Account**, then you the file will look like this:
+   ```json
+   {
+     "Arcus": {
+        "StorageAccount": {
+            "Name": "mystorageaccount"
+        }
+     }
+   }
+   ```
+   🚀 Don't worry, if a value is missing, the test will fail and point you to the values you require to run the test.
+
+5. You can now run the tests locally! 🎉
+</details>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ When you submit a new pull request, please make sure that:
 <summary>How to run the integration tests locally?</summary>
 The integration tests make use of real Azure resources, which means that the test suite needs to be aware of which resources you want to use locally.
 
-> 👉 If you're a [Codit](http://codit.eu/) employee, we can also provide you with a ready-to-use `appsettings.local.json` that allows for you to run the tests locally.
+> 👉 If you're a [Codit](http://codit.eu/) employee, we can also provide you with a ready-to-use `appsettings.local.json` that allows you to run the tests locally.
 
 1. Make sure you have an **active Azure subscription**.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@
 This guide helps with newcomers to contribute effectively to Arcus Testing.
 
 * **🐞 I found a bug!** </br>
-Great Scott! Please [report the problem](https://github.com/arcus-azure/arcus.testing/issues/new/choose) so we can have a look, or if you're up to it: you can always fix it yourself and [submit a PR]().
+Great Scott! Please [report the problem](https://github.com/arcus-azure/arcus.testing/issues/new/choose) so we can have a look, or if you're up to it: you can always fix it yourself and [submit a PR](#submitting-a-pr).
 
 * **❔ I have a question or an idea** </br>
 [GitHub discussions](https://github.com/arcus-azure/arcus.testing/discussions/new/choose) is the place to host discussions, questions or ideas related to anything available in the codebase. Ideas can always be transformed in workable [GitHub issues](https://github.com/arcus-azure/arcus.testing/issues) once the team decides to place this on the roadmap.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ When you submit a new pull request, please make sure that:
 ## FAQ
 <details>
 <summary>How to run the integration tests locally?</summary>
-The integration tests make use of real Azure resources, which means that the the test suite need to be aware of what resources you want to use locally.
+The integration tests make use of real Azure resources, which means that the test suite needs to be aware of which resources you want to use locally.
 
 > 👉 If you're a [Codit](http://codit.eu/) employee, we can also provide you with a ready-to-use `appsettings.local.json` that allows for you to run the tests locally.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@ The integration tests make use of real Azure resources, which means that the tes
     * ⚠️ Make sure that you have enough rights on your Azure resources to do CRUD operations (ex. the **Azure Blob Storage** tests require [`Storage Blob Data Contributor`](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles/storage#storage-blob-data-contributor)-rights.)
 
 4. Add an `appsettings.local.json` file to your integration test project - this file is ignored in Git by default: </br>
-   The local file needs to have the names of your **Azure resources**. If you deployed an **Azure Storage Account**, then you the file will look like this:
+   The local file needs to have the names of your **Azure resources**. If you deployed an **Azure Storage Account**, the file will look like this:
    ```json
    {
      "Arcus": {

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 > 🎉 First off, **thank you** for taking the time to contribute! </br>
 > We're really glad you're reading this.
 
-This guide helps with newcomers to contribute effectively to Arcus Testing.
+This guide helps newcomers to contribute effectively to Arcus Testing.
 
 * **🐞 I found a bug!** </br>
 Great Scott! Please [report the problem](https://github.com/arcus-azure/arcus.testing/issues/new/choose) so we can have a look, or if you're up to it: you can always fix it yourself and [submit a PR](#submitting-a-pr).

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ In short: Arcus Testing is a set of libraries that makes tests more fun to write
 Checkout our [documentation site](https://testing.arcus-azure.net/) to learn all about Arcus Testing.
 
 ## Contributing?
-Yes please! Please have a look at our [contribution guide](CONTRIBUTING.md) to get you started.
+Yes please! Have a look at our [contribution guide](CONTRIBUTING.md) to get you started.
 
 ## License Information
 This is licensed under The MIT License (MIT). Which means that you can use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the web application. But you always need to state that Codit is the original author of this web application.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Arcus - Testing
+# Arcus Testing
 [![Build Status](https://dev.azure.com/codit/Arcus/_apis/build/status/Commit%20builds/CI%20-%20Arcus.Testing?branchName=main)](https://dev.azure.com/codit/Arcus/_build/latest?definitionId=804&branchName=main)
 [![NuGet Version](https://img.shields.io/nuget/v/Arcus.Testing.Logging.Xunit)](https://www.nuget.org/packages/Arcus.Testing.Logging.Xunit/)
 ![Azure DevOps coverage (branch)](https://img.shields.io/azure-devops/coverage/codit/arcus/804/main)
@@ -12,10 +12,13 @@ In short: Arcus Testing is a set of libraries that makes tests more fun to write
 
 ![Arcus](https://raw.githubusercontent.com/arcus-azure/arcus/master/media/arcus.png)
 
-# Documentation
-All documentation can be found [here](https://testing.arcus-azure.net/).
+## Documentation
+Checkout our [documentation site](https://testing.arcus-azure.net/) to learn all about Arcus Testing.
 
-# License Information
+## Contributing?
+Yes please! Please have a look at our [contribution guide](CONTRIBUTING.md) to get you started.
+
+## License Information
 This is licensed under The MIT License (MIT). Which means that you can use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the web application. But you always need to state that Codit is the original author of this web application.
 
-Read the full license [here](https://github.com/arcus-azure/arcus.testing/blob/master/LICENSE).
+[Read the full license](https://github.com/arcus-azure/arcus.testing/blob/master/LICENSE)

--- a/src/Arcus.Testing.Tests.Integration/Arcus.Testing.Tests.Integration.csproj
+++ b/src/Arcus.Testing.Tests.Integration/Arcus.Testing.Tests.Integration.csproj
@@ -30,7 +30,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Update="appsettings.default.json">
+    <None Update="appsettings.default.json" Condition="'$(Configuration)' == 'Debug'">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Update="appsettings.local.json">

--- a/src/Arcus.Testing.Tests.Integration/Arcus.Testing.Tests.Integration.csproj
+++ b/src/Arcus.Testing.Tests.Integration/Arcus.Testing.Tests.Integration.csproj
@@ -30,6 +30,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Update="appsettings.default.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Update="appsettings.local.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/src/Arcus.Testing.Tests.Integration/Configuration/ServicePrincipal.cs
+++ b/src/Arcus.Testing.Tests.Integration/Configuration/ServicePrincipal.cs
@@ -17,6 +17,8 @@
         public string ClientId { get; }
 
         public string ClientSecret { get; }
+
+        public bool IsDefault => TenantId == "default" && ClientId == "default" && ClientSecret == "default";
     }
 
     public static partial class TestConfigExtensions

--- a/src/Arcus.Testing.Tests.Integration/Fixture/TemporaryManagedIdentityConnection.cs
+++ b/src/Arcus.Testing.Tests.Integration/Fixture/TemporaryManagedIdentityConnection.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Arcus.Testing.Tests.Integration.Configuration;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
@@ -8,42 +9,37 @@ namespace Arcus.Testing.Tests.Integration.Fixture
     /// <summary>
     /// Represents a temporary managed identity authentication that is set for the duration of the test.
     /// </summary>
-    internal class TemporaryManagedIdentityConnection : IDisposable
+    internal sealed class TemporaryManagedIdentityConnection : IDisposable
     {
         private readonly TemporaryEnvironmentVariable[] _environmentVariables;
 
-        private TemporaryManagedIdentityConnection(string clientId, TemporaryEnvironmentVariable[] environmentVariables)
+        private TemporaryManagedIdentityConnection(TemporaryEnvironmentVariable[] environmentVariables)
         {
             _environmentVariables = environmentVariables;
-            ClientId = clientId;
         }
 
         /// <summary>
-        /// Gets the client ID of the temporary managed identity authentication.
+        /// Creates a new <see cref="TemporaryManagedIdentityConnection"/> instance for a specific <paramref name="configuration"/>
+        /// using the current registration of the service principal.
         /// </summary>
-        public string ClientId { get; }
-
-        /// <summary>
-        /// Creates a new <see cref="TemporaryManagedIdentityConnection"/> instance for a specific <paramref name="servicePrincipal"/>.
-        /// </summary>
-        /// <param name="servicePrincipal">The service principal that should be authenticated with the test resources using managed identity.</param>
-        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="servicePrincipal"/> is <c>null</c>.</exception>
-        public static TemporaryManagedIdentityConnection Create(ServicePrincipal servicePrincipal)
+        public static TemporaryManagedIdentityConnection Create(TestConfig configuration, ILogger logger)
         {
-            if (servicePrincipal is null)
+            ArgumentNullException.ThrowIfNull(configuration);
+            logger ??= NullLogger.Instance;
+
+            ServicePrincipal servicePrincipal = configuration.GetServicePrincipal();
+            if (servicePrincipal.IsDefault)
             {
-                throw new ArgumentNullException(nameof(servicePrincipal));
+                logger.LogTrace("[Test:Setup] no local service principal was registered in the test configuration 'appsettings.*.json', which means managed identity relies on local authenticated sessions (ex. VisualStudio account, Azure CLI...)");
+                return new TemporaryManagedIdentityConnection([]);
             }
 
-            var logger = NullLogger.Instance;
-            var environmentVariables = new[]
-            {
+            return new TemporaryManagedIdentityConnection(
+            [
                 TemporaryEnvironmentVariable.SetSecretIfNotExists("AZURE_TENANT_ID", servicePrincipal.TenantId, logger),
                 TemporaryEnvironmentVariable.SetSecretIfNotExists("AZURE_CLIENT_ID", servicePrincipal.ClientId, logger),
                 TemporaryEnvironmentVariable.SetSecretIfNotExists("AZURE_CLIENT_SECRET", servicePrincipal.ClientSecret, logger)
-            };
-
-            return new TemporaryManagedIdentityConnection(servicePrincipal.ClientId, environmentVariables);
+            ]);
         }
 
         /// <summary>

--- a/src/Arcus.Testing.Tests.Integration/Integration/DataFactory/RunDataFlowTests.cs
+++ b/src/Arcus.Testing.Tests.Integration/Integration/DataFactory/RunDataFlowTests.cs
@@ -1,21 +1,20 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text.Json.Nodes;
 using System.Threading.Tasks;
 using Arcus.Testing.Tests.Core.Assert_.Fixture;
 using Arcus.Testing.Tests.Core.Integration.DataFactory;
-using Arcus.Testing.Tests.Integration.Configuration;
 using Arcus.Testing.Tests.Integration.Fixture;
 using Arcus.Testing.Tests.Integration.Integration.DataFactory.Fixture;
 using Azure.Identity;
-using Azure.ResourceManager.DataFactory.Models;
-using Azure.ResourceManager.DataFactory;
 using Azure.ResourceManager;
+using Azure.ResourceManager.DataFactory;
+using Azure.ResourceManager.DataFactory.Models;
 using Bogus;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 using Xunit.Abstractions;
-using System.Linq;
 
 namespace Arcus.Testing.Tests.Integration.Integration.DataFactory
 {
@@ -170,7 +169,7 @@ namespace Arcus.Testing.Tests.Integration.Integration.DataFactory
         /// </summary>
         public async Task InitializeAsync()
         {
-            _connection = TemporaryManagedIdentityConnection.Create(_config.GetServicePrincipal());
+            _connection = TemporaryManagedIdentityConnection.Create(_config, NullLogger.Instance);
 
             DataFactoryConfig dataFactory = _config.GetDataFactory();
             Guid unknownSessionId = Guid.NewGuid();

--- a/src/Arcus.Testing.Tests.Integration/IntegrationTest.cs
+++ b/src/Arcus.Testing.Tests.Integration/IntegrationTest.cs
@@ -1,5 +1,4 @@
-﻿using Arcus.Testing.Tests.Integration.Configuration;
-using Bogus;
+﻿using Bogus;
 using Microsoft.Extensions.Logging;
 using Xunit.Abstractions;
 
@@ -15,18 +14,16 @@ namespace Arcus.Testing.Tests.Integration
         protected IntegrationTest(ITestOutputHelper outputWriter)
         {
             Logger = new XunitTestLogger(outputWriter);
-            Configuration = TestConfig.Create();
+            Configuration = TestConfig.Create(options =>
+            {
+                options.AddOptionalJsonFile("appsettings.default.json");
+            });
         }
 
         /// <summary>
         /// Gets the current configuration loaded for this integration test suite.
         /// </summary>
         protected TestConfig Configuration { get; }
-
-        /// <summary>
-        /// Gets the service principal that has access to the interacted with test resources currently being tested.
-        /// </summary>
-        protected ServicePrincipal ServicePrincipal => Configuration.GetServicePrincipal();
 
         /// <summary>
         /// Gets the logger to write diagnostic messages during the integration test execution.

--- a/src/Arcus.Testing.Tests.Integration/Messaging/Fixture/ServiceBusTestContext.cs
+++ b/src/Arcus.Testing.Tests.Integration/Messaging/Fixture/ServiceBusTestContext.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Threading.Tasks;
-using Arcus.Testing.Tests.Integration.Configuration;
 using Arcus.Testing.Tests.Integration.Fixture;
 using Arcus.Testing.Tests.Integration.Messaging.Configuration;
 using Azure.Identity;
@@ -46,10 +45,9 @@ namespace Arcus.Testing.Tests.Integration.Messaging.Fixture
         /// </summary>
         public static ServiceBusTestContext Given(TestConfig config, ILogger logger)
         {
-            ServicePrincipal servicePrincipal = config.GetServicePrincipal();
             ServiceBusNamespace serviceBus = config.GetServiceBus();
 
-            var connection = TemporaryManagedIdentityConnection.Create(servicePrincipal);
+            var connection = TemporaryManagedIdentityConnection.Create(config, logger);
             var credential = new DefaultAzureCredential();
             var adminClient = new ServiceBusAdministrationClient(serviceBus.HostName, credential);
             var messagingClient = new ServiceBusClient(serviceBus.HostName, credential);
@@ -78,7 +76,7 @@ namespace Arcus.Testing.Tests.Integration.Messaging.Fixture
         {
             string queueName = $"queue-{Guid.NewGuid()}";
             _queueNames.Add(queueName);
-            
+
             return queueName;
         }
 
@@ -276,7 +274,7 @@ namespace Arcus.Testing.Tests.Integration.Messaging.Fixture
         {
             await ShouldCompletedMessageAsync(entityName, subscriptionName: null, message);
         }
-        
+
         /// <summary>
         /// Verifies that the message is completed on the Azure Service bus entity.
         /// </summary>

--- a/src/Arcus.Testing.Tests.Integration/Storage/Fixture/BlobStorageTestContext.cs
+++ b/src/Arcus.Testing.Tests.Integration/Storage/Fixture/BlobStorageTestContext.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.ObjectModel;
 using System.Threading.Tasks;
-using Arcus.Testing.Tests.Integration.Configuration;
 using Arcus.Testing.Tests.Integration.Fixture;
 using Arcus.Testing.Tests.Integration.Storage.Configuration;
 using Azure;
@@ -45,8 +44,8 @@ namespace Arcus.Testing.Tests.Integration.Storage.Fixture
         /// </summary>
         public static Task<BlobStorageTestContext> GivenAsync(TestConfig configuration, ILogger logger)
         {
-            var connection = TemporaryManagedIdentityConnection.Create(configuration.GetServicePrincipal());
-            
+            var connection = TemporaryManagedIdentityConnection.Create(configuration, logger);
+
             StorageAccount storageAccount = configuration.GetStorageAccount();
             var serviceClient = new BlobServiceClient(
                 new Uri($"https://{storageAccount.Name}.blob.core.windows.net"),

--- a/src/Arcus.Testing.Tests.Integration/Storage/Fixture/MongoDbTestContext.cs
+++ b/src/Arcus.Testing.Tests.Integration/Storage/Fixture/MongoDbTestContext.cs
@@ -49,7 +49,7 @@ namespace Arcus.Testing.Tests.Integration.Storage.Fixture
         /// </summary>
         public static async Task<MongoDbTestContext> GivenAsync(TestConfig config, ILogger logger)
         {
-            var connection = TemporaryManagedIdentityConnection.Create(config.GetServicePrincipal());
+            var connection = TemporaryManagedIdentityConnection.Create(config, logger);
             MongoClient mongoDbClient = await AuthenticateMongoDbClientAsync(config);
             IMongoDatabase database = mongoDbClient.GetDatabase(config["Arcus:Cosmos:MongoDb:DatabaseName"]);
 

--- a/src/Arcus.Testing.Tests.Integration/Storage/Fixture/NoSqlTestContext.cs
+++ b/src/Arcus.Testing.Tests.Integration/Storage/Fixture/NoSqlTestContext.cs
@@ -2,7 +2,6 @@
 using System.Collections.ObjectModel;
 using System.Net;
 using System.Threading.Tasks;
-using Arcus.Testing.Tests.Integration.Configuration;
 using Arcus.Testing.Tests.Integration.Fixture;
 using Azure;
 using Azure.Identity;
@@ -63,7 +62,7 @@ namespace Arcus.Testing.Tests.Integration.Storage.Fixture
         /// </summary>
         public static NoSqlTestContext Given(TestConfig config, ILogger logger)
         {
-            var connection = TemporaryManagedIdentityConnection.Create(config.GetServicePrincipal());
+            var connection = TemporaryManagedIdentityConnection.Create(config, logger);
             CosmosDbConfig noSql = config.GetNoSql();
 
             var client = new CosmosClient(noSql.AccountEndpoint.ToString(), new DefaultAzureCredential());

--- a/src/Arcus.Testing.Tests.Integration/Storage/Fixture/TableStorageTestContext.cs
+++ b/src/Arcus.Testing.Tests.Integration/Storage/Fixture/TableStorageTestContext.cs
@@ -2,7 +2,6 @@
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Threading.Tasks;
-using Arcus.Testing.Tests.Integration.Configuration;
 using Arcus.Testing.Tests.Integration.Fixture;
 using Arcus.Testing.Tests.Integration.Storage.Configuration;
 using Azure;
@@ -42,8 +41,8 @@ namespace Arcus.Testing.Tests.Integration.Storage.Fixture
         /// </summary>
         public static Task<TableStorageTestContext> GivenAsync(TestConfig configuration, ILogger logger)
         {
-            var connection = TemporaryManagedIdentityConnection.Create(configuration.GetServicePrincipal());
-            
+            var connection = TemporaryManagedIdentityConnection.Create(configuration, logger);
+
             StorageAccount storageAccount = configuration.GetStorageAccount();
             var serviceClient = new TableServiceClient(
                 new Uri($"https://{storageAccount.Name}.table.core.windows.net"),

--- a/src/Arcus.Testing.Tests.Integration/appsettings.default.json
+++ b/src/Arcus.Testing.Tests.Integration/appsettings.default.json
@@ -1,0 +1,9 @@
+﻿{
+  "Arcus": {
+    "TenantId": "default",
+    "ServicePrincipal": {
+      "ClientId": "default",
+      "ClientSecret": "default"
+    }
+  }
+}


### PR DESCRIPTION
To make sure that both internal (Codit)/external (non-Codit) contributions happen more easily, this PR:
* Adds GitHub's `CONTRIBUTING.md` file that gives an overview of what people can do in case of bug/feature/idea.
* Adds an `default` authentication to the test suite, so that one can run integration tests locally outside of Codit/Arcus-deployed Azure resources.