### PR TITLE
fix(poll): use new `PollOptions` instance on each call

### DIFF
--- a/src/Arcus.Testing.Core/Poll.cs
+++ b/src/Arcus.Testing.Core/Poll.cs
@@ -179,7 +179,7 @@ namespace Arcus.Testing
         /// <summary>
         /// Gets the default set of polling options.
         /// </summary>
-        internal static PollOptions Default { get; } = new();
+        internal static PollOptions Default => new();
 
         /// <summary>
         /// Gets or sets the interval between each poll operation.

--- a/src/Arcus.Testing.Tests.Unit/Core/PollTests.cs
+++ b/src/Arcus.Testing.Tests.Unit/Core/PollTests.cs
@@ -267,8 +267,8 @@ namespace Arcus.Testing.Tests.Unit.Core
 
         private async Task<object> SometimesSucceedsResultAsync(Queue<bool> failures)
         {
-            SometimesSucceeds(failures);
             await Task.Delay(TimeSpan.FromMilliseconds(100));
+            SometimesSucceeds(failures);
 
             return _expectedResult;
         }

--- a/src/Arcus.Testing.Tests.Unit/Core/PollTests.cs
+++ b/src/Arcus.Testing.Tests.Unit/Core/PollTests.cs
@@ -16,23 +16,35 @@ namespace Arcus.Testing.Tests.Unit.Core
         private static readonly Faker Bogus = new();
 
         [Fact]
-        public async Task PollAsync_WithTargetAvailableWithinTimeFrame_SucceedsByContinuing()
+        public async Task PollDirectAsync_WithTargetAvailableWithinTimeFrame_SucceedsByContinuing()
         {
             await Poll.UntilAvailableAsync(AlwaysSucceedsAsync);
             await Poll.UntilAvailableAsync(SometimesSucceedsAsync, ReasonableTimeFrame);
             await Poll.UntilAvailableAsync<InvalidOperationException>(AlwaysSucceedsAsync);
             await Poll.UntilAvailableAsync<TestPollException>(SometimesSucceedsAsync, ReasonableTimeFrame);
+        }
 
+        [Fact]
+        public async Task PollFluentAsync_WithTargetAvailableWithinTimeFrame_SucceedsByContinuing()
+        {
             await Poll.Target(AlwaysSucceedsAsync);
             await Poll.Target(SometimesSucceedsAsync).ReasonableTimeFrame();
             await Poll.Target<ArrayTypeMismatchException>(AlwaysSucceedsAsync);
             await Poll.Target<TestPollException>(SometimesSucceedsAsync).ReasonableTimeFrame();
+        }
 
+        [Fact]
+        public async Task PollDirectResultAsync_WithTargetAvailableWithinTimeFrame_SucceedsByContinuing()
+        {
             await GetsResultAsync(() => Poll.UntilAvailableAsync(AlwaysSucceedsResultAsync));
             await GetsResultAsync(() => Poll.UntilAvailableAsync(SometimesSucceedsResultAsync, ReasonableTimeFrame));
             await GetsResultAsync(() => Poll.UntilAvailableAsync<object, AggregateException>(AlwaysSucceedsResultAsync));
             await GetsResultAsync(() => Poll.UntilAvailableAsync<object, TestPollException>(SometimesSucceedsResultAsync, ReasonableTimeFrame));
+        }
 
+        [Fact]
+        public async Task PollFluentResultAsync_WithTargetAvailableWithinTimeFrame_SucceedsByContinuing()
+        {
             await GetsResultAsync(async () => await Poll.Target(AlwaysSucceedsResultAsync));
             await GetsResultAsync(async () => await Poll.Target(SometimesSucceedsResultAsync).ReasonableTimeFrame());
             await GetsResultAsync(async () => await Poll.Target<object, DllNotFoundException>(AlwaysSucceedsResultAsync));
@@ -40,13 +52,17 @@ namespace Arcus.Testing.Tests.Unit.Core
         }
 
         [Fact]
