### PR TITLE
fix(assert.csv): show correct failed headers w/ ignored coll

### DIFF
--- a/src/Arcus.Testing.Assert/AssertCsv.cs
+++ b/src/Arcus.Testing.Assert/AssertCsv.cs
@@ -870,8 +870,8 @@ namespace Arcus.Testing
                 return _originalCsv;
             }
 
-            string headerLine = _options.Header is AssertCsvHeader.Present ? rows.ElementAtOrDefault(0) + _options.NewLine : "";
-            return headerLine + row;
+            string headerLine = _options.Header is AssertCsvHeader.Present ? rows.ElementAtOrDefault(0) : "";
+            return headerLine + _options.NewLine + row;
         }
 
         /// <summary>

--- a/src/Arcus.Testing.Assert/AssertCsv.cs
+++ b/src/Arcus.Testing.Assert/AssertCsv.cs
@@ -853,25 +853,25 @@ namespace Arcus.Testing
         }
 
         /// <summary>
-        /// Gets the original CSV row at a given <paramref name="index"/>,
+        /// Gets the original CSV row at a given <paramref name="rowNumber"/>,
         /// or the entire table when no such row could be found.
         /// </summary>
         /// <remarks>
         ///     Safely implemented to fallback on the original CSV when the row cannot be found.
         /// </remarks>
-        internal string GetOriginalRowAtOrAll(int index)
+        internal string GetOriginalRowAtOrAll(int rowNumber)
         {
             string[] rows = _originalCsv.Split(_options.NewLine, StringSplitOptions.RemoveEmptyEntries);
-            int i = _options.Header is AssertCsvHeader.Present ? index + 1 : index;
+            int diffIndex = _options.Header is AssertCsvHeader.Present ? rowNumber + 1 : rowNumber;
 
-            string row = rows.ElementAtOrDefault(i);
+            string row = rows.ElementAtOrDefault(diffIndex);
             if (row is null)
             {
                 return _originalCsv;
             }
 
-            string headerLine = string.Join(_options.Separator, HeaderNames);
-            return headerLine + _options.NewLine + row;
+            string headerLine = _options.Header is AssertCsvHeader.Present ? rows.ElementAtOrDefault(0) + _options.NewLine : "";
+            return headerLine + row;
         }
 
         /// <summary>

--- a/src/Arcus.Testing.Tests.Unit/Assert_/AssertCsvTests.cs
+++ b/src/Arcus.Testing.Tests.Unit/Assert_/AssertCsvTests.cs
@@ -698,7 +698,7 @@ namespace Arcus.Testing.Tests.Unit.Assert_
 
                 yield return TestCase(
                     expectedCsv: $"#;movie;genre;year;accepted{NewLine}1;blade runner;sf;1982;yes",
-                    actualCsv: $"#;movie;genre;year{NewLine}1;the thing;sf;1982",
+                    actualCsv: $"##;movie;genre;year{NewLine}1;the thing;sf;1982",
                     configureLoadExpectedOptions: null,
                     configureLoadActualOptions: null,
                     configureEqualOptions: options =>
@@ -706,7 +706,7 @@ namespace Arcus.Testing.Tests.Unit.Assert_
                         options.IgnoreColumn("accepted");
                         options.IgnoreColumn(0);
                     },
-                    "different", "value", "\"blade runner\" while actual \"the thing\"");
+                    "different", "value", "\"blade runner\" while actual \"the thing\"", "#;movie;genre;year;accepted", "##;movie;genre;year");
             }
         }
 


### PR DESCRIPTION
Stricten the `AssertCsvTest` so that we know that both specific headers (without ignoring) are shown in the test output upon a row failure (meaning: a failing within the values of the row).

The problem was that the previous PR #382 altered the final `HeaderNames` when loading the CSV, but this same one was used when constructing the final 'row difference'. This PR removes all references to the 'assertion result' and solely uses the `_originalCsv` to construct differences at row level.

Follow-up of #382 