### PR TITLE
fix(release): use custom nuget release due to updated ubuntu img

### DIFF
--- a/build/nuget-release.yml
+++ b/build/nuget-release.yml
@@ -20,6 +20,7 @@ resources:
 
 variables:
   - group: 'GitHub Configuration'
+  - group: 'NuGet'
   - group: 'Build Configuration'
   - template: ./variables/build.yml
   - template: ./variables/test.yml
@@ -107,7 +108,12 @@ stages:
                 None.
                 ### Removal
                 None.
-          - template: nuget/publish-official-package.yml@templates
+          - task: DotNetCoreCLI@2
+            displayName: 'Push to NuGet.org'
+            inputs:
+              command: 'custom'
+              custom: 'nuget'
+              arguments: 'push src/**/*.nupkg --source $(NuGet.SourceUrl) --api-key $(NuGet.ApiKey)'
           - template: templates/trigger-bump-docs-version.yml
             parameters:
               gitHubToken: $(GITHUB_TOKEN)


### PR DESCRIPTION
Since the new Ubuntu build image on DevOps does not have `mono` installed, it means that some tools like **NuGet** are not built-in installed anymore. As a migration, they recommend doing it yourself.

This PR uses the `dotnet nuget push` instead (like we did with the MyGet release), which fixes this problem.