-        public async Task PollSync_WithTargetAvailableWithinTimeFrame_SucceedsByContinuing()
+        public async Task PollFluentSync_WithTargetAvailableWithinTimeFrame_SucceedsByContinuing()
         {
             await Poll.Target(AlwaysSucceeds);
             await Poll.Target(SometimesSucceeds).ReasonableTimeFrame();
             await Poll.Target<ArrayTypeMismatchException>(AlwaysSucceeds);
             await Poll.Target<TestPollException>(SometimesSucceeds).ReasonableTimeFrame();
+        }
 
+        [Fact]
+        public async Task PollDirectSync_WithTargetAvailableWithinTimeFrame_SucceedsByContinuing()
+        {
             await GetsResultAsync(async () => await Poll.Target(AlwaysSucceedsResult));
             await GetsResultAsync(async () => await Poll.Target(SometimesSucceedsResult).ReasonableTimeFrame());
             await GetsResultAsync(async () => await Poll.Target<object, DllNotFoundException>(AlwaysSucceedsResult));
@@ -54,13 +70,17 @@ namespace Arcus.Testing.Tests.Unit.Core
         }
 
         [Fact]
-        public async Task Poll_WithTargetRemainsUnavailableWithinTimeFrame_FailsWithDescription()
+        public async Task PollDirectly_WithTargetRemainsUnavailableWithinTimeFrame_FailsWithDescription()
         {
             await FailsByExceptionAsync(() => Poll.UntilAvailableAsync(AlwaysFailsAsync, LowestTimeFrame));
             await FailsByExceptionAsync(() => Poll.UntilAvailableAsync(AlwaysFailsResultAsync, LowestTimeFrame));
             await FailsByExceptionAsync(() => Poll.UntilAvailableAsync<TestPollException>(AlwaysFailsAsync, LowestTimeFrame));
             await FailsByExceptionAsync(() => Poll.UntilAvailableAsync<object, TestPollException>(AlwaysFailsResultAsync, LowestTimeFrame));
+        }
 
