### PR TITLE
chore(az.sb): use microsoft naming for az service-bus

### DIFF
--- a/src/Arcus.Testing.Messaging.ServiceBus/ServiceBusMessageFilter.cs
+++ b/src/Arcus.Testing.Messaging.ServiceBus/ServiceBusMessageFilter.cs
@@ -10,7 +10,7 @@ using Azure.Messaging.ServiceBus;
 namespace Arcus.Testing
 {
     /// <summary>
-    /// Represents a configurable filter instance that selects a subset of <see cref="ServiceBusReceivedMessage"/>s on an Azure Service bus queue or topic subscription
+    /// Represents a configurable filter instance that selects a subset of <see cref="ServiceBusReceivedMessage"/>s on an Azure Service Bus queue or topic subscription
     /// (a.k.a. 'spy test fixture').
     /// </summary>
     public class ServiceBusMessageFilter

--- a/src/Arcus.Testing.Messaging.ServiceBus/TemporaryQueue.cs
+++ b/src/Arcus.Testing.Messaging.ServiceBus/TemporaryQueue.cs
@@ -323,7 +323,7 @@ namespace Arcus.Testing
 
             if (shouldDeadLetter && shouldComplete)
             {
-                logger.LogWarning("[Test:Teardown] Service Bus message '{MessageId}' matches both for dead-letter as completion in custom message filters, uses dead-letter, from queue '{QueueName}' in namespace '{Namespace}'", message.MessageId, receiver.EntityPath, receiver.FullyQualifiedNamespace);
+                logger.LogWarning("[Test:Teardown] Service Bus message '{MessageId}' matches both for dead-letter as completion in custom message filters, uses dead-letter, happening in queue '{Namespace}/{QueueName}'", message.MessageId, receiver.FullyQualifiedNamespace, receiver.EntityPath);
                 return MessageSettle.DeadLetter;
             }
             if (shouldDeadLetter)

--- a/src/Arcus.Testing.Messaging.ServiceBus/TemporaryQueue.cs
+++ b/src/Arcus.Testing.Messaging.ServiceBus/TemporaryQueue.cs
@@ -318,22 +318,23 @@ namespace Arcus.Testing
 
         internal MessageSettle DetermineMessageSettle(ServiceBusReceivedMessage message, ServiceBusReceiver receiver, ILogger logger)
         {
-            bool shouldDeadLetter = _shouldDeadLetterMessages.Any(func => func(message));
             bool shouldComplete = _shouldCompleteMessages.Any(func => func(message));
+            bool shouldDeadLetter = _shouldDeadLetterMessages.Any(func => func(message));
 
-            if (shouldDeadLetter && shouldComplete)
+            if (shouldComplete && shouldDeadLetter)
             {
                 logger.LogWarning("[Test:Teardown] Service Bus message '{MessageId}' matches both for dead-letter as completion in custom message filters, uses dead-letter, happening in queue '{Namespace}/{QueueName}'", message.MessageId, receiver.FullyQualifiedNamespace, receiver.EntityPath);
-                return MessageSettle.DeadLetter;
-            }
-            if (shouldDeadLetter)
-            {
                 return MessageSettle.DeadLetter;
             }
 
             if (shouldComplete)
             {
                 return MessageSettle.Complete;
+            }
+
+            if (shouldDeadLetter)
+            {
+                return MessageSettle.DeadLetter;
             }
 
             if (Messages is OnTeardownQueue.CompleteMessages)

--- a/src/Arcus.Testing.Messaging.ServiceBus/TemporaryQueue.cs
+++ b/src/Arcus.Testing.Messaging.ServiceBus/TemporaryQueue.cs
@@ -323,7 +323,7 @@ namespace Arcus.Testing
 
             if (shouldDeadLetter && shouldComplete)
             {
-                logger.LogWarning("[Test:Teardown] Service bus message '{MessageId}' matches both for dead-letter as completion in custom message filters, uses dead-letter, from queue '{QueueName}' in namespace '{Namespace}'", message.MessageId, receiver.EntityPath, receiver.FullyQualifiedNamespace);
+                logger.LogWarning("[Test:Teardown] Service Bus message '{MessageId}' matches both for dead-letter as completion in custom message filters, uses dead-letter, from queue '{QueueName}' in namespace '{Namespace}'", message.MessageId, receiver.EntityPath, receiver.FullyQualifiedNamespace);
                 return MessageSettle.DeadLetter;
             }
             if (shouldDeadLetter)
@@ -362,7 +362,7 @@ namespace Arcus.Testing
     }
 
     /// <summary>
-    /// Represents a temporary Azure Service bus queue that will be deleted when the instance is disposed.
+    /// Represents a temporary Azure Service Bus queue that will be deleted when the instance is disposed.
     /// </summary>
     public class TemporaryQueue : IAsyncDisposable
     {
@@ -400,12 +400,12 @@ namespace Arcus.Testing
         }
 
         /// <summary>
-        /// Gets the name of the Azure Service bus queue that is possibly created by the test fixture.
+        /// Gets the name of the Azure Service Bus queue that is possibly created by the test fixture.
         /// </summary>
         public string Name { get; }
 
         /// <summary>
-        /// Gets the fully-qualified name of the Azure Service bus namespace for which this test fixture managed a queue.
+        /// Gets the fully-qualified name of the Azure Service Bus namespace for which this test fixture managed a queue.
         /// </summary>
         public string FullyQualifiedNamespace { get; }
 
@@ -415,18 +415,18 @@ namespace Arcus.Testing
         public OnTeardownTemporaryQueueOptions OnTeardown => _options.OnTeardown;
 
         /// <summary>
-        /// Gets the filter client to search for messages on the Azure Service bus test-managed queue (a.k.a. 'spy test fixture').
+        /// Gets the filter client to search for messages on the Azure Service Bus test-managed queue (a.k.a. 'spy test fixture').
         /// </summary>
         public ServiceBusMessageFilter Messages => new(Name, _messagingClient);
 
         /// <summary>
-        /// Creates a new instance of the <see cref="TemporaryQueue"/> which creates a new Azure Service bus queue if it doesn't exist yet.
+        /// Creates a new instance of the <see cref="TemporaryQueue"/> which creates a new Azure Service Bus queue if it doesn't exist yet.
         /// </summary>
         /// <param name="fullyQualifiedNamespace">
-        ///     The fully qualified Service bus namespace to connect to. This is likely to be similar to <c>{yournamespace}.servicebus.windows.net</c>.
+        ///     The fully qualified Service Bus namespace to connect to. This is likely to be similar to <c>{yournamespace}.servicebus.windows.net</c>.
         /// </param>
-        /// <param name="queueName">The name of the Azure Service bus queue that should be created.</param>
-        /// <param name="logger">The logger to write diagnostic messages during the lifetime of the Azure Service bus queue.</param>
+        /// <param name="queueName">The name of the Azure Service Bus queue that should be created.</param>
+        /// <param name="logger">The logger to write diagnostic messages during the lifetime of the Azure Service Bus queue.</param>
         /// <exception cref="ArgumentException">
         ///     Thrown when the <paramref name="fullyQualifiedNamespace"/> or the <paramref name="queueName"/> is blank.
         /// </exception>
@@ -436,15 +436,15 @@ namespace Arcus.Testing
         }
 
         /// <summary>
