### PR TITLE
fix(az.sb.topic.sub): add missing coverage for az sb topic sub rules

### DIFF
--- a/docs/preview/03-Features/04-Azure/05-Messaging/01-servicebus.mdx
+++ b/docs/preview/03-Features/04-Azure/05-Messaging/01-servicebus.mdx
@@ -1,7 +1,7 @@
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-# Service bus
+# Service Bus
 The `Arcus.Testing.Messaging.ServiceBus` package provides test fixtures related to Azure Service Bus. By using the common testing practice 'clean environment', it provides a temporary Topic (subscription) and queue.
 
 ## Installation
@@ -101,7 +101,7 @@ await TemporaryTopic.CreateIfNotExistsAsync(..., options =>
 ```
 
 ### Peek for messages
-The `TemporaryTopic` is equipped with a message filtering system that allows testers to search for messages during the lifetime of the test fixture. This can be useful to verify the current state of a topic, or as a test assertion to verify Service bus-related implementations.
+The `TemporaryTopic` is equipped with a message filtering system that allows testers to search for messages during the lifetime of the test fixture. This can be useful to verify the current state of a topic, or as a test assertion to verify Service Bus-related implementations.
 
 ```csharp
 using Arcus.Testing;
@@ -123,6 +123,35 @@ IEnumerable<ServiceBusReceivedMessage> messages =
 
              // Start peeking for messages.
              .ToListAsync();
+```
+
+### Temporary topic subscription
+The `TemporaryTopicSubscription` provides a solution when the integration test requires an Azure Service Bus topic subscription during the test run. A subscription is created upon the setup of the test fixture and is deleted again when the test fixture is disposed.
+
+> ✨ Only when the test fixture was responsible for creating the topic subscription, will the subscription be deleted upon the fixture's disposal. This follows the 'clean environment' testing principle that describes that after the test run, the same state should be achieved as before the test run.
+
+```csharp
+using Arcus.Testing;
+
+await using var sub = await TemporaryTopicSubscription.CreateIfNotExistsAsync(
+    "<fully-qualified-namespace>", "<topic-name>", "<subscription-name>", logger);
+```
+
+> ⚡ Uses by default the [`DefaultAzureCredential`](https://learn.microsoft.com/en-us/dotnet/api/azure.identity.defaultazurecredential) but other type of authentication mechanisms are supported with overloads.
+
+Adding rules to the subscription can also be done via the test fixture. It always makes sure that any added rules are deleted again afterwards.
+
+:::warning[no default rule]
+The `$Default` rule name is not supported to be added as a temporary subscription rule name. Please use custom rule names.
+:::
+
+```csharp
+using Arcus.Testing;
+
+await using TemporaryTopicSubscription sub = ...
+
+RuleFilter filter = new SqlRuleFilter("1=1");
+await sub.AddRuleIfNotExistsAsync("<rule-name>", filter);
 ```
 
 </TabItem>
@@ -206,7 +235,7 @@ await TemporaryQueue.CreateIfNotExistsAsync(..., options =>
 ```
 
 ### Peek for messages
-The `TemporaryQueue` is equipped with a message filtering system that allows testers to search for messages during the lifetime of the test fixture. This can be useful to verify the current state of a queue, or as a test assertion to verify Service bus-related implementations.
+The `TemporaryQueue` is equipped with a message filtering system that allows testers to search for messages during the lifetime of the test fixture. This can be useful to verify the current state of a queue, or as a test assertion to verify Service Bus-related implementations.
 
 ```csharp
 using Arcus.Testing;

--- a/docs/versioned_docs/version-v2.0.0/03-Features/04-Azure/05-Messaging/01-servicebus.mdx
+++ b/docs/versioned_docs/version-v2.0.0/03-Features/04-Azure/05-Messaging/01-servicebus.mdx
@@ -1,7 +1,7 @@
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-# Service bus
+# Service Bus
 The `Arcus.Testing.Messaging.ServiceBus` package provides test fixtures related to Azure Service Bus. By using the common testing practice 'clean environment', it provides a temporary Topic (subscription) and queue.
 
 ## Installation
@@ -101,7 +101,7 @@ await TemporaryTopic.CreateIfNotExistsAsync(..., options =>
 ```
 
 ### Peek for messages
-The `TemporaryTopic` is equipped with a message filtering system that allows testers to search for messages during the lifetime of the test fixture. This can be useful to verify the current state of a topic, or as a test assertion to verify Service bus-related implementations.
+The `TemporaryTopic` is equipped with a message filtering system that allows testers to search for messages during the lifetime of the test fixture. This can be useful to verify the current state of a topic, or as a test assertion to verify Service Bus-related implementations.
 
 ```csharp
 using Arcus.Testing;
@@ -123,6 +123,35 @@ IEnumerable<ServiceBusReceivedMessage> messages =
 
              // Start peeking for messages.
              .ToListAsync();
+```
+
+### Temporary topic subscription
+The `TemporaryTopicSubscription` provides a solution when the integration test requires an Azure Service Bus topic subscription during the test run. A subscription is created upon the setup of the test fixture and is deleted again when the test fixture is disposed.
+
+> ✨ Only when the test fixture was responsible for creating the topic subscription, will the subscription be deleted upon the fixture's disposal. This follows the 'clean environment' testing principle that describes that after the test run, the same state should be achieved as before the test run.
+
+```csharp
+using Arcus.Testing;
+
+await using var sub = await TemporaryTopicSubscription.CreateIfNotExistsAsync(
+    "<fully-qualified-namespace>", "<topic-name>", "<subscription-name>", logger);
+```
+
+> ⚡ Uses by default the [`DefaultAzureCredential`](https://learn.microsoft.com/en-us/dotnet/api/azure.identity.defaultazurecredential) but other type of authentication mechanisms are supported with overloads.
+
+Adding rules to the subscription can also be done via the test fixture. It always makes sure that any added rules are deleted again afterwards.
+
+:::warning[no default rule]
+The `$Default` rule name is not supported to be added as a temporary subscription rule name. Please use custom rule names.
+:::
+
+```csharp
+using Arcus.Testing;
+
+await using TemporaryTopicSubscription sub = ...
+
+RuleFilter filter = new SqlRuleFilter("1=1");
+await sub.AddRuleIfNotExistsAsync("<rule-name>", filter);
 ```
 
 </TabItem>
@@ -206,7 +235,7 @@ await TemporaryQueue.CreateIfNotExistsAsync(..., options =>
 ```
 
 ### Peek for messages
-The `TemporaryQueue` is equipped with a message filtering system that allows testers to search for messages during the lifetime of the test fixture. This can be useful to verify the current state of a queue, or as a test assertion to verify Service bus-related implementations.
+The `TemporaryQueue` is equipped with a message filtering system that allows testers to search for messages during the lifetime of the test fixture. This can be useful to verify the current state of a queue, or as a test assertion to verify Service Bus-related implementations.
 
 ```csharp
 using Arcus.Testing;

--- a/docs/versioned_docs/version-v2.1.0/03-Features/04-Azure/05-Messaging/01-servicebus.mdx
+++ b/docs/versioned_docs/version-v2.1.0/03-Features/04-Azure/05-Messaging/01-servicebus.mdx
@@ -1,7 +1,7 @@
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-# Service bus
+# Service Bus
 The `Arcus.Testing.Messaging.ServiceBus` package provides test fixtures related to Azure Service Bus. By using the common testing practice 'clean environment', it provides a temporary Topic (subscription) and queue.
 
 ## Installation
@@ -101,7 +101,7 @@ await TemporaryTopic.CreateIfNotExistsAsync(..., options =>
 ```
 
 ### Peek for messages
-The `TemporaryTopic` is equipped with a message filtering system that allows testers to search for messages during the lifetime of the test fixture. This can be useful to verify the current state of a topic, or as a test assertion to verify Service bus-related implementations.
+The `TemporaryTopic` is equipped with a message filtering system that allows testers to search for messages during the lifetime of the test fixture. This can be useful to verify the current state of a topic, or as a test assertion to verify Service Bus-related implementations.
 
 ```csharp
 using Arcus.Testing;
@@ -123,6 +123,35 @@ IEnumerable<ServiceBusReceivedMessage> messages =
 
              // Start peeking for messages.
              .ToListAsync();
+```
+
+### Temporary topic subscription
+The `TemporaryTopicSubscription` provides a solution when the integration test requires an Azure Service Bus topic subscription during the test run. A subscription is created upon the setup of the test fixture and is deleted again when the test fixture is disposed.
+
+> ✨ Only when the test fixture was responsible for creating the topic subscription, will the subscription be deleted upon the fixture's disposal. This follows the 'clean environment' testing principle that describes that after the test run, the same state should be achieved as before the test run.
+
+```csharp
+using Arcus.Testing;
+
+await using var sub = await TemporaryTopicSubscription.CreateIfNotExistsAsync(
+    "<fully-qualified-namespace>", "<topic-name>", "<subscription-name>", logger);
+```
+
+> ⚡ Uses by default the [`DefaultAzureCredential`](https://learn.microsoft.com/en-us/dotnet/api/azure.identity.defaultazurecredential) but other type of authentication mechanisms are supported with overloads.
+
+Adding rules to the subscription can also be done via the test fixture. It always makes sure that any added rules are deleted again afterwards.
+
+:::warning[no default rule]
+The `$Default` rule name is not supported to be added as a temporary subscription rule name. Please use custom rule names.
+:::
+
+```csharp
+using Arcus.Testing;
+
+await using TemporaryTopicSubscription sub = ...
+
+RuleFilter filter = new SqlRuleFilter("1=1");
+await sub.AddRuleIfNotExistsAsync("<rule-name>", filter);
 ```
 
 </TabItem>
@@ -206,7 +235,7 @@ await TemporaryQueue.CreateIfNotExistsAsync(..., options =>
 ```
 
 ### Peek for messages
-The `TemporaryQueue` is equipped with a message filtering system that allows testers to search for messages during the lifetime of the test fixture. This can be useful to verify the current state of a queue, or as a test assertion to verify Service bus-related implementations.
+The `TemporaryQueue` is equipped with a message filtering system that allows testers to search for messages during the lifetime of the test fixture. This can be useful to verify the current state of a queue, or as a test assertion to verify Service Bus-related implementations.
 
 ```csharp
 using Arcus.Testing;

--- a/src/Arcus.Testing.Messaging.ServiceBus/TemporaryTopicSubscription.cs
+++ b/src/Arcus.Testing.Messaging.ServiceBus/TemporaryTopicSubscription.cs
@@ -90,17 +90,17 @@ namespace Arcus.Testing
         }
 
         /// <summary>
-        /// Gets the name of the Azure Service bus topic subscription that is possibly created by the test fixture.
+        /// Gets the name of the Azure Service Bus topic subscription that is possibly created by the test fixture.
         /// </summary>
         public string Name { get; }
 
         /// <summary>
-        /// Gets the name of the Azure Service bus topic where this topic subscription is test-managed.
+        /// Gets the name of the Azure Service Bus topic where this topic subscription is test-managed.
         /// </summary>
         public string TopicName { get; }
 
         /// <summary>
-        /// Gets the fully-qualified name of the Azure Service bus namespace for which this test fixture managed a topic subscription.
+        /// Gets the fully-qualified name of the Azure Service Bus namespace for which this test fixture managed a topic subscription.
         /// </summary>
         public string FullyQualifiedNamespace { get; }
 
@@ -110,9 +110,9 @@ namespace Arcus.Testing
         /// <param name="fullyQualifiedNamespace">
         ///     The fully qualified Service Bus namespace to connect to. This is likely to be similar to <c>{yournamespace}.servicebus.windows.net</c>.
         /// </param>
-        /// <param name="topicName">The name of the Azure Service bus topic in which the subscription should be created.</param>
-        /// <param name="subscriptionName">The name of the subscription in the configured Azure Service bus topic.</param>
-        /// <param name="logger">The logger to write diagnostic messages during the lifetime of the Azure Service bus topic subscription.</param>
+        /// <param name="topicName">The name of the Azure Service Bus topic in which the subscription should be created.</param>
+        /// <param name="subscriptionName">The name of the subscription in the configured Azure Service Bus topic.</param>
+        /// <param name="logger">The logger to write diagnostic messages during the lifetime of the Azure Service Bus topic subscription.</param>
         /// <exception cref="ArgumentException">Thrown when one of the passed arguments is blank.</exception>
         /// <exception cref="InvalidOperationException">
         ///     Thrown when the no Azure Service Bus topic exists with the provided <paramref name="topicName"/> in the given <paramref name="fullyQualifiedNamespace"/>.
@@ -123,20 +123,20 @@ namespace Arcus.Testing
         }
 
         /// <summary>
-        /// Creates a new instance of the <see cref="TemporaryTopicSubscription"/> which creates a new Azure Service bus topic subscription if it doesn't exist yet.
+        /// Creates a new instance of the <see cref="TemporaryTopicSubscription"/> which creates a new Azure Service Bus topic subscription if it doesn't exist yet.
         /// </summary>
         /// <param name="fullyQualifiedNamespace">
         ///     The fully qualified Service Bus namespace to connect to. This is likely to be similar to <c>{yournamespace}.servicebus.windows.net</c>.
         /// </param>
-        /// <param name="topicName">The name of the Azure Service bus topic in which the subscription should be created.</param>
-        /// <param name="subscriptionName">The name of the subscription in the configured Azure Service bus topic.</param>
+        /// <param name="topicName">The name of the Azure Service Bus topic in which the subscription should be created.</param>
+        /// <param name="subscriptionName">The name of the subscription in the configured Azure Service Bus topic.</param>
         /// <param name="logger">The logger to write diagnostic messages during the lifetime of the Azure Service Bus topic subscription.</param>
         /// <param name="configureOptions">
-        ///     The function to configure the additional options that describes how the Azure Service bus topic subscription should be created.
+        ///     The function to configure the additional options that describes how the Azure Service Bus topic subscription should be created.
         /// </param>
         /// <exception cref="ArgumentException">Thrown when one of the passed arguments is blank.</exception>
         /// <exception cref="InvalidOperationException">
-        ///     Thrown when the no Azure Service bus topic exists with the provided <paramref name="topicName"/> in the given <paramref name="fullyQualifiedNamespace"/>.
+        ///     Thrown when the no Azure Service Bus topic exists with the provided <paramref name="topicName"/> in the given <paramref name="fullyQualifiedNamespace"/>.
         /// </exception>
         public static async Task<TemporaryTopicSubscription> CreateIfNotExistsAsync(
             string fullyQualifiedNamespace,
@@ -152,16 +152,16 @@ namespace Arcus.Testing
         }
 
         /// <summary>
-        /// Creates a new instance of the <see cref="TemporaryTopicSubscription"/> which creates a new Azure Service bus topic subscription if it doesn't exist yet.
+        /// Creates a new instance of the <see cref="TemporaryTopicSubscription"/> which creates a new Azure Service Bus topic subscription if it doesn't exist yet.
         /// </summary>
-        /// <param name="adminClient">The administration client to interact with the Azure Service bus resource where the topic subscription should be created.</param>
-        /// <param name="topicName">The name of the Azure Service bus topic in which the subscription should be created.</param>
-        /// <param name="subscriptionName">The name of the subscription in the configured Azure Service bus topic.</param>
-        /// <param name="logger">The logger to write diagnostic messages during the lifetime of the Azure Service bus topic subscription.</param>
+        /// <param name="adminClient">The administration client to interact with the Azure Service Bus resource where the topic subscription should be created.</param>
+        /// <param name="topicName">The name of the Azure Service Bus topic in which the subscription should be created.</param>
+        /// <param name="subscriptionName">The name of the subscription in the configured Azure Service Bus topic.</param>
+        /// <param name="logger">The logger to write diagnostic messages during the lifetime of the Azure Service Bus topic subscription.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="adminClient"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when one of the passed arguments is blank.</exception>
         /// <exception cref="InvalidOperationException">
-        ///     Thrown when the no Azure Service bus topic exists with the provided <paramref name="topicName"/>
+        ///     Thrown when the no Azure Service Bus topic exists with the provided <paramref name="topicName"/>
         ///     in the given namespace where the given <paramref name="adminClient"/> points to.
         /// </exception>
         public static async Task<TemporaryTopicSubscription> CreateIfNotExistsAsync(
@@ -174,19 +174,19 @@ namespace Arcus.Testing
         }
 
         /// <summary>
-        /// Creates a new instance of the <see cref="TemporaryTopicSubscription"/> which creates a new Azure Service bus topic subscription if it doesn't exist yet.
+        /// Creates a new instance of the <see cref="TemporaryTopicSubscription"/> which creates a new Azure Service Bus topic subscription if it doesn't exist yet.
         /// </summary>
-        /// <param name="adminClient">The administration client to interact with the Azure Service bus resource where the topic subscription should be created.</param>
-        /// <param name="topicName">The name of the Azure Service bus topic in which the subscription should be created.</param>
-        /// <param name="subscriptionName">The name of the subscription in the configured Azure Service bus topic.</param>
-        /// <param name="logger">The logger to write diagnostic messages during the lifetime of the Azure Service bus topic subscription.</param>
+        /// <param name="adminClient">The administration client to interact with the Azure Service Bus resource where the topic subscription should be created.</param>
+        /// <param name="topicName">The name of the Azure Service Bus topic in which the subscription should be created.</param>
+        /// <param name="subscriptionName">The name of the subscription in the configured Azure Service Bus topic.</param>
+        /// <param name="logger">The logger to write diagnostic messages during the lifetime of the Azure Service Bus topic subscription.</param>
         /// <param name="configureOptions">
-        ///     The function to configure the additional options that describes how the Azure Service bus topic subscription should be created.
+        ///     The function to configure the additional options that describes how the Azure Service Bus topic subscription should be created.
         /// </param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="adminClient"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when one of the passed arguments is blank.</exception>
         /// <exception cref="InvalidOperationException">
-        ///     Thrown when the no Azure Service bus topic exists with the provided <paramref name="topicName"/>
+        ///     Thrown when the no Azure Service Bus topic exists with the provided <paramref name="topicName"/>
         ///     in the given namespace where the given <paramref name="adminClient"/> points to.
         /// </exception>
         public static async Task<TemporaryTopicSubscription> CreateIfNotExistsAsync(
@@ -212,25 +212,25 @@ namespace Arcus.Testing
             if (!await adminClient.TopicExistsAsync(createOptions.TopicName))
             {
                 throw new InvalidOperationException(
-                    $"[Test:Setup] cannot create temporary subscription '{createOptions.SubscriptionName}' on Azure Service bus topic '{serviceBusNamespace}/{createOptions.TopicName}' " +
-                    $"because the topic '{createOptions.TopicName}' does not exists in the provided Azure Service bus namespace. " +
-                    $"Please make sure to have an available Azure Service bus topic before using the temporary topic subscription test fixture");
+                    $"[Test:Setup] cannot create temporary subscription '{createOptions.SubscriptionName}' on Azure Service Bus topic '{serviceBusNamespace}/{createOptions.TopicName}' " +
+                    $"because the topic '{createOptions.TopicName}' does not exists in the provided Azure Service Bus namespace. " +
+                    $"Please make sure to have an available Azure Service Bus topic before using the temporary topic subscription test fixture");
             }
 
             if (await adminClient.SubscriptionExistsAsync(createOptions.TopicName, createOptions.SubscriptionName))
             {
-                logger.LogTrace("[Test:Setup] Use already existing Azure Service bus topic subscription '{SubscriptionName}' in '{Namespace}/{TopicName}'", createOptions.SubscriptionName, serviceBusNamespace, createOptions.TopicName);
+                logger.LogTrace("[Test:Setup] Use already existing Azure Service Bus topic subscription '{SubscriptionName}' in '{Namespace}/{TopicName}'", createOptions.SubscriptionName, serviceBusNamespace, createOptions.TopicName);
                 return new TemporaryTopicSubscription(adminClient, serviceBusNamespace, createOptions, createdByUs: false, logger);
             }
 
-            logger.LogTrace("[Test:Setup] Create new Azure Service bus topic subscription '{SubscriptionName}' in '{Namespace}/{TopicName}'", createOptions.SubscriptionName, serviceBusNamespace, createOptions.TopicName);
+            logger.LogTrace("[Test:Setup] Create new Azure Service Bus topic subscription '{SubscriptionName}' in '{Namespace}/{TopicName}'", createOptions.SubscriptionName, serviceBusNamespace, createOptions.TopicName);
             await adminClient.CreateSubscriptionAsync(createOptions);
 
             return new TemporaryTopicSubscription(adminClient, serviceBusNamespace, createOptions, createdByUs: true, logger);
         }
 
         /// <summary>
-        /// Adds an Azure Service bus topic subscription rule to the test fixture, which will get disposed of when the test fixture gets disposed.
+        /// Adds an Azure Service Bus topic subscription rule to the test fixture, which will get disposed of when the test fixture gets disposed.
         /// </summary>
         /// <param name="ruleName">The name to describe the subscription rule.</param>
         /// <param name="ruleFilter">The filter expression used to match messages.</param>
@@ -244,16 +244,20 @@ namespace Arcus.Testing
             if (ruleName == CreateRuleOptions.DefaultRuleName)
             {
                 throw new ArgumentException(
-                    "Only custom Azure Service bus topic subscription rules can be added to the test fixture, please provide a custom name for your test-managed rule", nameof(ruleName));
+                    "Only custom Azure Service Bus topic subscription rules can be added to the test fixture, please provide a custom name for your test-managed rule", nameof(ruleName));
             }
 
-            if (!await _client.RuleExistsAsync(TopicName, Name, ruleName))
+            if (await _client.RuleExistsAsync(TopicName, Name, ruleName))
             {
-                _logger.LogDebug("[Test] Create new Azure Service bus topic subscription rule '{RuleName}' in '{Namespace}/{TopicName}/{SubscriptionName}'", ruleName, FullyQualifiedNamespace, TopicName, Name);
+                _logger.LogDebug("[Test] Skip creation of Azure Service Bus topic subscription rule '{RuleName}' in '{Namespace}/{TopicName}/{SubscriptionName}' as it already exists", ruleName, FullyQualifiedNamespace, TopicName, Name);
+            }
+            else
+            {
+                _logger.LogDebug("[Test] Create new Azure Service Bus topic subscription rule '{RuleName}' in '{Namespace}/{TopicName}/{SubscriptionName}'", ruleName, FullyQualifiedNamespace, TopicName, Name);
 
                 var options = new CreateRuleOptions(ruleName, ruleFilter);
                 await _client.CreateRuleAsync(TopicName, Name, options);
-            
+
                 _rules.Add(options);
             }
         }
@@ -282,7 +286,7 @@ namespace Arcus.Testing
                     {
                         if (await _client.RuleExistsAsync(TopicName, Name, r.Name))
                         {
-                            _logger.LogDebug("[Test:Teardown] Delete Azure Service bus topic subscription rule '{RuleName}' in {Namespace}/{TopicName}/{SubscriptionName}", r.Name, FullyQualifiedNamespace, _options.TopicName, _options.SubscriptionName);
+                            _logger.LogDebug("[Test:Teardown] Delete Azure Service Bus topic subscription rule '{RuleName}' in {Namespace}/{TopicName}/{SubscriptionName}", r.Name, FullyQualifiedNamespace, _options.TopicName, _options.SubscriptionName);
                             await _client.DeleteRuleAsync(TopicName, Name, r.Name);
                         }
                     })));

--- a/src/Arcus.Testing.Tests.Integration/Messaging/Fixture/ServiceBusTestContext.cs
+++ b/src/Arcus.Testing.Tests.Integration/Messaging/Fixture/ServiceBusTestContext.cs
@@ -24,6 +24,7 @@ namespace Arcus.Testing.Tests.Integration.Messaging.Fixture
         private readonly ServiceBusClient _messagingClient;
         private readonly Collection<string> _topicNames = new(), _queueNames = new();
         private readonly Collection<(string topicName, string subscriptionName)> _subscriptionNames = new();
+        private readonly Collection<(string topicName, string subscriptionName, string ruleName)> _ruleNames = new();
         private readonly ILogger _logger;
 
         private static readonly Faker Bogus = new();
@@ -119,6 +120,28 @@ namespace Arcus.Testing.Tests.Integration.Messaging.Fixture
             return subscriptionName;
         }
 
+        public async Task<string> WhenTopicSubscriptionRuleAvailableAsync(string topicName, string subscriptionName)
+        {
+            string ruleName = WhenTopicSubscriptionRuleNameUnavailable(topicName, subscriptionName);
+            _logger.LogTrace("[Test:Setup] Create available Azure Service Bus topic subscription rule '{RuleName}' on subscription '{SubscriptionName}' on topic '{TopicName}'", ruleName, subscriptionName, topicName);
+
+            await _adminClient.CreateRuleAsync(topicName, subscriptionName, new CreateRuleOptions
+            {
+                Name = ruleName,
+                Filter = new TrueRuleFilter()
+            });
+
+            return ruleName;
+        }
+
+        private string WhenTopicSubscriptionRuleNameUnavailable(string topicName, string subscriptionName)
+        {
+            string ruleName = $"rule-{Guid.NewGuid()}";
+            _ruleNames.Add((topicName, subscriptionName, ruleName));
+            
+            return ruleName;
+        }
+
         /// <summary>
         /// Provides an Azure Service bus topic subscription that is unavailable remotely.
         /// </summary>
@@ -157,6 +180,12 @@ namespace Arcus.Testing.Tests.Integration.Messaging.Fixture
         {
             _logger.LogTrace("[Test:Setup] Delete available Azure Service Bus topic subscription '{SubscriptionName}' in topic '{TopicName}'", subscriptionName, topicName);
             await _adminClient.DeleteSubscriptionAsync(topicName, subscriptionName);
+        }
+
+        public async Task WhenTopicSubscriptionRuleDeletedAsync(string topicName, string subscriptionName, string ruleName)
+        {
+            _logger.LogTrace("[Test:Setup] Delete available Azure Service Bus topic subscription rule '{RuleName}' on subscription '{SubscriptionName}' on topic '{TopicName}'", ruleName, subscriptionName, topicName);
+            await _adminClient.DeleteRuleAsync(topicName, subscriptionName, ruleName);
         }
 
         public async Task<ServiceBusMessage> WhenMessageSentAsync(string entityName)
@@ -229,6 +258,16 @@ namespace Arcus.Testing.Tests.Integration.Messaging.Fixture
         public async Task ShouldNotHaveTopicSubscriptionAsync(string topicName, string subscriptionName)
         {
             Assert.False(await _adminClient.SubscriptionExistsAsync(topicName, subscriptionName), $"Azure Service Bus topic '{topicName}' should not have a subscription '{subscriptionName}', but it has");
+        }
+
+        public async Task ShouldHaveTopicSubscriptionRuleAsync(string topicName, string subscriptionName, string ruleName)
+        {
+            Assert.True(await _adminClient.RuleExistsAsync(topicName, subscriptionName, ruleName), $"Azure Service Bus topic subscription '{subscriptionName}' should have a rule '{ruleName}', but it hasn't");
+        }
+
+        public async Task ShouldNotHaveTopicSubscriptionRuleAsync(string topicName, string subscriptionName, string ruleName)
+        {
+            Assert.False(await _adminClient.RuleExistsAsync(topicName, subscriptionName, ruleName), $"Azure Service Bus topic subscription '{subscriptionName}' should not have a rule '{ruleName}', but it has");
         }
 
         /// <summary>
@@ -312,6 +351,15 @@ namespace Arcus.Testing.Tests.Integration.Messaging.Fixture
                 {
                     _logger.LogTrace("[Test:Teardown] Fallback delete Azure Service Bus queue '{QueueName}'", queueName);
                     await _adminClient.DeleteQueueAsync(queueName);
+                }
+            })));
+
+            disposables.AddRange(_ruleNames.Select(item => AsyncDisposable.Create(async () =>
+            {
+                if (await _adminClient.RuleExistsAsync(item.topicName, item.subscriptionName, item.ruleName))
+                {
+                    _logger.LogTrace("[Test:Teardown] Fallback delete Azure Service Bus topic subscription rule '{RuleName}' on subscription '{SubscriptionName}' on topic '{TopicName}'", item.ruleName, item.subscriptionName, item.topicName);
+                    await _adminClient.DeleteRuleAsync(item.topicName, item.subscriptionName, item.ruleName);
                 }
             })));
 


### PR DESCRIPTION
The Azure Service Bus topic subscription rule functionality was not fully covered by the feature documentation as well as the tests. This PR fixes that, by enhancing the existing tests and adding dedicated failure scenarios.

> [!NOTE]
> The `Service bus` has been renamed to `Service Bus` as well in the docs, as to follow Microsoft's standards.

Follow-up of #96 