### PR TITLE
chore(resource.dir): use simplified resource directory file api for text/bytes

### DIFF
--- a/docs/preview/03-Features/01-core.md
+++ b/docs/preview/03-Features/01-core.md
@@ -199,13 +199,15 @@ Try to come up with a sweet spot that does not wait too long for the target reso
 ## Resource directory
 The `ResourceDirectory` provides a solution to retrieving local files during the test run. It points by default to the root output directory where the test suite is running, and from there any sub-directory can be navigated to in a test-friendly manner. Each time a directory or a file does not exists, an IO exception will be thrown with a clear message on what is missing on disk.
 
+> 🔗 More information on search patterns can be found on [Microsoft's documentation site](https://learn.microsoft.com/en-us/dotnet/api/system.io.directoryinfo.getfiles).
+
 ```csharp
 using Arcus.Testing;
 
 // Path: /bin/net8.0/
 ResourceDirectory root = ResourceDirectory.CurrentDirectory;
 
-string txt = root.ReadFileText("file.txt");
+string txt = root.ReadFileText("file?.txt");
 byte[] img = root.ReadFileBytes("file.png");
 
 // Path: /bin/net8.0/resources

--- a/docs/preview/03-Features/01-core.md
+++ b/docs/preview/03-Features/01-core.md
@@ -205,16 +205,16 @@ using Arcus.Testing;
 // Path: /bin/net8.0/
 ResourceDirectory root = ResourceDirectory.CurrentDirectory;
 
-string txt = root.ReadFileTextByName("file.txt");
-byte[] img = root.ReadFileBytesByName("file.png");
+string txt = root.ReadFileText("file.txt");
+byte[] img = root.ReadFileBytes("file.png");
 
 // Path: /bin/net8.0/resources
 ResourceDirectory sub = 
     root.WithSubDirectory("resources")
         .WithSubDirectory("component");
 
-string txt = sub.ReadFileTextByName("file.txt");
-byte[] img = sub.ReadFileBytesByPattern("*.png");
+string txt = sub.ReadFileText("file.txt");
+byte[] img = sub.ReadFileBytes("*.png");
 
 
 // FileNotFoundException: 

--- a/samples/Arcus.Testing.Sample.TestingFrameworkMigration/OutputComparison/XsltHelper_To_AssertXslt.cs
+++ b/samples/Arcus.Testing.Sample.TestingFrameworkMigration/OutputComparison/XsltHelper_To_AssertXslt.cs
@@ -37,14 +37,14 @@ namespace Arcus.Testing.Sample.TestingFrameworkMigration.OutputComparison
         public void TestXslt_XmlToXml_PassWithArcus()
         {
             // Arrange
-            string xslt = ScenarioFiles.ReadFileTextByName("TestXslt_XmlToXml.xslt");
-            string input = ScenarioFiles.ReadFileTextByName("TestXslt_XmlToXml_Pass_input.xml");
+            string xslt = ScenarioFiles.ReadFileText("TestXslt_XmlToXml.xslt");
+            string input = ScenarioFiles.ReadFileText("TestXslt_XmlToXml_Pass_input.xml");
 
             // Act
             string actual = AssertXslt.TransformToXml(xslt, input);
 
             // Assert
-            string expected = ScenarioFiles.ReadFileTextByName("TestXslt_XmlToXml_Pass_expected.xml");
+            string expected = ScenarioFiles.ReadFileText("TestXslt_XmlToXml_Pass_expected.xml");
             AssertXml.Equal(expected, actual, opt =>
             {
                 opt.IgnoreNode("Node1");
@@ -77,14 +77,14 @@ namespace Arcus.Testing.Sample.TestingFrameworkMigration.OutputComparison
         public void TestXslt_XmlToJson_PassWithArcus()
         {
             // Arrange
-            string xslt = ScenarioFiles.ReadFileTextByName("TestXslt_XmlToJson.xslt");
-            string input = ScenarioFiles.ReadFileTextByName("TestXslt_XmlToJson_Pass_input.xml");
+            string xslt = ScenarioFiles.ReadFileText("TestXslt_XmlToJson.xslt");
+            string input = ScenarioFiles.ReadFileText("TestXslt_XmlToJson_Pass_input.xml");
 
             // Act
             string actual = AssertXslt.TransformToJson(xslt, input);
 
             // Assert
-            string expected = ScenarioFiles.ReadFileTextByName("TestXslt_XmlToJson_Pass_expected.json");
+            string expected = ScenarioFiles.ReadFileText("TestXslt_XmlToJson_Pass_expected.json");
             AssertJson.Equal(expected, actual);
         }
 
@@ -114,14 +114,14 @@ namespace Arcus.Testing.Sample.TestingFrameworkMigration.OutputComparison
         public void TestXslt_XmlToCsv_PassWithArcus()
         {
             // Arrange
-            string xlst = ScenarioFiles.ReadFileTextByName("TestXslt_XmlToCsv.xslt");
-            string input = ScenarioFiles.ReadFileTextByName("TestXslt_XmlToCsv_Pass_input.xml");
+            string xlst = ScenarioFiles.ReadFileText("TestXslt_XmlToCsv.xslt");
+            string input = ScenarioFiles.ReadFileText("TestXslt_XmlToCsv_Pass_input.xml");
 
             // Act
             string actual = AssertXslt.TransformToCsv(xlst, input);
 
             // Assert
-            string expected = ScenarioFiles.ReadFileTextByName("TestXslt_XmlToCsv_Pass_expected.csv");
+            string expected = ScenarioFiles.ReadFileText("TestXslt_XmlToCsv_Pass_expected.csv");
             AssertCsv.Equal(expected, actual);
         }
     }

--- a/src/Arcus.Testing.Core/ResourceDirectory.cs
+++ b/src/Arcus.Testing.Core/ResourceDirectory.cs
@@ -73,6 +73,30 @@ namespace Arcus.Testing
 
         /// <summary>
         /// Gets the file contents of a test resource file within the directory.
+        /// <example>
+        ///   <code>
+        ///    string contents = resourceDirectory.ReadFileText("example.txt");
+        ///    string contents = resourceDirectory.ReadFileText("example.*");
+        ///   </code>
+        /// </example>
+        /// </summary>
+        /// <param name="fileNameOrSearchPattern">
+        ///     The file name of the test resource or the search string to match against the test resource's file name.
+        ///     This parameter can contain a combination of valid literal path and wildcard (* and ?) characters, but it doesn't support regular expressions.
+        /// </param>
+        /// <returns>The raw contents of the test resource file.</returns>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="fileNameOrSearchPattern"/> is blank.</exception>
+        /// <exception cref="FileNotFoundException">
+        ///     Thrown when there exists no test resource file in the current test resource directory with the given <paramref name="fileNameOrSearchPattern"/>.
+        /// </exception>
+        public string ReadFileText(string fileNameOrSearchPattern)
+        {
+            FileInfo file = GetFileByPattern(fileNameOrSearchPattern);
+            return File.ReadAllText(file.FullName);
+        }
+
+        /// <summary>
+        /// Gets the file contents of a test resource file within the directory.
         /// </summary>
         /// <param name="fileName">The file name of the test resource.</param>
         /// <returns>The raw contents of the test resource file.</returns>
@@ -80,6 +104,7 @@ namespace Arcus.Testing
         /// <exception cref="FileNotFoundException">
         ///     Thrown when there exists no test resource file in the current test resource directory with the given <paramref name="fileName"/>.
         /// </exception>
+        [Obsolete("Will be removed in v3.0, please use " + nameof(ReadFileText) + " instead")]
         public string ReadFileTextByName(string fileName)
         {
             FileInfo file = GetFileByPattern(fileName);
@@ -98,10 +123,35 @@ namespace Arcus.Testing
         /// <exception cref="FileNotFoundException">
         ///     Thrown when there exists no test resource file in the current test resource directory with the given <paramref name="searchPattern"/>.
         /// </exception>
+        [Obsolete("Will be removed in v3.0, please use " + nameof(ReadFileText) + " instead")]
         public string ReadFileTextByPattern(string searchPattern)
         {
             FileInfo file = GetFileByPattern(searchPattern);
             return File.ReadAllText(file.FullName);
+        }
+
+        /// <summary>
+        /// Gets the file contents of a test resource file within the directory.
+        /// <example>
+        ///   <code>
+        ///     byte[] contents = resourceDirectory.ReadFileBytes("example.txt");
+        ///     byte[] contents = resourceDirectory.ReadFileBytes("example.*");
+        ///   </code>
+        /// </example>
+        /// </summary>
+        /// <param name="fileNameOrSearchPattern">
+        ///     The file name of the test resource or the search string to match against the test resource's file name.
+        ///     This parameter can contain a combination of valid literal path and wildcard (* and ?) characters, but it doesn't support regular expressions.
+        /// </param>
+        /// <returns>The raw contents of the test resource file.</returns>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="fileNameOrSearchPattern"/> is blank.</exception>
+        /// <exception cref="FileNotFoundException">
+        ///     Thrown when there exists no test resource file in the current test resource directory with the given <paramref name="fileNameOrSearchPattern"/>.
+        /// </exception>
+        public byte[] ReadFileBytes(string fileNameOrSearchPattern)
+        {
+            FileInfo file = GetFileByPattern(fileNameOrSearchPattern);
+            return File.ReadAllBytes(file.FullName);
         }
 
         /// <summary>
@@ -113,6 +163,7 @@ namespace Arcus.Testing
         /// <exception cref="FileNotFoundException">
         ///     Thrown when there exists no test resource file in the current test resource directory with the given <paramref name="fileName"/>.
         /// </exception>
+        [Obsolete("Will be removed in v3.0, please use " + nameof(ReadFileBytes) + " instead")]
         public byte[] ReadFileBytesByName(string fileName)
         {
             FileInfo file = GetFileByPattern(fileName);
@@ -131,6 +182,7 @@ namespace Arcus.Testing
         /// <exception cref="FileNotFoundException">
         ///     Thrown when there exists no test resource file in the current test resource directory with the given <paramref name="searchPattern"/>.
         /// </exception>
+        [Obsolete("Will be removed in v3.0, please use " + nameof(ReadFileBytes) + " instead")]
         public byte[] ReadFileBytesByPattern(string searchPattern)
         {
             FileInfo file = GetFileByPattern(searchPattern);

--- a/src/Arcus.Testing.Tests.Integration/Core/ResourceDirectoryTests.cs
+++ b/src/Arcus.Testing.Tests.Integration/Core/ResourceDirectoryTests.cs
@@ -117,18 +117,14 @@ namespace Arcus.Testing.Tests.Integration.Core
 
         private static void AssertContainsFile(TemporaryFile expectedFile, ResourceDirectory directory)
         {
-            Assert.Equal(expectedFile.Contents, directory.ReadFileBytesByName(expectedFile.Name));
-            Assert.Equal(expectedFile.Contents, directory.ReadFileBytesByPattern(expectedFile.Name[..^1] + "?"));
-            Assert.Equal(expectedFile.Text, directory.ReadFileTextByName(expectedFile.Name));
-            Assert.Equal(expectedFile.Text, directory.ReadFileTextByPattern(expectedFile.Name[..5] + "*"));
+            Assert.Equal(expectedFile.Contents, directory.ReadFileBytes(Bogus.PickRandom(expectedFile.Name, expectedFile.Name[..^1] + "?")));
+            Assert.Equal(expectedFile.Text, directory.ReadFileText(Bogus.PickRandom(expectedFile.Name, expectedFile.Name[..5] + "*"))));
         }
 
         private static void AssertFileNotFound(string input, ResourceDirectory directory)
         {
-            AssertFileNotFound(() => directory.ReadFileTextByName(input), input);
-            AssertFileNotFound(() => directory.ReadFileBytesByName(input), input);
-            AssertFileNotFound(() => directory.ReadFileTextByPattern(input), input);
-            AssertFileNotFound(() => directory.ReadFileBytesByPattern(input), input);
+            AssertFileNotFound(() => directory.ReadFileText(input), input);
+            AssertFileNotFound(() => directory.ReadFileBytes(input), input);
         }
 
         private static void AssertFileNotFound(Action dirAction, params string[] errorParts)

--- a/src/Arcus.Testing.Tests.Unit/Assert_/AssertJsonTests.cs
+++ b/src/Arcus.Testing.Tests.Unit/Assert_/AssertJsonTests.cs
@@ -315,8 +315,8 @@ namespace Arcus.Testing.Tests.Unit.Assert_
         {
             // Arrange
             string fileNamePrefix = "json.ignored.order.objects.in.array.sample";
-            string actual = _resourceDir.ReadFileTextByName(fileNamePrefix + ".actual.json");
-            string expected = _resourceDir.ReadFileTextByName(fileNamePrefix + ".expected.json");
+            string actual = _resourceDir.ReadFileText(fileNamePrefix + ".actual.json");
+            string expected = _resourceDir.ReadFileText(fileNamePrefix + ".expected.json");
 
             // Act / Assert
             EqualJson(expected, actual);


### PR DESCRIPTION
The `ResourceDirectory` exposed two sets of name/pattern members to read test resource files, while behind-the-scenes these are actually doing the same. While it make sense to provide context to the test reader on whether the file name or search pattern is used, this can also be done via the parameter name.

This PR reduces the amount of file members to expose, which makes the exposed members and their names more clear.

Closes #375