-        /// Creates a new instance of the <see cref="TemporaryQueue"/> which creates a new Azure Service bus queue if it doesn't exist yet.
+        /// Creates a new instance of the <see cref="TemporaryQueue"/> which creates a new Azure Service Bus queue if it doesn't exist yet.
         /// </summary>
         /// <param name="fullyQualifiedNamespace">
-        ///     The fully qualified Service bus namespace to connect to. This is likely to be similar to <c>{yournamespace}.servicebus.windows.net</c>.
+        ///     The fully qualified Service Bus namespace to connect to. This is likely to be similar to <c>{yournamespace}.servicebus.windows.net</c>.
         /// </param>
-        /// <param name="queueName">The name of the Azure Service bus queue that should be created.</param>
-        /// <param name="logger">The logger to write diagnostic messages during the lifetime of the Azure Service bus queue.</param>
+        /// <param name="queueName">The name of the Azure Service Bus queue that should be created.</param>
+        /// <param name="logger">The logger to write diagnostic messages during the lifetime of the Azure Service Bus queue.</param>
         /// <param name="configureOptions">
-        ///     The function to configure the additional options that describes how the Azure Service bus queue should be created.
+        ///     The function to configure the additional options that describes how the Azure Service Bus queue should be created.
         /// </param>
         /// <exception cref="ArgumentException">
         ///     Thrown when the <paramref name="fullyQualifiedNamespace"/> or the <paramref name="queueName"/> is blank.
