### PR TITLE
docs(code.highlights): add code highlights for samples in feature docs

### DIFF
--- a/docs/preview/03-Features/03-logging.mdx
+++ b/docs/preview/03-Features/03-logging.mdx
@@ -26,6 +26,7 @@ This page describes functionality related to logging in tests.
     Log messages written to the `ILogger` instance will be written to the xUnit test output.
     
     ```csharp
+    // highlight-next-line
     using Arcus.Testing;
     using Microsoft.Extensions.Logging;
     using Xunit.Abstractions;
@@ -36,13 +37,29 @@ This page describes functionality related to logging in tests.
     
         public TestClass(ITestOutputHelper outputWriter)
         {
+            // highlight-next-line
             _testLogger = new XunitTestLogger(outputWriter);
         }
     }
     ```
 
-    In the same fashion there is a:
-    * [`AddXunitTestLogging`] extension to add a `ILoggerProvider` to a [Microsoft Logging](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/logging/?view=aspnetcore-3.1) setup.
+    In the same fashion there is an extension to add a `ILoggerProvider` to a [Microsoft Logging](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/logging/) setup:
+
+    ``csharp
+    // highlight-next-line
+    using Arcus.Testing;
+    using Microsoft.Extensions.Logging;
+
+    ILoggerFactory factory = LoggerFactory.Create(logging =>
+    {
+        logging.SetMinimumLevel(LogLevel.Warning)
+               .AddFilter("Example.DefaultService", LogLevel.Trace)
+               .AddFile("logs/test-{0:yyyy}-{0:MM}-{0:dd}.log")
+               // highlight-next-line
+               .AddXunitTestLogging(outputWriter);
+    });
+    ILogger logger = factory.CreateLogger<TestClass>();
+    ```
   </TabItem>
   <TabItem value="nunit" label="NUnit">
     The `Arcus.Testing.Logging.NUnit` library provides a `NUnitTestLogger` type that's an implementation of the abstracted Microsoft [`Ilogger`](https://docs.microsoft.com/en-us/dotnet/api/microsoft.extensions.logging)
@@ -61,6 +78,7 @@ This page describes functionality related to logging in tests.
     Log messages written to the `ILogger` instance will be written to the `TestContext.Out/Error` in the NUnit test output.
     
     ```csharp
+    // highlight-next-line
     using Arcus.Testing;
     using Microsoft.Extensions.Logging;
     using NUnit.Framework;
@@ -71,13 +89,29 @@ This page describes functionality related to logging in tests.
     
         public TestClass()
         {
+            // highlight-next-line
             _testLogger = new NUnitTestLogger(TestContext.Out, TestContext.Error);
         }
     }
     ```
 
-    In the same fashion there is a:
-    * [`AddNUnitTestLogging`] extension to add a `ILoggerProvider` to a [Microsoft Logging](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/logging/?view=aspnetcore-3.1) setup.
+    In the same fashion there is an extension to add a `ILoggerProvider` to a [Microsoft Logging](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/logging/) setup:
+
+    ``csharp
+    // highlight-next-line
+    using Arcus.Testing;
+    using Microsoft.Extensions.Logging;
+
+    ILoggerFactory factory = LoggerFactory.Create(logging =>
+    {
+        logging.SetMinimumLevel(LogLevel.Warning)
+               .AddFilter("Example.DefaultService", LogLevel.Trace)
+               .AddFile("logs/test-{0:yyyy}-{0:MM}-{0:dd}.log")
+               // highlight-next-line
+               .AddNUnitTestLogging(TestContext.Out, TestContext.Error);
+    });
+    ILogger logger = factory.CreateLogger<TestClass>();
+    ```
   </TabItem>
   <TabItem value="mstest" label="MSTest">
     The `Arcus.Testing.Logging.MSTest` library provides a `MSTestLogger` type that's an implementation of the abstracted Microsoft [`Ilogger`](https://docs.microsoft.com/en-us/dotnet/api/microsoft.extensions.logging)
@@ -96,18 +130,35 @@ This page describes functionality related to logging in tests.
     Log messages written to the `ILogger` instance will be written to the `TestContext` in the MSTest test output.
     
     ```csharp
+    // highlight-next-line
     using Arcus.Testing;
     using Microsoft.Extensions.Logging;
     using NUnit.Framework;
     
     public class TestClass
     {
+        // highlight-next-line
         private ILogger TestLogger => new MSTestLogger(TestContext);
         public TestContext TestContext { get; set; }
     }
     ```
     