+        [Fact]
+        public async Task PollFluent_WithTargetRemainsUnavailableWithinTimeFrame_FailsWithDescription()
+        {
             await FailsByExceptionAsync(async () => await Poll.Target(AlwaysFailsAsync).LowestTimeFrame());
             await FailsByExceptionAsync(async () => await Poll.Target(AlwaysFailsResultAsync).Until(AlwaysTrue).LowestTimeFrame());
             await FailsByExceptionAsync(async () => await Poll.Target<TestPollException>(AlwaysFailsAsync).LowestTimeFrame());
@@ -218,7 +238,7 @@ namespace Arcus.Testing.Tests.Unit.Core
 
         private static void SometimesSucceeds()
         {
-            if (Bogus.PickRandom(false, false, false, true))
+            if (Bogus.PickRandom(false, false, false, false, true))
             {
                 throw new TestPollException("Sabotage polling!");
             }

--- a/src/Arcus.Testing.Tests.Unit/Core/PollTests.cs
+++ b/src/Arcus.Testing.Tests.Unit/Core/PollTests.cs
@@ -73,35 +73,35 @@ namespace Arcus.Testing.Tests.Unit.Core
         [Fact]
         public async Task PollDirectly_WithTargetRemainsUnavailableWithinTimeFrame_FailsWithDescription()
         {
-            await FailsByExceptionAsync(() => Poll.UntilAvailableAsync(AlwaysFailsAsync, LowestTimeFrame));
-            await FailsByExceptionAsync(() => Poll.UntilAvailableAsync(AlwaysFailsResultAsync, LowestTimeFrame));
-            await FailsByExceptionAsync(() => Poll.UntilAvailableAsync<TestPollException>(AlwaysFailsAsync, LowestTimeFrame));
-            await FailsByExceptionAsync(() => Poll.UntilAvailableAsync<object, TestPollException>(AlwaysFailsResultAsync, LowestTimeFrame));
+            await FailsByExceptionAsync(() => Poll.UntilAvailableAsync(AlwaysFailsAsync, ReasonableTimeFrame));
+            await FailsByExceptionAsync(() => Poll.UntilAvailableAsync(AlwaysFailsResultAsync, ReasonableTimeFrame));
+            await FailsByExceptionAsync(() => Poll.UntilAvailableAsync<TestPollException>(AlwaysFailsAsync, ReasonableTimeFrame));
+            await FailsByExceptionAsync(() => Poll.UntilAvailableAsync<object, TestPollException>(AlwaysFailsResultAsync, ReasonableTimeFrame));
         }
 
         [Fact]
         public async Task PollFluent_WithTargetRemainsUnavailableWithinTimeFrame_FailsWithDescription()
         {
-            await FailsByExceptionAsync(async () => await Poll.Target(AlwaysFailsAsync).LowestTimeFrame());
-            await FailsByExceptionAsync(async () => await Poll.Target(AlwaysFailsResultAsync).Until(AlwaysTrue).LowestTimeFrame());
-            await FailsByExceptionAsync(async () => await Poll.Target<TestPollException>(AlwaysFailsAsync).LowestTimeFrame());
-            await FailsByExceptionAsync(async () => await Poll.Target<object, TestPollException>(AlwaysFailsResultAsync).Until(AlwaysTrue).LowestTimeFrame());
+            await FailsByExceptionAsync(async () => await Poll.Target(AlwaysFailsAsync).ReasonableTimeFrame());
+            await FailsByExceptionAsync(async () => await Poll.Target(AlwaysFailsResultAsync).Until(AlwaysTrue).ReasonableTimeFrame());
+            await FailsByExceptionAsync(async () => await Poll.Target<TestPollException>(AlwaysFailsAsync).ReasonableTimeFrame());
+            await FailsByExceptionAsync(async () => await Poll.Target<object, TestPollException>(AlwaysFailsResultAsync).Until(AlwaysTrue).ReasonableTimeFrame());
         }
 
         [Fact]
         public async Task Poll_WithDiffExceptionThanUnavailableTarget_FailsDirectlyWithDescription()
         {
-            await FailsByExceptionAsync(() => Poll.UntilAvailableAsync<InvalidOperationException>(AlwaysFailsAsync, LowestTimeFrame));
-            await FailsByExceptionAsync(() => Poll.UntilAvailableAsync<object, FileNotFoundException>(AlwaysFailsResultAsync, LowestTimeFrame));
+            await FailsByExceptionAsync(() => Poll.UntilAvailableAsync<InvalidOperationException>(AlwaysFailsAsync, ReasonableTimeFrame));
+            await FailsByExceptionAsync(() => Poll.UntilAvailableAsync<object, FileNotFoundException>(AlwaysFailsResultAsync, ReasonableTimeFrame));
 
-            await FailsByExceptionAsync(async () => await Poll.Target<AggregateException>(AlwaysFailsAsync).LowestTimeFrame());
-            await FailsByExceptionAsync(async () => await Poll.Target<object, ApplicationException>(AlwaysFailsResultAsync).LowestTimeFrame());
+            await FailsByExceptionAsync(async () => await Poll.Target<AggregateException>(AlwaysFailsAsync).ReasonableTimeFrame());
+            await FailsByExceptionAsync(async () => await Poll.Target<object, ApplicationException>(AlwaysFailsResultAsync).ReasonableTimeFrame());
         }
 
         [Fact]
         public async Task PollFailure_WithoutResult_ShouldFail()
         {
-            await Assert.ThrowsAsync<TimeoutException>(() => Poll.UntilAvailableAsync(async () => await AlwaysFailsAsync(), LowestTimeFrame));
+            await Assert.ThrowsAsync<TimeoutException>(() => Poll.UntilAvailableAsync(async () => await AlwaysFailsAsync(), ReasonableTimeFrame));
         }
 
         [Fact]
@@ -133,7 +133,7 @@ namespace Arcus.Testing.Tests.Unit.Core
             // Act / Assert
             await FailsByResultAsync(async () =>
                 await Poll.Target(AlwaysSucceedsResultAsync)
-                          .LowestTimeFrame()
+                          .ReasonableTimeFrame()
                           .Until(AlwaysTrue)
                           .Until(AlwaysFalse)
                           .Until(AlwaysTrue)
@@ -141,7 +141,7 @@ namespace Arcus.Testing.Tests.Unit.Core
 
             await FailsByResultAsync(async () =>
                 await Poll.Target<object, TestPollException>(AlwaysSucceedsResultAsync)
-                          .LowestTimeFrame()
+                          .ReasonableTimeFrame()
                           .Until(AlwaysTrue)
                           .Until(AlwaysFalse)
                           .Until(AlwaysTrue)
@@ -212,7 +212,7 @@ namespace Arcus.Testing.Tests.Unit.Core
             return options =>
             {
                 options.FailureMessage = message;
-                LowestTimeFrame(options);
+                ReasonableTimeFrame(options);
             };
         }
 
@@ -220,12 +220,6 @@ namespace Arcus.Testing.Tests.Unit.Core
         {
             options.Timeout = _5s;
             options.Interval = _100ms;
-        }
-
-        private void LowestTimeFrame(PollOptions options)
-        {
-            options.Timeout = _100ms;
-            options.Interval = TimeSpan.FromMilliseconds(10);
         }
 
         private static bool AlwaysTrue(object result) => true;
@@ -362,13 +356,6 @@ namespace Arcus.Testing.Tests.Unit.Core
             where TException : Exception
         {
             return poll.Every(TimeSpan.FromMilliseconds(100)).Timeout(TimeSpan.FromSeconds(5));
-        }
-
-        public static Poll<TResult, TException> LowestTimeFrame<TResult, TException>(
-            this Poll<TResult, TException> poll)
-            where TException : Exception
-        {
-            return poll.Every(TimeSpan.FromMilliseconds(10)).Timeout(TimeSpan.FromSeconds(1));
         }
     }
 

--- a/src/Arcus.Testing.Tests.Unit/Core/PollTests.cs
+++ b/src/Arcus.Testing.Tests.Unit/Core/PollTests.cs
@@ -349,7 +349,7 @@ namespace Arcus.Testing.Tests.Unit.Core
             this Poll<TResult, TException> poll)
             where TException : Exception
         {
-            return poll.Every(TimeSpan.FromMilliseconds(10)).Timeout(TimeSpan.FromMilliseconds(100));
+            return poll.Every(TimeSpan.FromMilliseconds(10)).Timeout(TimeSpan.FromSeconds(1));
         }
     }
 