@@ -465,14 +465,14 @@ namespace Arcus.Testing
         }
 
         /// <summary>
-        /// Creates a new instance of the <see cref="TemporaryQueue"/> which creates a new Azure Service bus queue if it doesn't exist yet.
+        /// Creates a new instance of the <see cref="TemporaryQueue"/> which creates a new Azure Service Bus queue if it doesn't exist yet.
         /// </summary>
-        /// <param name="adminClient">The administration client to interact with the Azure Service bus resource where the topic should be created.</param>
+        /// <param name="adminClient">The administration client to interact with the Azure Service Bus resource where the topic should be created.</param>
         /// <param name="messagingClient">
-        ///     The messaging client to both send and receive messages on the Azure Service bus, as well as handling setup and teardown actions.
+        ///     The messaging client to both send and receive messages on the Azure Service Bus, as well as handling setup and teardown actions.
         /// </param>
-        /// <param name="queueName">The name of the Azure Service bus queue that should be created.</param>
-        /// <param name="logger">The logger to write diagnostic messages during the lifetime of the Azure Service bus queue.</param>
+        /// <param name="queueName">The name of the Azure Service Bus queue that should be created.</param>
+        /// <param name="logger">The logger to write diagnostic messages during the lifetime of the Azure Service Bus queue.</param>
         /// <exception cref="ArgumentNullException">
         /// Thrown when the <paramref name="adminClient"/> or the <paramref name="messagingClient"/> is <c>null</c>.
         /// </exception>
@@ -487,16 +487,16 @@ namespace Arcus.Testing
         }
 
         /// <summary>
-        /// Creates a new instance of the <see cref="TemporaryQueue"/> which creates a new Azure Service bus queue if it doesn't exist yet.
+        /// Creates a new instance of the <see cref="TemporaryQueue"/> which creates a new Azure Service Bus queue if it doesn't exist yet.
         /// </summary>
-        /// <param name="adminClient">The administration client to interact with the Azure Service bus resource where the topic should be created.</param>
+        /// <param name="adminClient">The administration client to interact with the Azure Service Bus resource where the topic should be created.</param>
         /// <param name="messagingClient">
-        ///     The messaging client to both send and receive messages on the Azure Service bus, as well as handling setup and teardown actions.
+        ///     The messaging client to both send and receive messages on the Azure Service Bus, as well as handling setup and teardown actions.
         /// </param>
-        /// <param name="queueName">The name of the Azure Service bus queue that should be created.</param>
-        /// <param name="logger">The logger to write diagnostic messages during the lifetime of the Azure Service bus queue.</param>
+        /// <param name="queueName">The name of the Azure Service Bus queue that should be created.</param>
+        /// <param name="logger">The logger to write diagnostic messages during the lifetime of the Azure Service Bus queue.</param>
         /// <param name="configureOptions">
-        ///     The function to configure the additional options that describes how the Azure Service bus queue should be created.
+        ///     The function to configure the additional options that describes how the Azure Service Bus queue should be created.
         /// </param>
         /// <exception cref="ArgumentNullException">
         /// Thrown when the <paramref name="adminClient"/> or the <paramref name="messagingClient"/> is <c>null</c>.
