### PR TITLE
chore(readme): use github markdown note instead of blockquote

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@
 
 Arcus Testing is an umbrella term for a set of NuGet packages `Arcus.Testing.*` that help with the creation, maintenance, and defect localization of code testing.
 
-> 🎖️ Specifically designed to help with integration testing against Azure resources, but also helps with tech-independent infrastructure.
+> [!NOTE]
+> Specifically designed to help with integration testing against Azure resources, but also helps with tech-independent infrastructure.
 
 In short: Arcus Testing is a set of libraries that makes tests more fun to write!
 


### PR DESCRIPTION
This PR uses the built-in GitHub Markdown 'Note' functionality in the repository root `README.md`, instead of the Markdown blockquote one. It makes it more visually attractive. 