--- a/src/Arcus.Testing.Tests.Unit/Core/PollTests.cs
+++ b/src/Arcus.Testing.Tests.Unit/Core/PollTests.cs
@@ -80,19 +80,19 @@ namespace Arcus.Testing.Tests.Unit.Core
         [Fact]
         public async Task PollDirectly_WithTargetRemainsUnavailableWithinTimeFrame_FailsWithDescription()
         {
-            await FailsByExceptionAsync(() => Poll.UntilAvailableAsync(AlwaysFailsAsync, ReasonableTimeFrame));
-            await FailsByExceptionAsync(() => Poll.UntilAvailableAsync(AlwaysFailsResultAsync, ReasonableTimeFrame));
-            await FailsByExceptionAsync(() => Poll.UntilAvailableAsync<TestPollException>(AlwaysFailsAsync, ReasonableTimeFrame));
-            await FailsByExceptionAsync(() => Poll.UntilAvailableAsync<object, TestPollException>(AlwaysFailsResultAsync, ReasonableTimeFrame));
+            await FailsByExceptionAsync(() => Poll.UntilAvailableAsync(AlwaysFailsAsync, LowestTimeFrame));
+            await FailsByExceptionAsync(() => Poll.UntilAvailableAsync(AlwaysFailsResultAsync, LowestTimeFrame));
+            await FailsByExceptionAsync(() => Poll.UntilAvailableAsync<TestPollException>(AlwaysFailsAsync, LowestTimeFrame));
+            await FailsByExceptionAsync(() => Poll.UntilAvailableAsync<object, TestPollException>(AlwaysFailsResultAsync, LowestTimeFrame));
         }
 
         [Fact]
         public async Task PollFluent_WithTargetRemainsUnavailableWithinTimeFrame_FailsWithDescription()
         {
-            await FailsByExceptionAsync(async () => await Poll.Target(AlwaysFailsAsync).ReasonableTimeFrame());
-            await FailsByExceptionAsync(async () => await Poll.Target(AlwaysFailsResultAsync).Until(AlwaysTrue).ReasonableTimeFrame());
-            await FailsByExceptionAsync(async () => await Poll.Target<TestPollException>(AlwaysFailsAsync).ReasonableTimeFrame());
-            await FailsByExceptionAsync(async () => await Poll.Target<object, TestPollException>(AlwaysFailsResultAsync).Until(AlwaysTrue).ReasonableTimeFrame());
+            await FailsByExceptionAsync(async () => await Poll.Target(AlwaysFailsAsync).LowestTimeFrame());
+            await FailsByExceptionAsync(async () => await Poll.Target(AlwaysFailsResultAsync).Until(AlwaysTrue).LowestTimeFrame());
+            await FailsByExceptionAsync(async () => await Poll.Target<TestPollException>(AlwaysFailsAsync).LowestTimeFrame());
+            await FailsByExceptionAsync(async () => await Poll.Target<object, TestPollException>(AlwaysFailsResultAsync).Until(AlwaysTrue).LowestTimeFrame());
         }
 
         [Fact]