@@ -531,7 +531,7 @@ namespace Arcus.Testing
 
             if (await adminClient.QueueExistsAsync(createOptions.Name))
             {
-                logger.LogDebug("[Test:Setup] Use already existing Azure Service bus queue '{QueueName}' in namespace '{Namespace}'", createOptions.Name, messagingClient.FullyQualifiedNamespace);
+                logger.LogDebug("[Test:Setup] Use already existing Azure Service Bus queue '{QueueName}' in namespace '{Namespace}'", createOptions.Name, messagingClient.FullyQualifiedNamespace);
                 var queue = new TemporaryQueue(adminClient, messagingClient, createOptions.Name, queueCreatedByUs: false, messagingClientCreatedByUs, options, logger);
 
                 await queue.CleanOnSetupAsync();
@@ -539,7 +539,7 @@ namespace Arcus.Testing
             }
             else
             {
-                logger.LogDebug("[Test:Setup] Create new Azure Service bus queue '{Queue}' in namespace '{Namespace}'", createOptions.Name, messagingClient.FullyQualifiedNamespace);
+                logger.LogDebug("[Test:Setup] Create new Azure Service Bus queue '{Queue}' in namespace '{Namespace}'", createOptions.Name, messagingClient.FullyQualifiedNamespace);
                 await adminClient.CreateQueueAsync(createOptions);
 
                 var queue = new TemporaryQueue(adminClient, messagingClient, createOptions.Name, queueCreatedByUs: true, messagingClientCreatedByUs, options, logger);
@@ -562,12 +562,12 @@ namespace Arcus.Testing
                 MessageSettle settle = _options.OnSetup.DetermineMessageSettle(message);
                 if (settle is MessageSettle.DeadLetter)
                 {
-                    _logger.LogDebug("[Test:Setup] Dead-letter Azure Service bus message '{MessageId}' from queue '{QueueName}' in namespace '{Namespace}'", message.MessageId, Name, FullyQualifiedNamespace);
+                    _logger.LogDebug("[Test:Setup] Dead-letter Azure Service Bus message '{MessageId}' from queue '{QueueName}' in namespace '{Namespace}'", message.MessageId, Name, FullyQualifiedNamespace);
                     await receiver.DeadLetterMessageAsync(message);
                 }
                 else if (settle is MessageSettle.Complete)
                 {
-                    _logger.LogDebug("[Test:Setup] Complete Azure Service bus message '{MessageId}' from queue '{QueueName}' in namespace '{Namespace}'", message.MessageId, Name, FullyQualifiedNamespace);
+                    _logger.LogDebug("[Test:Setup] Complete Azure Service Bus message '{MessageId}' from queue '{QueueName}' in namespace '{Namespace}'", message.MessageId, Name, FullyQualifiedNamespace);
                     await receiver.CompleteMessageAsync(message);
                 }
             });
@@ -587,7 +587,7 @@ namespace Arcus.Testing
                 {
                     disposables.Add(AsyncDisposable.Create(async () =>
                     {
-                        _logger.LogDebug("[Test:Teardown] Delete Azure Service bus queue '{QueueName}' in namespace '{Namespace}'", Name, FullyQualifiedNamespace);
+                        _logger.LogDebug("[Test:Teardown] Delete Azure Service Bus queue '{QueueName}' in namespace '{Namespace}'", Name, FullyQualifiedNamespace);
                         await _adminClient.DeleteQueueAsync(Name);
                     }));
                 }
@@ -614,12 +614,12 @@ namespace Arcus.Testing
                 MessageSettle settle = _options.OnTeardown.DetermineMessageSettle(message, receiver, _logger);
                 if (settle is MessageSettle.DeadLetter)
                 {
-                    _logger.LogDebug("[Test:Teardown] Dead-letter Azure Service bus message '{MessageId}' from queue '{QueueName}' in namespace '{Namespace}'", message.MessageId, Name, FullyQualifiedNamespace);
+                    _logger.LogDebug("[Test:Teardown] Dead-letter Azure Service Bus message '{MessageId}' from queue '{QueueName}' in namespace '{Namespace}'", message.MessageId, Name, FullyQualifiedNamespace);
                     await receiver.DeadLetterMessageAsync(message);
                 }
                 else if (settle is MessageSettle.Complete)
                 {
-                    _logger.LogDebug("[Test:Teardown] Complete Azure Service bus message '{MessageId}' from queue '{QueueName}' in namespace '{Namespace}'", message.MessageId, Name, FullyQualifiedNamespace);
+                    _logger.LogDebug("[Test:Teardown] Complete Azure Service Bus message '{MessageId}' from queue '{QueueName}' in namespace '{Namespace}'", message.MessageId, Name, FullyQualifiedNamespace);
                     await receiver.CompleteMessageAsync(message);
                 }
             });