-    In the same fashion there is a:
-    * [`AddMSTestLogging`] extension to add a `ILoggerProvider` to a [Microsoft Logging](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/logging/?view=aspnetcore-3.1) setup.
+    In the same fashion there is an extension to add a `ILoggerProvider` to a [Microsoft Logging](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/logging/) setup:
+
+    ``csharp
+    // highlight-next-line
+    using Arcus.Testing;
+    using Microsoft.Extensions.Logging;
+
+    ILoggerFactory factory = LoggerFactory.Create(logging =>
+    {
+        logging.SetMinimumLevel(LogLevel.Warning)
+               .AddFilter("Example.DefaultService", LogLevel.Trace)
+               .AddFile("logs/test-{0:yyyy}-{0:MM}-{0:dd}.log")
+               // highlight-next-line
+               .AddMSTestLogging(TestContext);
+    });
+    ILogger logger = factory.CreateLogger<TestClass>();
+    ```
   </TabItem>
 </Tabs>

--- a/docs/preview/03-Features/04-Azure/06-Integration/01-data-factory.mdx
+++ b/docs/preview/03-Features/04-Azure/06-Integration/01-data-factory.mdx
@@ -71,20 +71,24 @@ The following snippet provides a full examples of how the `TemporaryDataFlowDebu
 <Tabs>
   <TabItem value="xunit" label="xUnit" default>
     ```csharp
+    // highlight-next-line
     using Arcus.Testing;
     using Xunit;
     
      public class DataFactoryFixture : IAsyncLifetime
      {
+        // highlight-next-line
          public TemporaryDataFlowDebugSession Session { get; private set; }
     
          public async Task InitializeAsync()
          {
+            // highlight-next-line
              Session = await TemporaryDataFlowDebugSession.StartDebugSessionAsync(...);
          }
     
          public async Task DisposeAsync()
          {
+             // highlight-next-line
              await Session.DisposeAsync();
          }
      }
@@ -105,23 +109,27 @@ The following snippet provides a full examples of how the `TemporaryDataFlowDebu
   </TabItem>
   <TabItem value="nunit" label="NUnit">
     ```csharp
+    // highlight-next-line
     using Arcus.Testing;
     using NUnit.Framework;
   
     [TestFixture]
     public class MyDataFactoryTests
     {
+        // highlight-next-line
         private TemporaryDataFlowDebugSession _session;
   
         [OneTimeSetUp]
         public async Task InitAsync()
         {
+            // highlight-next-line
             _session = await TemporaryDataFlowDebugSession.StartDebugSessionAsync(...);
         }
   
         [OneTimeTearDown]
         public async Task CleanupAsync()
         {
+            // highlight-next-line
             await _session.DisposeAsync();
         }
     }
@@ -129,23 +137,27 @@ The following snippet provides a full examples of how the `TemporaryDataFlowDebu
   </TabItem>
   <TabItem value="mstest" label="MSTest">
     ```csharp
+    // highlight-next-line
     using Arcus.Testing;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
 
     [TestClass]
     public class MyDataFactoryTests
     {
+        // highlight-next-line
         private static TemporaryDataFlowDebugSession _session;
 
         [ClassInitialize]
         public static async Task InitializeAsync(TestContext context)
         {
+            // highlight-next-line
             _session = await TemporaryDataFlowDebugSession.StartDebugSessionAsync(...);
         }
 
         [ClassCleanup]
         public static async Task CleanupAsync()
         {
+            // highlight-next-line
             await _session.DisposeAsync();
         }
     } 
@@ -160,6 +172,7 @@ The following snippet provides a full examples of how the `TemporaryDataFlowDebu
 
     [<EntryPoint>]
     let main args = task {
+        // highlight-next-line
         use! session = TemporaryDataFlowDebugSession.StartDebugSessionAsync(...)
 
         let tests = TestList ([ myDataFactoryTests session ], Normal)


### PR DESCRIPTION
Certain code samples spans 'full' examples where the Arcus Testing-specific code could get obscured. This PR makes use of Docusaurus 'highlight code' functionality to highlight the specific code related to Arcus Testing.