@@ -108,7 +108,7 @@ namespace Arcus.Testing.Tests.Unit.Core
         [Fact]
         public async Task PollFailure_WithoutResult_ShouldFail()
         {
-            await Assert.ThrowsAsync<TimeoutException>(() => Poll.UntilAvailableAsync(async () => await AlwaysFailsAsync(), ReasonableTimeFrame));
+            await Assert.ThrowsAsync<TimeoutException>(() => Poll.UntilAvailableAsync(async () => await AlwaysFailsAsync(), LowestTimeFrame));
         }
 
         [Fact]
@@ -200,7 +200,7 @@ namespace Arcus.Testing.Tests.Unit.Core
             // Arrange
             var watch = Stopwatch.StartNew();
             var message = Bogus.Lorem.Sentence();
-            var timeout = TimeSpan.FromSeconds(3);
+            var timeout = TimeSpan.FromSeconds(1);
 
             // Act
             await Assert.ThrowsAsync<TimeoutException>(async () =>
@@ -219,7 +219,7 @@ namespace Arcus.Testing.Tests.Unit.Core
             return options =>
             {
                 options.FailureMessage = message;
-                ReasonableTimeFrame(options);
+                LowestTimeFrame(options);
             };
         }
 
@@ -375,7 +375,7 @@ namespace Arcus.Testing.Tests.Unit.Core
             this Poll<TResult, TException> poll)
             where TException : Exception
         {
-            return poll.Every(TimeSpan.FromMilliseconds(10)).Timeout(TimeSpan.FromSeconds(100));
+            return poll.Every(TimeSpan.FromMilliseconds(10)).Timeout(TimeSpan.FromMilliseconds(100));
         }
     }
 