--- a/src/Arcus.Testing.Messaging.ServiceBus/TemporaryTopic.cs
+++ b/src/Arcus.Testing.Messaging.ServiceBus/TemporaryTopic.cs
@@ -317,7 +317,7 @@ namespace Arcus.Testing
 
             if (shouldDeadLetter && shouldComplete)
             {
-                logger.LogWarning("[Test:Teardown] Service bus message '{MessageId}' matches both for dead-letter as completion in custom message filters, uses dead-letter, from topic subscription '{TopicSubscriptionName}' in namespace '{Namespace}'", message.MessageId, receiver.EntityPath, receiver.FullyQualifiedNamespace);
+                logger.LogWarning("[Test:Teardown] Service Bus message '{MessageId}' matches both for dead-letter as completion in custom message filters, uses dead-letter, from topic subscription '{TopicSubscriptionName}' in namespace '{Namespace}'", message.MessageId, receiver.EntityPath, receiver.FullyQualifiedNamespace);
                 return MessageSettle.DeadLetter;
             }
 
@@ -401,19 +401,19 @@ namespace Arcus.Testing
         public string Name { get; }
 
         /// <summary>
-        /// Gets the fully-qualified name of the Azure Service bus namespace for which this test fixture managed a topic.
+        /// Gets the fully-qualified name of the Azure Service Bus namespace for which this test fixture managed a topic.
         /// </summary>
         public string FullyQualifiedNamespace { get; }
 
         /// <summary>
-        /// Gets the client to send messages to this Azure Service bus test-managed topic.
+        /// Gets the client to send messages to this Azure Service Bus test-managed topic.
         /// </summary>
         public ServiceBusSender Sender { get; }
 
         /// <summary>
-        /// creates a filter topic subscription client to search for messages on the Azure Service bus test-managed topic (a.k.a. 'spy test fixture').
+        /// creates a filter topic subscription client to search for messages on the Azure Service Bus test-managed topic (a.k.a. 'spy test fixture').
         /// </summary>
-        /// <param name="subscriptionName">The subscription specific to the test-managed Azure Service bus topic to create a filter for.</param>
+        /// <param name="subscriptionName">The subscription specific to the test-managed Azure Service Bus topic to create a filter for.</param>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="subscriptionName"/> is blank.</exception>
         public ServiceBusMessageFilter MessagesOn(string subscriptionName) => new(Name, subscriptionName, _messagingClient);
 
@@ -467,7 +467,7 @@ namespace Arcus.Testing
         /// </summary>
         /// <param name="adminClient">The administration client to interact with the Azure Service Bus resource where the topic should be created.</param>
         /// <param name="messagingClient">
-        ///     The messaging client to both send and receive messages on the Azure Service bus, as well as handling setup and teardown actions.
+        ///     The messaging client to both send and receive messages on the Azure Service Bus, as well as handling setup and teardown actions.
         /// </param>
         /// <param name="topicName">The name of the Azure Service Bus topic that should be created.</param>
         /// <param name="logger">The logger to write diagnostic messages during the lifetime of the Azure Service Bus topic.</param>
@@ -487,7 +487,7 @@ namespace Arcus.Testing
         /// </summary>
         /// <param name="adminClient">The administration client to interact with the Azure Service Bus resource where the topic should be created.</param>
         /// <param name="messagingClient">
-        ///     The messaging client to both send and receive messages on the Azure Service bus, as well as handling setup and teardown actions.
+        ///     The messaging client to both send and receive messages on the Azure Service Bus, as well as handling setup and teardown actions.
         /// </param>
         /// <param name="topicName">The name of the Azure Service Bus topic that should be created.</param>
         /// <param name="logger">The logger to write diagnostic messages during the lifetime of the Azure Service Bus topic.</param>
