### PR TITLE
357 enhance add guidance on string data flow parameters in documentation and add tests with different data flow parameter types

### DIFF
--- a/docs/preview/03-Features/04-Azure/06-Integration/01-data-factory.mdx
+++ b/docs/preview/03-Features/04-Azure/06-Integration/01-data-factory.mdx
@@ -209,6 +209,8 @@ using Arcus.Testing;
 await session.RunDataFlowAsync(..., options =>
 {
     // Adds a parameter to the data flow upon starting.
+    // Note: For string parameters, enclose your value with single quotes (example: "'myValue'").
+    //       For boolean parameters, values must be "true()" or "false()".
     options.AddDataFlowParameter("<name>", "<value>");
 
     // Adds a dataset parameter to the data flow upon starting.

--- a/src/Arcus.Testing.Integration.DataFactory/TemporaryDataFlowDebugSession.cs
+++ b/src/Arcus.Testing.Integration.DataFactory/TemporaryDataFlowDebugSession.cs
@@ -443,6 +443,10 @@ namespace Arcus.Testing
         /// <summary>
         /// Adds a parameter to the DataFlow to run.
         /// </summary>
+        /// <remarks>
+        /// For string parameters, the value must be enclosed in single quotes (example: "'myValue'").
+        /// For boolean parameters, the value must be either "true()" or "false()".
+        /// </remarks>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="name"/> is blank.</exception>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="value"/> is null.</exception>
         public RunDataFlowOptions AddDataFlowParameter(string name, object value)

--- a/src/Arcus.Testing.Tests.Integration/Integration/DataFactory/RunDataFlowTests.cs
+++ b/src/Arcus.Testing.Tests.Integration/Integration/DataFactory/RunDataFlowTests.cs
@@ -13,6 +13,7 @@ using Azure.ResourceManager.DataFactory;
 using Azure.ResourceManager.DataFactory.Models;
 using Bogus;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -173,7 +174,7 @@ namespace Arcus.Testing.Tests.Integration.Integration.DataFactory
 
             // Create new CSV with just expected columns and values from dataflow params
             var lineKeys = string.Join(';', dataFlowParametersWithTypes.Keys);
-            var lineValues = string.Join(';', dataFlowParametersWithValues.Values);
+            var lineValues = string.Join(';', dataFlowParametersWithValues.Values).Replace("\'", string.Empty).Replace("(", string.Empty).Replace(")", string.Empty);
             var expectedString = $"{lineKeys}{Environment.NewLine}";
             // Generate as many lines as we have in actualData
             for (var i = 0; i < actualData.RowCount; i++)
@@ -254,7 +255,7 @@ namespace Arcus.Testing.Tests.Integration.Integration.DataFactory
 
             DataFactoryConfig dataFactory = _config.GetDataFactory();
             Guid unknownSessionId = Guid.NewGuid();
-            /*
+
             Value = Bogus.Random.Bool()
                 ? await TemporaryDataFlowDebugSession.StartDebugSessionAsync(dataFactory.ResourceId, NullLogger.Instance)
                 : await TemporaryDataFlowDebugSession.StartDebugSessionAsync(dataFactory.ResourceId, NullLogger.Instance, opt =>
@@ -262,12 +263,6 @@ namespace Arcus.Testing.Tests.Integration.Integration.DataFactory
                     opt.TimeToLiveInMinutes = Bogus.Random.Int(10, 15);
                     opt.ActiveSessionId = unknownSessionId;
                 });
-            */
-            Value = await TemporaryDataFlowDebugSession.StartDebugSessionAsync(dataFactory.ResourceId, NullLogger.Instance, opt =>
-            {
-                opt.TimeToLiveInMinutes = 60;
-                opt.ActiveSessionId = Guid.Parse("2709a7f4-661f-49a3-93f4-b7caa2db00ff");
-            });
 
             Assert.NotEqual(unknownSessionId, Value.SessionId);
             SessionId = Value.SessionId;


### PR DESCRIPTION
- Added documentation for string and boolean data flow parameters format
- Added a test case and support to add data flow parameters. When adding data flow parameters, an additional step in the data flow is created to add columns to the output with the content of the data flow parameters.