--- a/src/Arcus.Testing.Tests.Unit/Core/PollTests.cs
+++ b/src/Arcus.Testing.Tests.Unit/Core/PollTests.cs
@@ -246,7 +246,7 @@ namespace Arcus.Testing.Tests.Unit.Core
 
         private static void SometimesSucceeds()
         {
-            if (Bogus.PickRandom(false, false, false, false, true))
+            if (Bogus.PickRandom(false, false, false, true))
             {
                 throw new TestPollException("Sabotage polling!");
             }

--- a/src/Arcus.Testing.Tests.Unit/Core/PollTests.cs
+++ b/src/Arcus.Testing.Tests.Unit/Core/PollTests.cs
@@ -56,9 +56,16 @@ namespace Arcus.Testing.Tests.Unit.Core
         public async Task PollFluentSync_WithTargetAvailableWithinTimeFrame_SucceedsByContinuing()
         {
             await Poll.Target(AlwaysSucceeds);
-            await Poll.Target(SometimesSucceeds).ReasonableTimeFrame();
             await Poll.Target<ArrayTypeMismatchException>(AlwaysSucceeds);
-            await Poll.Target<TestPollException>(SometimesSucceeds).ReasonableTimeFrame();
+
+            await ShouldContinueAsync(async failures => await Poll.Target(() => SometimesSucceeds(failures)).ReasonableTimeFrame());
+            await ShouldContinueAsync(async failures => await Poll.Target<TestPollException>(() => SometimesSucceeds(failures)).ReasonableTimeFrame());
+        }
+
+        private async Task ShouldContinueAsync(Func<Queue<bool>, Task> pollAsync)
+        {
+            var failures = new Queue<bool>([Bogus.Random.Bool(), Bogus.Random.Bool(), false]);
+            await pollAsync(failures);
         }
 
         [Fact]

--- a/src/Arcus.Testing.Tests.Unit/Core/PollTests.cs
+++ b/src/Arcus.Testing.Tests.Unit/Core/PollTests.cs
@@ -91,11 +91,11 @@ namespace Arcus.Testing.Tests.Unit.Core
         [Fact]
         public async Task Poll_WithDiffExceptionThanUnavailableTarget_FailsDirectlyWithDescription()
         {
-            await FailsByExceptionAsync(() => Poll.UntilAvailableAsync<InvalidOperationException>(AlwaysFailsAsync, ReasonableTimeFrame));
-            await FailsByExceptionAsync(() => Poll.UntilAvailableAsync<object, FileNotFoundException>(AlwaysFailsResultAsync, ReasonableTimeFrame));
+            await FailsByExceptionAsync(() => Poll.UntilAvailableAsync<InvalidOperationException>(AlwaysFailsAsync, LowestTimeFrame));
+            await FailsByExceptionAsync(() => Poll.UntilAvailableAsync<object, FileNotFoundException>(AlwaysFailsResultAsync, LowestTimeFrame));
 
-            await FailsByExceptionAsync(async () => await Poll.Target<AggregateException>(AlwaysFailsAsync).ReasonableTimeFrame());
-            await FailsByExceptionAsync(async () => await Poll.Target<object, ApplicationException>(AlwaysFailsResultAsync).ReasonableTimeFrame());
+            await FailsByExceptionAsync(async () => await Poll.Target<AggregateException>(AlwaysFailsAsync).LowestTimeFrame());
+            await FailsByExceptionAsync(async () => await Poll.Target<object, ApplicationException>(AlwaysFailsResultAsync).LowestTimeFrame());
         }
 
         [Fact]
@@ -133,7 +133,7 @@ namespace Arcus.Testing.Tests.Unit.Core
             // Act / Assert
             await FailsByResultAsync(async () =>
                 await Poll.Target(AlwaysSucceedsResultAsync)
-                          .ReasonableTimeFrame()
+                          .Timeout(_100ms)
                           .Until(AlwaysTrue)
                           .Until(AlwaysFalse)
                           .Until(AlwaysTrue)
@@ -141,7 +141,7 @@ namespace Arcus.Testing.Tests.Unit.Core
 
             await FailsByResultAsync(async () =>
                 await Poll.Target<object, TestPollException>(AlwaysSucceedsResultAsync)
-                          .ReasonableTimeFrame()
+                          .Timeout(_100ms)
                           .Until(AlwaysTrue)
                           .Until(AlwaysFalse)
                           .Until(AlwaysTrue)
@@ -220,6 +220,12 @@ namespace Arcus.Testing.Tests.Unit.Core
         {
             options.Timeout = _5s;
             options.Interval = _100ms;
+        }
+
+        private void LowestTimeFrame(PollOptions options)
+        {
+            options.Timeout = _100ms;
+            options.Interval = TimeSpan.FromMilliseconds(10);
         }
 
         private static bool AlwaysTrue(object result) => true;
@@ -356,6 +362,13 @@ namespace Arcus.Testing.Tests.Unit.Core
             where TException : Exception
         {
             return poll.Every(TimeSpan.FromMilliseconds(100)).Timeout(TimeSpan.FromSeconds(5));
+        }
+
+        public static Poll<TResult, TException> LowestTimeFrame<TResult, TException>(
+            this Poll<TResult, TException> poll)
+            where TException : Exception
+        {
+            return poll.Every(TimeSpan.FromMilliseconds(10)).Timeout(TimeSpan.FromSeconds(100));
         }
     }
 


### PR DESCRIPTION
The combination of the new xUnit v3 testing framework and the additional polling tests created by #348 , made the current polling tests fail. Since these tests were also a bit harder to investigate if something failed, since they were grouped together, plus the nature of instable timeouts - it already helped a lot if the tests were split by category (direct/fluent, sync/async).

Furthermore, the `PollOptions` weren't always created 'fresh', which could cause disruption in a multi-polling scenario.

This PR both simplifies the tests for better defect localization, as well as fixes the `PollOptions` creation process.