@@ -557,12 +557,12 @@ namespace Arcus.Testing
 
                 if (settle is MessageSettle.DeadLetter)
                 {
-                    _logger.LogDebug("[Test:Setup] Dead-letter Azure Service bus message '{MessageId}' from topic subscription '{TopicSubscriptionName}' in namespace '{Namespace}'", message.MessageId, receiver.EntityPath, FullyQualifiedNamespace);
+                    _logger.LogDebug("[Test:Setup] Dead-letter Azure Service Bus message '{MessageId}' from topic subscription '{TopicSubscriptionName}' in namespace '{Namespace}'", message.MessageId, receiver.EntityPath, FullyQualifiedNamespace);
                     await receiver.DeadLetterMessageAsync(message);
                 }
                 else if (settle is MessageSettle.Complete)
                 {
-                    _logger.LogDebug("[Test:Setup] Complete Azure Service bus message '{MessageId}' from topic subscription '{TopicSubscriptionName}' in namespace '{Namespace}'", message.MessageId, receiver.EntityPath, FullyQualifiedNamespace);
+                    _logger.LogDebug("[Test:Setup] Complete Azure Service Bus message '{MessageId}' from topic subscription '{TopicSubscriptionName}' in namespace '{Namespace}'", message.MessageId, receiver.EntityPath, FullyQualifiedNamespace);
                     await receiver.CompleteMessageAsync(message);
                 }
             });
@@ -632,12 +632,12 @@ namespace Arcus.Testing
 
                 if (settle is MessageSettle.DeadLetter)
                 {
-                    _logger.LogDebug("[Test:Teardown] Dead-letter Azure Service bus message '{MessageId}' from topic subscription '{TopicSubscriptionName}' in namespace '{Namespace}'", message.MessageId, receiver.EntityPath, FullyQualifiedNamespace);
+                    _logger.LogDebug("[Test:Teardown] Dead-letter Azure Service Bus message '{MessageId}' from topic subscription '{TopicSubscriptionName}' in namespace '{Namespace}'", message.MessageId, receiver.EntityPath, FullyQualifiedNamespace);
                     await receiver.DeadLetterMessageAsync(message);
                 }
                 else if (settle is MessageSettle.Complete)
                 {
-                    _logger.LogDebug("[Test:Teardown] Complete Azure Service bus message '{MessageId}' from topic subscription '{TopicSubscriptionName}' in namespace '{Namespace}'", message.MessageId, receiver.EntityPath, FullyQualifiedNamespace);
+                    _logger.LogDebug("[Test:Teardown] Complete Azure Service Bus message '{MessageId}' from topic subscription '{TopicSubscriptionName}' in namespace '{Namespace}'", message.MessageId, receiver.EntityPath, FullyQualifiedNamespace);
                     await receiver.CompleteMessageAsync(message);
                 }
             });

--- a/src/Arcus.Testing.Messaging.ServiceBus/TemporaryTopic.cs
+++ b/src/Arcus.Testing.Messaging.ServiceBus/TemporaryTopic.cs
@@ -317,7 +317,7 @@ namespace Arcus.Testing
 
             if (shouldDeadLetter && shouldComplete)
             {
-                logger.LogWarning("[Test:Teardown] Service Bus message '{MessageId}' matches both for dead-letter as completion in custom message filters, uses dead-letter, from topic subscription '{TopicSubscriptionName}' in namespace '{Namespace}'", message.MessageId, receiver.EntityPath, receiver.FullyQualifiedNamespace);
+                logger.LogWarning("[Test:Teardown] Service Bus message '{MessageId}' matches both for dead-letter as completion in custom message filters, uses dead-letter, happening in topic '{Namespace}/{TopicName}'", message.MessageId, receiver.FullyQualifiedNamespace, receiver.EntityPath);
                 return MessageSettle.DeadLetter;
             }
 


### PR DESCRIPTION
Use 'Service Bus' instead of 'Service bus' everywhere in the test fixtures (except the topic subscription, as that is done in #415).

Follow-up of #201 