### PR TITLE
chore(az.storage): use microsoft naming for az storage account

### DIFF
--- a/docs/preview/03-Features/04-Azure/04-Storage/01-storage-account.mdx
+++ b/docs/preview/03-Features/04-Azure/04-Storage/01-storage-account.mdx
@@ -6,7 +6,7 @@ import TabItem from '@theme/TabItem';
 <Tabs groupId="storage-systems">
 <TabItem value="blob" label="Blob storage" default>
 
-The `Arcus.Testing.Storage.Blob` package provides test fixtures related to Azure Blob storage. By using the common testing practice 'clean environment', it provides a temporary Blob container and Blob file.
+The `Arcus.Testing.Storage.Blob` package provides test fixtures related to Azure Blob Storage. By using the common testing practice 'clean environment', it provides a temporary Blob container and Blob file.
 
 ## Installation
 The following functionality is available when installing this package:
@@ -121,7 +121,7 @@ BlobClient client = file.Client;
 </TabItem>
 <TabItem value="table" label="Table storage">
 
-The `Arcus.Testing.Storage.Table` package provides test fixtures related to Azure Table storage. By using the common testing practice 'clean environment', it provides a temporary Table and Table entity.
+The `Arcus.Testing.Storage.Table` package provides test fixtures related to Azure Table Storage. By using the common testing practice 'clean environment', it provides a temporary Table and Table entity.
 
 ## Installation
 The following functionality is available when installing this package:
@@ -147,7 +147,7 @@ await using var table = await TemporaryTable.CreateIfNotExistsAsync(
 TableClient client = table.Client;
 ```
 
-> 🎖️ Overloads are available to fully control the authentication mechanism to Azure Table storage. By default, it uses the [`DefaultAzureCredential`](https://learn.microsoft.com/en-us/dotnet/api/azure.identity.defaultazurecredential).
+> 🎖️ Overloads are available to fully control the authentication mechanism to Azure Table Storage. By default, it uses the [`DefaultAzureCredential`](https://learn.microsoft.com/en-us/dotnet/api/azure.identity.defaultazurecredential).
 
 Upserting entities to the table can also be done via the test fixture. It always make sure that any added entities will be removed/reverted afterwards upon disposal.
 
@@ -224,12 +224,12 @@ await using var entity = await TemporaryTableEntity.UpsertEntityAsync(
     "<account-name>", "<table-name>", entity, logger);
 ```
 
-> 🎖️ Overloads are available to fully control the authentication mechanism to Azure Table storage. By default, it uses the [`DefaultAzureCredential`](https://learn.microsoft.com/en-us/dotnet/api/azure.identity.defaultazurecredential).
+> 🎖️ Overloads are available to fully control the authentication mechanism to Azure Table Storage. By default, it uses the [`DefaultAzureCredential`](https://learn.microsoft.com/en-us/dotnet/api/azure.identity.defaultazurecredential).
 
 </TabItem>
 <TabItem value="file-share" label="File share storage">
 
-The `Arcus.Testing.Storage.File.Share` package provides test fixtures related to Azure File share storage. By using the common testing practice 'clean environment', it provides a temporary Share directory and Share file.
+The `Arcus.Testing.Storage.File.Share` package provides test fixtures related to Azure Files share storage. By using the common testing practice 'clean environment', it provides a temporary Share directory and Share file.
 
 ## Installation
 The following functionality is available when installing this package:

--- a/docs/versioned_docs/version-v2.0.0/03-Features/04-Azure/04-Storage/01-storage-account.mdx
+++ b/docs/versioned_docs/version-v2.0.0/03-Features/04-Azure/04-Storage/01-storage-account.mdx
@@ -6,7 +6,7 @@ import TabItem from '@theme/TabItem';
 <Tabs groupId="storage-systems">
 <TabItem value="blob" label="Blob storage" default>
 
-The `Arcus.Testing.Storage.Blob` package provides test fixtures related to Azure Blob storage. By using the common testing practice 'clean environment', it provides a temporary Blob container and Blob file.
+The `Arcus.Testing.Storage.Blob` package provides test fixtures related to Azure Blob Storage. By using the common testing practice 'clean environment', it provides a temporary Blob container and Blob file.
 
 ## Installation
 The following functionality is available when installing this package:
@@ -121,7 +121,7 @@ BlobClient client = file.Client;
 </TabItem>
 <TabItem value="table" label="Table storage">
 
-The `Arcus.Testing.Storage.Table` package provides test fixtures related to Azure Table storage. By using the common testing practice 'clean environment', it provides a temporary Table and Table entity.
+The `Arcus.Testing.Storage.Table` package provides test fixtures related to Azure Table Storage. By using the common testing practice 'clean environment', it provides a temporary Table and Table entity.
 
 ## Installation
 The following functionality is available when installing this package:
@@ -147,7 +147,7 @@ await using var table = await TemporaryTable.CreateIfNotExistsAsync(
 TableClient client = table.Client;
 ```
 
-> 🎖️ Overloads are available to fully control the authentication mechanism to Azure Table storage. By default, it uses the [`DefaultAzureCredential`](https://learn.microsoft.com/en-us/dotnet/api/azure.identity.defaultazurecredential).
+> 🎖️ Overloads are available to fully control the authentication mechanism to Azure Table Storage. By default, it uses the [`DefaultAzureCredential`](https://learn.microsoft.com/en-us/dotnet/api/azure.identity.defaultazurecredential).
 
 Upserting entities to the table can also be done via the test fixture. It always make sure that any added entities will be removed/reverted afterwards upon disposal.
 
@@ -224,12 +224,12 @@ await using var entity = await TemporaryTableEntity.UpsertEntityAsync(
     "<account-name>", "<table-name>", entity, logger);
 ```
 
-> 🎖️ Overloads are available to fully control the authentication mechanism to Azure Table storage. By default, it uses the [`DefaultAzureCredential`](https://learn.microsoft.com/en-us/dotnet/api/azure.identity.defaultazurecredential).
+> 🎖️ Overloads are available to fully control the authentication mechanism to Azure Table Storage. By default, it uses the [`DefaultAzureCredential`](https://learn.microsoft.com/en-us/dotnet/api/azure.identity.defaultazurecredential).
 
 </TabItem>
 <TabItem value="file-share" label="File share storage">
 
-The `Arcus.Testing.Storage.File.Share` package provides test fixtures related to Azure File share storage. By using the common testing practice 'clean environment', it provides a temporary Share directory and Share file.
+The `Arcus.Testing.Storage.File.Share` package provides test fixtures related to Azure Files share storage. By using the common testing practice 'clean environment', it provides a temporary Share directory and Share file.
 
 ## Installation
 The following functionality is available when installing this package:

--- a/docs/versioned_docs/version-v2.1.0/03-Features/04-Azure/04-Storage/01-storage-account.mdx
+++ b/docs/versioned_docs/version-v2.1.0/03-Features/04-Azure/04-Storage/01-storage-account.mdx
@@ -6,7 +6,7 @@ import TabItem from '@theme/TabItem';
 <Tabs groupId="storage-systems">
 <TabItem value="blob" label="Blob storage" default>
 
-The `Arcus.Testing.Storage.Blob` package provides test fixtures related to Azure Blob storage. By using the common testing practice 'clean environment', it provides a temporary Blob container and Blob file.
+The `Arcus.Testing.Storage.Blob` package provides test fixtures related to Azure Blob Storage. By using the common testing practice 'clean environment', it provides a temporary Blob container and Blob file.
 
 ## Installation
 The following functionality is available when installing this package:
@@ -121,7 +121,7 @@ BlobClient client = file.Client;
 </TabItem>
 <TabItem value="table" label="Table storage">
 
-The `Arcus.Testing.Storage.Table` package provides test fixtures related to Azure Table storage. By using the common testing practice 'clean environment', it provides a temporary Table and Table entity.
+The `Arcus.Testing.Storage.Table` package provides test fixtures related to Azure Table Storage. By using the common testing practice 'clean environment', it provides a temporary Table and Table entity.
 
 ## Installation
 The following functionality is available when installing this package:
@@ -147,7 +147,7 @@ await using var table = await TemporaryTable.CreateIfNotExistsAsync(
 TableClient client = table.Client;
 ```
 
-> 🎖️ Overloads are available to fully control the authentication mechanism to Azure Table storage. By default, it uses the [`DefaultAzureCredential`](https://learn.microsoft.com/en-us/dotnet/api/azure.identity.defaultazurecredential).
+> 🎖️ Overloads are available to fully control the authentication mechanism to Azure Table Storage. By default, it uses the [`DefaultAzureCredential`](https://learn.microsoft.com/en-us/dotnet/api/azure.identity.defaultazurecredential).
 
 Upserting entities to the table can also be done via the test fixture. It always make sure that any added entities will be removed/reverted afterwards upon disposal.
 
@@ -224,12 +224,12 @@ await using var entity = await TemporaryTableEntity.UpsertEntityAsync(
     "<account-name>", "<table-name>", entity, logger);
 ```
 
-> 🎖️ Overloads are available to fully control the authentication mechanism to Azure Table storage. By default, it uses the [`DefaultAzureCredential`](https://learn.microsoft.com/en-us/dotnet/api/azure.identity.defaultazurecredential).
+> 🎖️ Overloads are available to fully control the authentication mechanism to Azure Table Storage. By default, it uses the [`DefaultAzureCredential`](https://learn.microsoft.com/en-us/dotnet/api/azure.identity.defaultazurecredential).
 
 </TabItem>
 <TabItem value="file-share" label="File share storage">
 
-The `Arcus.Testing.Storage.File.Share` package provides test fixtures related to Azure File share storage. By using the common testing practice 'clean environment', it provides a temporary Share directory and Share file.
+The `Arcus.Testing.Storage.File.Share` package provides test fixtures related to Azure Files share storage. By using the common testing practice 'clean environment', it provides a temporary Share directory and Share file.
 
 ## Installation
 The following functionality is available when installing this package:

--- a/src/Arcus.Testing.Storage.Blob/TemporaryBlobContainer.cs
+++ b/src/Arcus.Testing.Storage.Blob/TemporaryBlobContainer.cs
@@ -262,7 +262,7 @@ namespace Arcus.Testing
         public OnTeardownBlobContainerOptions OnTeardown => _options.OnTeardown;
 
         /// <summary>
-        /// Creates a new instance of the <see cref="TemporaryBlobContainer"/> which creates a new Azure Blob storage container if it doesn't exist yet.
+        /// Creates a new instance of the <see cref="TemporaryBlobContainer"/> which creates a new Azure Blob Storage container if it doesn't exist yet.
         /// </summary>
         /// <param name="accountName">The name of the Azure Storage account to create the temporary Azure Blob container in.</param>
         /// <param name="containerName">The name of the Azure Blob container to create.</param>
@@ -274,7 +274,7 @@ namespace Arcus.Testing
         }
 
         /// <summary>
-        /// Creates a new instance of the <see cref="TemporaryBlobContainer"/> which creates a new Azure Blob storage container if it doesn't exist yet.
+        /// Creates a new instance of the <see cref="TemporaryBlobContainer"/> which creates a new Azure Blob Storage container if it doesn't exist yet.
         /// </summary>
         /// <param name="accountName">The name of the Azure Storage account to create the temporary Azure Blob container in.</param>
         /// <param name="containerName">The name of the Azure Blob container to create.</param>
@@ -297,9 +297,9 @@ namespace Arcus.Testing
         }
 
         /// <summary>
-        /// Creates a new instance of the <see cref="TemporaryBlobContainer"/> which creates a new Azure Blob storage container if it doesn't exist yet.
+        /// Creates a new instance of the <see cref="TemporaryBlobContainer"/> which creates a new Azure Blob Storage container if it doesn't exist yet.
         /// </summary>
-        /// <param name="containerClient">The client to interact with the Azure Blob storage container.</param>
+        /// <param name="containerClient">The client to interact with the Azure Blob Storage container.</param>
         /// <param name="logger">The logger to write diagnostic messages during the creation of the Azure Blob container.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="containerClient"/> is <c>null</c>.</exception>
         public static async Task<TemporaryBlobContainer> CreateIfNotExistsAsync(BlobContainerClient containerClient, ILogger logger)
@@ -308,9 +308,9 @@ namespace Arcus.Testing
         }
 
         /// <summary>
-        /// Creates a new instance of the <see cref="TemporaryBlobContainer"/> which creates a new Azure Blob storage container if it doesn't exist yet.
+        /// Creates a new instance of the <see cref="TemporaryBlobContainer"/> which creates a new Azure Blob Storage container if it doesn't exist yet.
         /// </summary>
-        /// <param name="containerClient">The client to interact with the Azure Blob storage container.</param>
+        /// <param name="containerClient">The client to interact with the Azure Blob Storage container.</param>
         /// <param name="logger">The logger to write diagnostic messages during the creation of the Azure Blob container.</param>
         /// <param name="configureOptions">The additional options to manipulate the behavior of the test fixture during its lifetime.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="containerClient"/> is <c>null</c>.</exception>

--- a/src/Arcus.Testing.Storage.Blob/TemporaryBlobFile.cs
+++ b/src/Arcus.Testing.Storage.Blob/TemporaryBlobFile.cs
@@ -51,7 +51,7 @@ namespace Arcus.Testing
         /// Uploads a temporary blob to the Azure Blob container.
         /// </summary>
         /// <remarks>
-        ///     Uses <see cref="DefaultAzureCredential"/> to authenticate with Azure Blob storage.
+        ///     Uses <see cref="DefaultAzureCredential"/> to authenticate with Azure Blob Storage.
         /// </remarks>
         /// <param name="blobContainerUri">
         ///     A <see cref="BlobContainerClient.Uri" /> referencing the blob container that includes the name of the account and the name of the container.
@@ -71,7 +71,7 @@ namespace Arcus.Testing
         /// <summary>
         /// Uploads a temporary blob to the Azure Blob container.
         /// </summary>
-        /// <param name="blobClient">The Azure Blob client to interact with Azure Blob storage.</param>
+        /// <param name="blobClient">The Azure Blob client to interact with Azure Blob Storage.</param>
         /// <param name="blobContent">The content of the blob to upload.</param>
         /// <param name="logger">The logger to write diagnostic messages during the upload process.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="blobClient"/> or the <paramref name="blobContent"/> is <c>null</c>.</exception>
@@ -85,10 +85,10 @@ namespace Arcus.Testing
         /// Creates a new or replaces an existing Azure Blob file in an Azure Blob container.
         /// </summary>
         /// <remarks>
-        ///     <para>⚡ Uses <see cref="DefaultAzureCredential"/> to authenticate with Azure Blob storage.</para>
+        ///     <para>⚡ Uses <see cref="DefaultAzureCredential"/> to authenticate with Azure Blob Storage.</para>
         ///     <para>⚡ File will be deleted (if new) or reverted (if existing) when the <see cref="TemporaryBlobFile"/> is disposed.</para>
         /// </remarks>
-        /// <param name="blobClient">The Azure Blob client to interact with Azure Blob storage.</param>
+        /// <param name="blobClient">The Azure Blob client to interact with Azure Blob Storage.</param>
         /// <param name="blobContent">The content of the blob to upload.</param>
         /// <param name="logger">The logger to write diagnostic messages during the upload process.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="blobClient"/> or the <paramref name="blobContent"/> is <c>null</c>.</exception>
@@ -107,7 +107,7 @@ namespace Arcus.Testing
         /// Creates a new or replaces an existing Azure Blob file in an Azure Blob container.
         /// </summary>
         /// <remarks>
-        ///     <para>⚡ Uses <see cref="DefaultAzureCredential"/> to authenticate with Azure Blob storage.</para>
+        ///     <para>⚡ Uses <see cref="DefaultAzureCredential"/> to authenticate with Azure Blob Storage.</para>
         ///     <para>⚡ File will be deleted (if new) or reverted (if existing) when the <see cref="TemporaryBlobFile"/> is disposed.</para>
         /// </remarks>
         /// <param name="blobContainerUri">

--- a/src/Arcus.Testing.Storage.File.Share/TemporaryShareDirectory.cs
+++ b/src/Arcus.Testing.Storage.File.Share/TemporaryShareDirectory.cs
@@ -57,7 +57,7 @@ namespace Arcus.Testing
 
             if (Array.Exists(filters, f => f is null))
             {
-                throw new ArgumentException("Requires all provided Azure File share item filters to be non-null", nameof(filters));
+                throw new ArgumentException("Requires all provided Azure Files share item filters to be non-null", nameof(filters));
             }
 
             _filters.AddRange(filters);
@@ -114,7 +114,7 @@ namespace Arcus.Testing
 
             if (Array.Exists(filters, f => f is null))
             {
-                throw new ArgumentException("Requires all provided Azure File share item filters to be non-null", nameof(filters));
+                throw new ArgumentException("Requires all provided Azure Files share item filters to be non-null", nameof(filters));
             }
 
             _filters.AddRange(filters);
@@ -146,7 +146,7 @@ namespace Arcus.Testing
     }
 
     /// <summary>
-    /// Represents a temporary directory share on an Azure Storage file share.
+    /// Represents a temporary directory share on an Azure Files share.
     /// </summary>
     public class TemporaryShareDirectory : IAsyncDisposable
     {
@@ -171,7 +171,7 @@ namespace Arcus.Testing
         }
 
         /// <summary>
-        /// Represents the client to interact with the temporary stored Azure Storage file share currently in storage.
+        /// Represents the client to interact with the temporary stored Azure Files share currently in storage.
         /// </summary>
         public ShareDirectoryClient Client { get; }
 
@@ -181,9 +181,9 @@ namespace Arcus.Testing
         public OnTeardownTemporaryShareDirectoryOptions OnTeardown => _options.OnTeardown;
 
         /// <summary>
-        /// Creates a temporary directory share on an Azure Storage file share resource.
+        /// Creates a temporary directory share on an Azure Files share resource.
         /// </summary>
-        /// <param name="shareClient">The client to interact with the Azure File share resource.</param>
+        /// <param name="shareClient">The client to interact with the Azure Files resource.</param>
         /// <param name="directoryName">The name of the directory to create on the file share.</param>
         /// <param name="logger">The logger instance to write diagnostic traces during the lifetime of the fixture.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="shareClient"/> is <c>null</c>.</exception>
@@ -194,9 +194,9 @@ namespace Arcus.Testing
         }
 
         /// <summary>
-        /// Creates a temporary directory share on an Azure Storage file share resource.
+        /// Creates a temporary directory share on an Azure Files share resource.
         /// </summary>
-        /// <param name="shareClient">The client to interact with the Azure File share resource.</param>
+        /// <param name="shareClient">The client to interact with the Azure Files share resource.</param>
         /// <param name="directoryName">The name of the directory to create on the file share.</param>
         /// <param name="logger">The logger instance to write diagnostic traces during the lifetime of the fixture.</param>
         /// <param name="configureOptions">The additional options to manipulate the behavior of the test fixture during its lifetime.</param>
@@ -216,9 +216,9 @@ namespace Arcus.Testing
         }
 
         /// <summary>
-        /// Creates a temporary directory share on an Azure Storage file share resource.
+        /// Creates a temporary directory share on an Azure Files share resource.
         /// </summary>
-        /// <param name="directoryClient">The client to interact with the directory share in the Azure File share resource.</param>
+        /// <param name="directoryClient">The client to interact with the directory share in the Azure Files share resource.</param>
         /// <param name="logger">The logger instance to write diagnostic traces during the lifetime of the fixture.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="directoryClient"/> is <c>null</c>.</exception>
         public static async Task<TemporaryShareDirectory> CreateIfNotExistsAsync(ShareDirectoryClient directoryClient, ILogger logger)
@@ -227,9 +227,9 @@ namespace Arcus.Testing
         }
 
         /// <summary>
-        /// Creates a temporary directory share on an Azure Storage file share resource.
+        /// Creates a temporary directory share on an Azure Files share resource.
         /// </summary>
-        /// <param name="directoryClient">The client to interact with the directory share in the Azure File share resource.</param>
+        /// <param name="directoryClient">The client to interact with the directory share in the Azure Files share resource.</param>
         /// <param name="logger">The logger instance to write diagnostic traces during the lifetime of the fixture.</param>
         /// <param name="configureOptions">The additional options to manipulate the behavior of the test fixture during its lifetime.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="directoryClient"/> is <c>null</c>.</exception>
@@ -246,7 +246,7 @@ namespace Arcus.Testing
 
             if (await directoryClient.ExistsAsync())
             {
-                logger.LogTrace("[Test:Setup] Use already existing Azure File share directory '{DirectoryName}' at '{AccountName}/{DirectoryPath}'", directoryClient.Name, directoryClient.AccountName, directoryClient.Path);
+                logger.LogTrace("[Test:Setup] Use already existing Azure Files share directory '{DirectoryName}' at '{AccountName}/{DirectoryPath}'", directoryClient.Name, directoryClient.AccountName, directoryClient.Path);
                 await CleanDirectoryOnSetupAsync(directoryClient, options, logger);
 
                 return new TemporaryShareDirectory(directoryClient, createdByUs: false, options, logger);
@@ -254,15 +254,15 @@ namespace Arcus.Testing
 
             try
             {
-                logger.LogTrace("[Test:Setup] Create new Azure File share directory '{DirectoryName}' at '{AccountName}/{DirectoryPath}'", directoryClient.Name, directoryClient.AccountName, directoryClient.Path);
+                logger.LogTrace("[Test:Setup] Create new Azure Files share directory '{DirectoryName}' at '{AccountName}/{DirectoryPath}'", directoryClient.Name, directoryClient.AccountName, directoryClient.Path);
                 await directoryClient.CreateAsync();
             }
             catch (RequestFailedException exception) when (exception.ErrorCode == ShareErrorCode.ShareNotFound)
             {
                 throw new DriveNotFoundException(
-                    $"[Test:Setup] Cannot create a new Azure File share directory '{directoryClient.Name}' at '{directoryClient.AccountName}/{directoryClient.Path}' " +
+                    $"[Test:Setup] Cannot create a new Azure Files share directory '{directoryClient.Name}' at '{directoryClient.AccountName}/{directoryClient.Path}' " +
                     $"because the share '{directoryClient.ShareName}' does not exists in account '{directoryClient.AccountName}'; " +
-                    $"please make sure to use an existing Azure File share to create a temporary directory test fixture",
+                    $"please make sure to use an existing Azure Files share to create a temporary directory test fixture",
                     exception);
             }
 
@@ -316,7 +316,7 @@ namespace Arcus.Testing
 
                 disposables.Add(AsyncDisposable.Create(async () =>
                 {
-                    _logger.LogTrace("[Test:Teardown] Delete Azure File share directory '{DirectoryName}' at '{AccountName}/{DirectoryPath}'", Client.Name, Client.AccountName, Client.Path);
+                    _logger.LogTrace("[Test:Teardown] Delete Azure Files share directory '{DirectoryName}' at '{AccountName}/{DirectoryPath}'", Client.Name, Client.AccountName, Client.Path);
                     await Client.DeleteAsync();
                 }));
             }
@@ -368,7 +368,7 @@ namespace Arcus.Testing
                         {
                             await DeleteAllDirectoryContentsAsync(sub, state, logger);
 
-                            logger.LogTrace("[Test:{State}] Delete Azure File share directory '{DirectoryName}' at '{AccountName}/{DirectoryPath}'", state, sub.Name, sub.AccountName, sub.Path);
+                            logger.LogTrace("[Test:{State}] Delete Azure Files share directory '{DirectoryName}' at '{AccountName}/{DirectoryPath}'", state, sub.Name, sub.AccountName, sub.Path);
                             await sub.DeleteIfExistsAsync();
                         }
                         else
@@ -380,7 +380,7 @@ namespace Arcus.Testing
                     {
                         ShareFileClient file = current.GetFileClient(item.Name);
 
-                        logger.LogTrace("[Test:{State}] Delete Azure File share item '{FileName}' at '{AccountName}/{FilePath}'", state, file.Name, file.AccountName, file.Path);
+                        logger.LogTrace("[Test:{State}] Delete Azure Files share item '{FileName}' at '{AccountName}/{FilePath}'", state, file.Name, file.AccountName, file.Path);
                         await file.DeleteIfExistsAsync();
                     }
                 }

--- a/src/Arcus.Testing.Storage.File.Share/TemporaryShareFile.cs
+++ b/src/Arcus.Testing.Storage.File.Share/TemporaryShareFile.cs
@@ -10,7 +10,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 namespace Arcus.Testing
 {
     /// <summary>
-    /// Represents a file that is temporary available on an Azure Storage file share directory.
+    /// Represents a file that is temporary available on an Azure Files share directory.
     /// </summary>
     public class TemporaryShareFile : IAsyncDisposable
     {
@@ -31,12 +31,12 @@ namespace Arcus.Testing
         }
 
         /// <summary>
-        /// Gets the client to interact with the temporary stored Azure Storage file share currently in storage.
+        /// Gets the client to interact with the temporary stored Azure Files share currently in storage.
         /// </summary>
         public ShareFileClient Client { get; }
 
         /// <summary>
-        /// Creates a new or replaces an existing file on an Azure Storage file share directory.
+        /// Creates a new or replaces an existing file on an Azure Files share directory.
         /// </summary>
         /// <remarks>
         ///     Make sure that the <paramref name="fileContents"/>'s <see cref="Stream.Length"/> is accessible,
@@ -58,7 +58,7 @@ namespace Arcus.Testing
         }
 
         /// <summary>
-        /// Creates a new or replaces an existing file on an Azure Storage file share directory.
+        /// Creates a new or replaces an existing file on an Azure Files share directory.
         /// </summary>
         /// <remarks>
         ///     Make sure that the <paramref name="fileStream"/>'s <see cref="Stream.Length"/> is accessible,
@@ -76,7 +76,7 @@ namespace Arcus.Testing
 
             if (await fileClient.ExistsAsync())
             {
-                logger.LogTrace("[Test:Setup] Replace already existing Azure File share file '{FileName}' in directory '{AccountName}/{FilePath}'", fileClient.Name, fileClient.AccountName, fileClient.Path);
+                logger.LogTrace("[Test:Setup] Replace already existing Azure Files share file '{FileName}' in directory '{AccountName}/{FilePath}'", fileClient.Name, fileClient.AccountName, fileClient.Path);
 
                 ShareFileDownloadInfo result = await fileClient.DownloadAsync();
                 await fileClient.CreateAsync(fileStream.Length);
@@ -87,24 +87,24 @@ namespace Arcus.Testing
 
             try
             {
-                logger.LogTrace("[Test:Setup] Upload Azure File share file '{FileName}' in directory '{AccountName}/{FilePath}'", fileClient.Name, fileClient.AccountName, fileClient.Path);
+                logger.LogTrace("[Test:Setup] Upload Azure Files share file '{FileName}' in directory '{AccountName}/{FilePath}'", fileClient.Name, fileClient.AccountName, fileClient.Path);
                 await fileClient.CreateAsync(fileStream.Length);
                 await fileClient.UploadAsync(fileStream);
             }
             catch (RequestFailedException exception) when (exception.ErrorCode == ShareErrorCode.ShareNotFound)
             {
                 throw new DriveNotFoundException(
-                    $"[Test:Setup] Cannot upload a new Azure File share file '{fileClient.Name}' at '{fileClient.AccountName}/{fileClient.Path}' " +
+                    $"[Test:Setup] Cannot upload a new Azure Files share file '{fileClient.Name}' at '{fileClient.AccountName}/{fileClient.Path}' " +
                     $"because the share '{fileClient.ShareName}' does not exists in account '{fileClient.AccountName}'; " +
-                    $"please make sure to use an existing Azure File share to create a temporary file test fixture",
+                    $"please make sure to use an existing Azure Files share to create a temporary file test fixture",
                     exception);
             }
             catch (RequestFailedException exception) when (exception.ErrorCode == ShareErrorCode.ParentNotFound)
             {
                 throw new DirectoryNotFoundException(
-                    $"[Test:Setup] Cannot upload a new Azure share file '{fileClient.Name}' at '{fileClient.AccountName}/{fileClient.Path}' " +
+                    $"[Test:Setup] Cannot upload a new Azure Files share file '{fileClient.Name}' at '{fileClient.AccountName}/{fileClient.Path}' " +
                     $"because the parent directory does not exists in account '{fileClient.AccountName}'; " +
-                    $"please make sure to use an existing Azure File share directory to create a temporary file test fixture",
+                    $"please make sure to use an existing Azure Files share directory to create a temporary file test fixture",
                     exception);
             }
 
@@ -123,7 +123,7 @@ namespace Arcus.Testing
             {
                 disposables.Add(AsyncDisposable.Create(async () =>
                 {
-                    _logger.LogTrace("[Test:Teardown] Delete Azure File share file '{FileName}' in directory '{AccountName}/{DirectoryName}'", Client.Name, Client.AccountName, Client.Path);
+                    _logger.LogTrace("[Test:Teardown] Delete Azure Files share file '{FileName}' in directory '{AccountName}/{DirectoryName}'", Client.Name, Client.AccountName, Client.Path);
                     await Client.DeleteIfExistsAsync();
                 }));
             }
@@ -131,7 +131,7 @@ namespace Arcus.Testing
             {
                 disposables.Add(AsyncDisposable.Create(async () =>
                 {
-                    _logger.LogTrace("[Test:Teardown] Replace Azure File share file '{FileName}' with original contents in directory '{AccountName}/{DirectoryName}'", Client.Name, Client.AccountName, Client.Path);
+                    _logger.LogTrace("[Test:Teardown] Replace Azure Files share file '{FileName}' with original contents in directory '{AccountName}/{DirectoryName}'", Client.Name, Client.AccountName, Client.Path);
                     await Client.CreateAsync(_original.length);
                     await Client.UploadAsync(_original.stream);
 

--- a/src/Arcus.Testing.Storage.Table/TemporaryTable.cs
+++ b/src/Arcus.Testing.Storage.Table/TemporaryTable.cs
@@ -256,7 +256,7 @@ namespace Arcus.Testing
         /// <summary>
         /// Creates a new instance of the <see cref="TemporaryTable"/> which creates a new Azure Table container if it doesn't exist yet.
         /// </summary>
-        /// <param name="serviceClient">The client to interact with the Azure Table storage resource as a whole.</param>
+        /// <param name="serviceClient">The client to interact with the Azure Table Storage resource as a whole.</param>
         /// <param name="tableName">The name of the Azure Table to create.</param>
         /// <param name="logger">The logger to write diagnostic messages during the lifetime of the Azure Table.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="serviceClient"/> is <c>null</c>.</exception>
@@ -269,7 +269,7 @@ namespace Arcus.Testing
         /// <summary>
         /// Creates a new instance of the <see cref="TemporaryTable"/> which creates a new Azure Table container if it doesn't exist yet.
         /// </summary>
-        /// <param name="serviceClient">The client to interact with the Azure Table storage resource as a whole.</param>
+        /// <param name="serviceClient">The client to interact with the Azure Table Storage resource as a whole.</param>
         /// <param name="tableName">The name of the Azure Table to create.</param>
         /// <param name="logger">The logger to write diagnostic messages during the lifetime of the Azure Table.</param>
         /// <param name="configureOptions">The additional options to manipulate the behavior of the test fixture during its lifetime.</param>


### PR DESCRIPTION
The test fixtures described for Azure Storage Account did not used the correct naming conventions (i.e. 'Blob Storage' instead of 'Blob storage').

This PR fixes those violations in both the code summary tags as well as the feature documentation.
Relates to #417 