### PR TITLE
chore(az.cosmos.db): use microsoft naming for az cosmos db

### DIFF
--- a/docs/preview/03-Features/04-Azure/04-Storage/02-cosmos.mdx
+++ b/docs/preview/03-Features/04-Azure/04-Storage/02-cosmos.mdx
@@ -1,8 +1,8 @@
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-# CosmosDb
-The `Arcus.Testing.Storage.Cosmos` package provides test fixtures to Azure CosmosDb storage. By using the common test practices 'clean environment', it provides a temporary collections and documents.
+# Cosmos DB
+The `Arcus.Testing.Storage.Cosmos` package provides test fixtures to Azure Cosmos DB storage. By using the common test practices 'clean environment', it provides a temporary collections and documents.
 
 ## Installation
 The following functionality is available when installing this package:
@@ -12,16 +12,16 @@ PM> Install-Package -Name Arcus.Testing.Storage.Cosmos
 ```
 
 <Tabs groupId="storage-types">
-<TabItem value="mongodb" label="MongoDb" default>
+<TabItem value="mongodb" label="MongoDB" default>
 
 :::info
-Make sure that the test client that interacts with the Cosmos storage has at least [`DocumentDB Account Contributor`](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles/databases#documentdb-account-contributor)-rights if the test needs to create/update/delete collections.
+Make sure that the test client that interacts with the Azure Cosmos DB storage has at least [`DocumentDB Account Contributor`](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles/databases#documentdb-account-contributor)-rights if the test needs to create/update/delete collections.
 :::
 
-### Temporary MongoDb collection
-The `TemporaryMongoDbCollection` provides a solution when the integration tes requires a storage system (collection) during the test run. A MongoDb collection is created upon setup of the test fixture and is deleted again when the test fixture disposed.
+### Temporary MongoDB collection
+The `TemporaryMongoDbCollection` provides a solution when the integration test requires a storage system (collection) during the test run. An Azure Cosmos DB for MongoDB collection is created upon setup of the test fixture and is deleted again when the test fixture disposed.
 
-> ⚡ The test fixture automatically uses an existing collection - if exists, but does not remove it if it was not responsible for creating the collection.
+> ⚡ The test fixture automatically uses an existing MongoDB collection - if exists, but does not remove it if it was not responsible for creating the collection.
 
 ```csharp
 using Arcus.Testing;
@@ -52,7 +52,7 @@ await collection.UpsertDocumentAsync(new Shipment { BoatName = "The Alice"  });
 ```
 
 :::praise
-The `TemporaryMongoDbCollection` will always remove/revert any MongoDb documents that were upserted via the temporary collection itself with the `collection.UpsertDocumentAsync`. This follows the 'clean environment' testing principal that any test should not leave any state it created behind after the test has run.
+The `TemporaryMongoDbCollection` will always remove/revert any MongoDB documents that were upserted via the temporary collection itself with the `collection.UpsertDocumentAsync`. This follows the 'clean environment' testing principal that any test should not leave any state it created behind after the test has run.
 :::
 
 #### Customization
@@ -66,14 +66,14 @@ await TemporaryMongoDbCollection.CreateIfNotExistsAsync(..., options =>
     // Options related to when the test fixture is set up.
     // ---------------------------------------------------
 
-    // (Default) Leaves all existing MongoDb documents untouched when the test fixture is created.
+    // (Default) Leaves all existing MongoDB documents untouched when the test fixture is created.
     options.OnSetup.LeaveAllDocuments();
 
-    // Delete all MongoDb documents that already existed before the test fixture creation, when there was already a MongoDb collection available.
+    // Delete all MongoDB documents that already existed before the test fixture creation, when there was already a MongoDB collection available.
     options.OnSetup.CleanAllDocuments();
 
-    // Delete all MongoDb documents that matches any of the configured filters,
-    // upon the test fixture creation, when there was already a MongoDb collection available.
+    // Delete all MongoDB documents that matches any of the configured filters,
+    // upon the test fixture creation, when there was already a MongoDB collection available.
     options.OnSetup.CleanMatchingDocuments(
         Builders<Shipment>.Filter.Eq(s => s.BoatName, "The Alice"));
     
@@ -82,14 +82,14 @@ await TemporaryMongoDbCollection.CreateIfNotExistsAsync(..., options =>
     // Options related to when the test fixture is teared down.
     // --------------------------------------------------------
 
-    // (Default) Delete/Revert all MongoDb documents that were upserted by the test fixture.
+    // (Default) Delete/Revert all MongoDB documents that were upserted by the test fixture.
     options.OnTeardown.CleanUpsertedDocuments();
 
-    // Delete all MongoDb documents upon the test fixture disposal,
+    // Delete all MongoDB documents upon the test fixture disposal,
     // even if the test fixture didn't upserted them.
     options.OnTeardown.CleanAllDocuments();
 
-    // Delete all MongoDb documents that matches any of the configured filters,
+    // Delete all MongoDB documents that matches any of the configured filters,
     // upon the test fixture disposal, even if the test fixture didn't upserted them.
     // ⚠️ MongoDb documents upserted by the test fixture will be deleted/reverted, even if the documents don't match the configured filters.
     options.OnTeardown.CleanMatchingDocuments(
@@ -104,8 +104,8 @@ await using TemporaryMongoDbCollection collection = ...
 collection.OnTeardown.CleanAllDocuments();
 ```
 
-### Temporary MongoDb document
-The `TemporaryMongoDbDocument` provides a solution when the integration test requires a document during the test run. A MongoDb document is created upon the setup of the test fixture and is deleted again when the test fixture is disposed.
+### Temporary MongoDB document
+The `TemporaryMongoDbDocument` provides a solution when the integration test requires a document during the test run. A MongoDB document is created upon the setup of the test fixture and is deleted again when the test fixture is disposed.
 
 When the document already existed (already a document with a same configured document ID), then the test fixture will revert to the original content of the document upon the test fixture disposal.
 
@@ -130,12 +130,12 @@ BsonValue documentId = document.Id;
 ```
 
 </TabItem>
-<TabItem value="nosql" label="NoSql">
+<TabItem value="nosql" label="NoSQL">
 
 :::info
 Make sure that the test client that interacts with the Cosmos storage has at least [`Cosmos DB Built-in Data Contributor`](https://learn.microsoft.com/en-us/azure/cosmos-db/nosql/security/reference-data-plane-roles)-rights if the test needs to create/update/delete containers.
 
-**This role is not a built-in Azure RBAC, but a role specific for NoSql**. One can [assign this role with Azure CLI](https://learn.microsoft.com/en-us/cli/azure/cosmosdb/sql/role/assignment?view=azure-cli-latest#az-cosmosdb-sql-role-assignment-create):
+**This role is not a built-in Azure RBAC, but a role specific for NoSQL**. One can [assign this role with Azure CLI](https://learn.microsoft.com/en-us/cli/azure/cosmosdb/sql/role/assignment?view=azure-cli-latest#az-cosmosdb-sql-role-assignment-create):
 ```powershell
 PS> az cosmosdb sql role assignment create `
   --account-name "CosmosDBAccountName" `
@@ -146,8 +146,8 @@ PS> az cosmosdb sql role assignment create `
 ```
 :::
 
-### Temporary NoSql container
-The `TemporaryNoSqlContainer` provides a solution when the integration tes requires a storage system (container) during the test run. A NoSql container is created upon setup of the test fixture and is deleted again when the test fixture disposed.
+### Temporary NoSQL container
+The `TemporaryNoSqlContainer` provides a solution when the integration tes requires a storage system (container) during the test run. An Azure Cosmos DB for NoSQL container is created upon setup of the test fixture and is deleted again when the test fixture disposed.
 
 > ⚡ The test fixture automatically uses an existing container - if exists, but does not remove it if it was not responsible for creating the container.
 
@@ -195,13 +195,13 @@ await TemporaryNoSqlContainer.CreateIfNotExistsAsync(..., options =>
     // Options related to when the test fixture is set up.
     // ---------------------------------------------------
 
-    // (Default) Leaves all existing NoSql items untouched when the test fixture is created.
+    // (Default) Leaves all existing NoSQL items untouched when the test fixture is created.
     options.OnSetup.LeaveAllItems();
 
-    // Delete all NoSql items that already existed before the test fixture creation, when there was already a NoSql container available.
+    // Delete all NoSQL items that already existed before the test fixture creation, when there was already a NoSQL container available.
     options.OnSetup.CleanAllItems();
 
-    // Delete all NoSql items that matches any of the configured filters,
+    // Delete all NoSQL items that matches any of the configured filters,
     // upon the test fixture creation, when there was already a NoSql container available.
     options.OnSetup.CleanMatchingItems((NoSqlItem item) => item.Id == "123");
     options.OnSetup.CleanMatchingItems((Shipment item) => item.BoatName == "The Alice");
@@ -212,11 +212,11 @@ await TemporaryNoSqlContainer.CreateIfNotExistsAsync(..., options =>
     // (Default) Delete/Revert all NoSql items that were upserted by the test fixture.
     options.OnTeardown.CleanUpsertedItems();
 
-    // Delete all NoSql items upon the test fixture disposal,
+    // Delete all NoSQL items upon the test fixture disposal,
     // even if the test fixture didn't upserted them.
     options.OnTeardown.CleanAllItems();
 
-    // Delete all NoSql items that matches any of the configured filters,
+    // Delete all NoSQL items that matches any of the configured filters,
     // upon the test fixture disposal, even if the test fixture didn't upserted them.
     // ⚠️ NoSql items upserted by the test fixture will be deleted/reverted, even if the items don't match the configured filters.
     options.OnTeardown.CleanMatchingItems((NoSqlItem item) => item.Id == "123"); 
@@ -229,8 +229,8 @@ await using TemporaryNoSqlContainer container = ...
 container.OnTeardown.CleanAllItems();
 ```
 
-### Temporary NoSql item
-The `TemporaryNoSqlItem` provides a solution when the integration test requires a item during the test run. A NoSql item is created upon the setup of the test fixture and is deleted again when the test fixture is disposed.
+### Temporary NoSQL item
+The `TemporaryNoSqlItem` provides a solution when the integration test requires a item during the test run. A NoSQL item is created upon the setup of the test fixture and is deleted again when the test fixture is disposed.
 
 > ⚡ When the item already existed (already a item with a same configured item ID), then the test fixture will revert to the original content of the item upon the test fixture disposal.
 

--- a/docs/versioned_docs/version-v2.0.0/03-Features/04-Azure/04-Storage/02-cosmos.mdx
+++ b/docs/versioned_docs/version-v2.0.0/03-Features/04-Azure/04-Storage/02-cosmos.mdx
@@ -1,8 +1,8 @@
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-# CosmosDb
-The `Arcus.Testing.Storage.Cosmos` package provides test fixtures to Azure CosmosDb storage. By using the common test practices 'clean environment', it provides a temporary collections and documents.
+# Cosmos DB
+The `Arcus.Testing.Storage.Cosmos` package provides test fixtures to Azure Cosmos DB storage. By using the common test practices 'clean environment', it provides a temporary collections and documents.
 
 ## Installation
 The following functionality is available when installing this package:
@@ -12,16 +12,16 @@ PM> Install-Package -Name Arcus.Testing.Storage.Cosmos
 ```
 
 <Tabs groupId="storage-types">
-<TabItem value="mongodb" label="MongoDb" default>
+<TabItem value="mongodb" label="MongoDB" default>
 
 :::info
-Make sure that the test client that interacts with the Cosmos storage has at least [`DocumentDB Account Contributor`](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles/databases#documentdb-account-contributor)-rights if the test needs to create/update/delete collections.
+Make sure that the test client that interacts with the Azure Cosmos DB storage has at least [`DocumentDB Account Contributor`](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles/databases#documentdb-account-contributor)-rights if the test needs to create/update/delete collections.
 :::
 
-### Temporary MongoDb collection
-The `TemporaryMongoDbCollection` provides a solution when the integration tes requires a storage system (collection) during the test run. A MongoDb collection is created upon setup of the test fixture and is deleted again when the test fixture disposed.
+### Temporary MongoDB collection
+The `TemporaryMongoDbCollection` provides a solution when the integration test requires a storage system (collection) during the test run. An Azure Cosmos DB for MongoDB collection is created upon setup of the test fixture and is deleted again when the test fixture disposed.
 
-> ⚡ The test fixture automatically uses an existing collection - if exists, but does not remove it if it was not responsible for creating the collection.
+> ⚡ The test fixture automatically uses an existing MongoDB collection - if exists, but does not remove it if it was not responsible for creating the collection.
 
 ```csharp
 using Arcus.Testing;
@@ -52,7 +52,7 @@ await collection.UpsertDocumentAsync(new Shipment { BoatName = "The Alice"  });
 ```
 
 :::praise
-The `TemporaryMongoDbCollection` will always remove/revert any MongoDb documents that were upserted via the temporary collection itself with the `collection.UpsertDocumentAsync`. This follows the 'clean environment' testing principal that any test should not leave any state it created behind after the test has run.
+The `TemporaryMongoDbCollection` will always remove/revert any MongoDB documents that were upserted via the temporary collection itself with the `collection.UpsertDocumentAsync`. This follows the 'clean environment' testing principal that any test should not leave any state it created behind after the test has run.
 :::
 
 #### Customization
@@ -66,14 +66,14 @@ await TemporaryMongoDbCollection.CreateIfNotExistsAsync(..., options =>
     // Options related to when the test fixture is set up.
     // ---------------------------------------------------
 
-    // (Default) Leaves all existing MongoDb documents untouched when the test fixture is created.
+    // (Default) Leaves all existing MongoDB documents untouched when the test fixture is created.
     options.OnSetup.LeaveAllDocuments();
 
-    // Delete all MongoDb documents that already existed before the test fixture creation, when there was already a MongoDb collection available.
+    // Delete all MongoDB documents that already existed before the test fixture creation, when there was already a MongoDB collection available.
     options.OnSetup.CleanAllDocuments();
 
-    // Delete all MongoDb documents that matches any of the configured filters,
-    // upon the test fixture creation, when there was already a MongoDb collection available.
+    // Delete all MongoDB documents that matches any of the configured filters,
+    // upon the test fixture creation, when there was already a MongoDB collection available.
     options.OnSetup.CleanMatchingDocuments(
         Builders<Shipment>.Filter.Eq(s => s.BoatName, "The Alice"));
     
@@ -82,14 +82,14 @@ await TemporaryMongoDbCollection.CreateIfNotExistsAsync(..., options =>
     // Options related to when the test fixture is teared down.
     // --------------------------------------------------------
 
-    // (Default) Delete/Revert all MongoDb documents that were upserted by the test fixture.
+    // (Default) Delete/Revert all MongoDB documents that were upserted by the test fixture.
     options.OnTeardown.CleanUpsertedDocuments();
 
-    // Delete all MongoDb documents upon the test fixture disposal,
+    // Delete all MongoDB documents upon the test fixture disposal,
     // even if the test fixture didn't upserted them.
     options.OnTeardown.CleanAllDocuments();
 
-    // Delete all MongoDb documents that matches any of the configured filters,
+    // Delete all MongoDB documents that matches any of the configured filters,
     // upon the test fixture disposal, even if the test fixture didn't upserted them.
     // ⚠️ MongoDb documents upserted by the test fixture will be deleted/reverted, even if the documents don't match the configured filters.
     options.OnTeardown.CleanMatchingDocuments(
@@ -104,8 +104,8 @@ await using TemporaryMongoDbCollection collection = ...
 collection.OnTeardown.CleanAllDocuments();
 ```
 
-### Temporary MongoDb document
-The `TemporaryMongoDbDocument` provides a solution when the integration test requires a document during the test run. A MongoDb document is created upon the setup of the test fixture and is deleted again when the test fixture is disposed.
+### Temporary MongoDB document
+The `TemporaryMongoDbDocument` provides a solution when the integration test requires a document during the test run. A MongoDB document is created upon the setup of the test fixture and is deleted again when the test fixture is disposed.
 
 When the document already existed (already a document with a same configured document ID), then the test fixture will revert to the original content of the document upon the test fixture disposal.
 
@@ -130,12 +130,12 @@ BsonValue documentId = document.Id;
 ```
 
 </TabItem>
-<TabItem value="nosql" label="NoSql">
+<TabItem value="nosql" label="NoSQL">
 
 :::info
 Make sure that the test client that interacts with the Cosmos storage has at least [`Cosmos DB Built-in Data Contributor`](https://learn.microsoft.com/en-us/azure/cosmos-db/nosql/security/reference-data-plane-roles)-rights if the test needs to create/update/delete containers.
 
-**This role is not a built-in Azure RBAC, but a role specific for NoSql**. One can [assign this role with Azure CLI](https://learn.microsoft.com/en-us/cli/azure/cosmosdb/sql/role/assignment?view=azure-cli-latest#az-cosmosdb-sql-role-assignment-create):
+**This role is not a built-in Azure RBAC, but a role specific for NoSQL**. One can [assign this role with Azure CLI](https://learn.microsoft.com/en-us/cli/azure/cosmosdb/sql/role/assignment?view=azure-cli-latest#az-cosmosdb-sql-role-assignment-create):
 ```powershell
 PS> az cosmosdb sql role assignment create `
   --account-name "CosmosDBAccountName" `
@@ -146,8 +146,8 @@ PS> az cosmosdb sql role assignment create `
 ```
 :::
 
-### Temporary NoSql container
-The `TemporaryNoSqlContainer` provides a solution when the integration tes requires a storage system (container) during the test run. A NoSql container is created upon setup of the test fixture and is deleted again when the test fixture disposed.
+### Temporary NoSQL container
+The `TemporaryNoSqlContainer` provides a solution when the integration tes requires a storage system (container) during the test run. An Azure Cosmos DB for NoSQL container is created upon setup of the test fixture and is deleted again when the test fixture disposed.
 
 > ⚡ The test fixture automatically uses an existing container - if exists, but does not remove it if it was not responsible for creating the container.
 
@@ -195,13 +195,13 @@ await TemporaryNoSqlContainer.CreateIfNotExistsAsync(..., options =>
     // Options related to when the test fixture is set up.
     // ---------------------------------------------------
 
-    // (Default) Leaves all existing NoSql items untouched when the test fixture is created.
+    // (Default) Leaves all existing NoSQL items untouched when the test fixture is created.
     options.OnSetup.LeaveAllItems();
 
-    // Delete all NoSql items that already existed before the test fixture creation, when there was already a NoSql container available.
+    // Delete all NoSQL items that already existed before the test fixture creation, when there was already a NoSQL container available.
     options.OnSetup.CleanAllItems();
 
-    // Delete all NoSql items that matches any of the configured filters,
+    // Delete all NoSQL items that matches any of the configured filters,
     // upon the test fixture creation, when there was already a NoSql container available.
     options.OnSetup.CleanMatchingItems((NoSqlItem item) => item.Id == "123");
     options.OnSetup.CleanMatchingItems((Shipment item) => item.BoatName == "The Alice");
@@ -212,11 +212,11 @@ await TemporaryNoSqlContainer.CreateIfNotExistsAsync(..., options =>
     // (Default) Delete/Revert all NoSql items that were upserted by the test fixture.
     options.OnTeardown.CleanUpsertedItems();
 
-    // Delete all NoSql items upon the test fixture disposal,
+    // Delete all NoSQL items upon the test fixture disposal,
     // even if the test fixture didn't upserted them.
     options.OnTeardown.CleanAllItems();
 
-    // Delete all NoSql items that matches any of the configured filters,
+    // Delete all NoSQL items that matches any of the configured filters,
     // upon the test fixture disposal, even if the test fixture didn't upserted them.
     // ⚠️ NoSql items upserted by the test fixture will be deleted/reverted, even if the items don't match the configured filters.
     options.OnTeardown.CleanMatchingItems((NoSqlItem item) => item.Id == "123"); 
@@ -229,8 +229,8 @@ await using TemporaryNoSqlContainer container = ...
 container.OnTeardown.CleanAllItems();
 ```
 
-### Temporary NoSql item
-The `TemporaryNoSqlItem` provides a solution when the integration test requires a item during the test run. A NoSql item is created upon the setup of the test fixture and is deleted again when the test fixture is disposed.
+### Temporary NoSQL item
+The `TemporaryNoSqlItem` provides a solution when the integration test requires a item during the test run. A NoSQL item is created upon the setup of the test fixture and is deleted again when the test fixture is disposed.
 
 > ⚡ When the item already existed (already a item with a same configured item ID), then the test fixture will revert to the original content of the item upon the test fixture disposal.
 

--- a/docs/versioned_docs/version-v2.1.0/03-Features/04-Azure/04-Storage/02-cosmos.mdx
+++ b/docs/versioned_docs/version-v2.1.0/03-Features/04-Azure/04-Storage/02-cosmos.mdx
@@ -1,8 +1,8 @@
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-# CosmosDb
-The `Arcus.Testing.Storage.Cosmos` package provides test fixtures to Azure CosmosDb storage. By using the common test practices 'clean environment', it provides a temporary collections and documents.
+# Cosmos DB
+The `Arcus.Testing.Storage.Cosmos` package provides test fixtures to Azure Cosmos DB storage. By using the common test practices 'clean environment', it provides a temporary collections and documents.
 
 ## Installation
 The following functionality is available when installing this package:
@@ -12,16 +12,16 @@ PM> Install-Package -Name Arcus.Testing.Storage.Cosmos
 ```
 
 <Tabs groupId="storage-types">
-<TabItem value="mongodb" label="MongoDb" default>
+<TabItem value="mongodb" label="MongoDB" default>
 
 :::info
-Make sure that the test client that interacts with the Cosmos storage has at least [`DocumentDB Account Contributor`](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles/databases#documentdb-account-contributor)-rights if the test needs to create/update/delete collections.
+Make sure that the test client that interacts with the Azure Cosmos DB storage has at least [`DocumentDB Account Contributor`](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles/databases#documentdb-account-contributor)-rights if the test needs to create/update/delete collections.
 :::
 
-### Temporary MongoDb collection
-The `TemporaryMongoDbCollection` provides a solution when the integration tes requires a storage system (collection) during the test run. A MongoDb collection is created upon setup of the test fixture and is deleted again when the test fixture disposed.
+### Temporary MongoDB collection
+The `TemporaryMongoDbCollection` provides a solution when the integration test requires a storage system (collection) during the test run. An Azure Cosmos DB for MongoDB collection is created upon setup of the test fixture and is deleted again when the test fixture disposed.
 
-> ⚡ The test fixture automatically uses an existing collection - if exists, but does not remove it if it was not responsible for creating the collection.
+> ⚡ The test fixture automatically uses an existing MongoDB collection - if exists, but does not remove it if it was not responsible for creating the collection.
 
 ```csharp
 using Arcus.Testing;
@@ -52,7 +52,7 @@ await collection.UpsertDocumentAsync(new Shipment { BoatName = "The Alice"  });
 ```
 
 :::praise
-The `TemporaryMongoDbCollection` will always remove/revert any MongoDb documents that were upserted via the temporary collection itself with the `collection.UpsertDocumentAsync`. This follows the 'clean environment' testing principal that any test should not leave any state it created behind after the test has run.
+The `TemporaryMongoDbCollection` will always remove/revert any MongoDB documents that were upserted via the temporary collection itself with the `collection.UpsertDocumentAsync`. This follows the 'clean environment' testing principal that any test should not leave any state it created behind after the test has run.
 :::
 
 #### Customization
@@ -66,14 +66,14 @@ await TemporaryMongoDbCollection.CreateIfNotExistsAsync(..., options =>
     // Options related to when the test fixture is set up.
     // ---------------------------------------------------
 
-    // (Default) Leaves all existing MongoDb documents untouched when the test fixture is created.
+    // (Default) Leaves all existing MongoDB documents untouched when the test fixture is created.
     options.OnSetup.LeaveAllDocuments();
 
-    // Delete all MongoDb documents that already existed before the test fixture creation, when there was already a MongoDb collection available.
+    // Delete all MongoDB documents that already existed before the test fixture creation, when there was already a MongoDB collection available.
     options.OnSetup.CleanAllDocuments();
 
-    // Delete all MongoDb documents that matches any of the configured filters,
-    // upon the test fixture creation, when there was already a MongoDb collection available.
+    // Delete all MongoDB documents that matches any of the configured filters,
+    // upon the test fixture creation, when there was already a MongoDB collection available.
     options.OnSetup.CleanMatchingDocuments(
         Builders<Shipment>.Filter.Eq(s => s.BoatName, "The Alice"));
     
@@ -82,14 +82,14 @@ await TemporaryMongoDbCollection.CreateIfNotExistsAsync(..., options =>
     // Options related to when the test fixture is teared down.
     // --------------------------------------------------------
 
-    // (Default) Delete/Revert all MongoDb documents that were upserted by the test fixture.
+    // (Default) Delete/Revert all MongoDB documents that were upserted by the test fixture.
     options.OnTeardown.CleanUpsertedDocuments();
 
-    // Delete all MongoDb documents upon the test fixture disposal,
+    // Delete all MongoDB documents upon the test fixture disposal,
     // even if the test fixture didn't upserted them.
     options.OnTeardown.CleanAllDocuments();
 
-    // Delete all MongoDb documents that matches any of the configured filters,
+    // Delete all MongoDB documents that matches any of the configured filters,
     // upon the test fixture disposal, even if the test fixture didn't upserted them.
     // ⚠️ MongoDb documents upserted by the test fixture will be deleted/reverted, even if the documents don't match the configured filters.
     options.OnTeardown.CleanMatchingDocuments(
@@ -104,8 +104,8 @@ await using TemporaryMongoDbCollection collection = ...
 collection.OnTeardown.CleanAllDocuments();
 ```
 
-### Temporary MongoDb document
-The `TemporaryMongoDbDocument` provides a solution when the integration test requires a document during the test run. A MongoDb document is created upon the setup of the test fixture and is deleted again when the test fixture is disposed.
+### Temporary MongoDB document
+The `TemporaryMongoDbDocument` provides a solution when the integration test requires a document during the test run. A MongoDB document is created upon the setup of the test fixture and is deleted again when the test fixture is disposed.
 
 When the document already existed (already a document with a same configured document ID), then the test fixture will revert to the original content of the document upon the test fixture disposal.
 
@@ -130,12 +130,12 @@ BsonValue documentId = document.Id;
 ```
 
 </TabItem>
-<TabItem value="nosql" label="NoSql">
+<TabItem value="nosql" label="NoSQL">
 
 :::info
 Make sure that the test client that interacts with the Cosmos storage has at least [`Cosmos DB Built-in Data Contributor`](https://learn.microsoft.com/en-us/azure/cosmos-db/nosql/security/reference-data-plane-roles)-rights if the test needs to create/update/delete containers.
 
-**This role is not a built-in Azure RBAC, but a role specific for NoSql**. One can [assign this role with Azure CLI](https://learn.microsoft.com/en-us/cli/azure/cosmosdb/sql/role/assignment?view=azure-cli-latest#az-cosmosdb-sql-role-assignment-create):
+**This role is not a built-in Azure RBAC, but a role specific for NoSQL**. One can [assign this role with Azure CLI](https://learn.microsoft.com/en-us/cli/azure/cosmosdb/sql/role/assignment?view=azure-cli-latest#az-cosmosdb-sql-role-assignment-create):
 ```powershell
 PS> az cosmosdb sql role assignment create `
   --account-name "CosmosDBAccountName" `
@@ -146,8 +146,8 @@ PS> az cosmosdb sql role assignment create `
 ```
 :::
 
-### Temporary NoSql container
-The `TemporaryNoSqlContainer` provides a solution when the integration tes requires a storage system (container) during the test run. A NoSql container is created upon setup of the test fixture and is deleted again when the test fixture disposed.
+### Temporary NoSQL container
+The `TemporaryNoSqlContainer` provides a solution when the integration tes requires a storage system (container) during the test run. An Azure Cosmos DB for NoSQL container is created upon setup of the test fixture and is deleted again when the test fixture disposed.
 
 > ⚡ The test fixture automatically uses an existing container - if exists, but does not remove it if it was not responsible for creating the container.
 
@@ -195,13 +195,13 @@ await TemporaryNoSqlContainer.CreateIfNotExistsAsync(..., options =>
     // Options related to when the test fixture is set up.
     // ---------------------------------------------------
 
-    // (Default) Leaves all existing NoSql items untouched when the test fixture is created.
+    // (Default) Leaves all existing NoSQL items untouched when the test fixture is created.
     options.OnSetup.LeaveAllItems();
 
-    // Delete all NoSql items that already existed before the test fixture creation, when there was already a NoSql container available.
+    // Delete all NoSQL items that already existed before the test fixture creation, when there was already a NoSQL container available.
     options.OnSetup.CleanAllItems();
 
-    // Delete all NoSql items that matches any of the configured filters,
+    // Delete all NoSQL items that matches any of the configured filters,
     // upon the test fixture creation, when there was already a NoSql container available.
     options.OnSetup.CleanMatchingItems((NoSqlItem item) => item.Id == "123");
     options.OnSetup.CleanMatchingItems((Shipment item) => item.BoatName == "The Alice");
@@ -212,11 +212,11 @@ await TemporaryNoSqlContainer.CreateIfNotExistsAsync(..., options =>
     // (Default) Delete/Revert all NoSql items that were upserted by the test fixture.
     options.OnTeardown.CleanUpsertedItems();
 
-    // Delete all NoSql items upon the test fixture disposal,
+    // Delete all NoSQL items upon the test fixture disposal,
     // even if the test fixture didn't upserted them.
     options.OnTeardown.CleanAllItems();
 
-    // Delete all NoSql items that matches any of the configured filters,
+    // Delete all NoSQL items that matches any of the configured filters,
     // upon the test fixture disposal, even if the test fixture didn't upserted them.
     // ⚠️ NoSql items upserted by the test fixture will be deleted/reverted, even if the items don't match the configured filters.
     options.OnTeardown.CleanMatchingItems((NoSqlItem item) => item.Id == "123"); 
@@ -229,8 +229,8 @@ await using TemporaryNoSqlContainer container = ...
 container.OnTeardown.CleanAllItems();
 ```
 
-### Temporary NoSql item
-The `TemporaryNoSqlItem` provides a solution when the integration test requires a item during the test run. A NoSql item is created upon the setup of the test fixture and is deleted again when the test fixture is disposed.
+### Temporary NoSQL item
+The `TemporaryNoSqlItem` provides a solution when the integration test requires a item during the test run. A NoSQL item is created upon the setup of the test fixture and is deleted again when the test fixture is disposed.
 
 > ⚡ When the item already existed (already a item with a same configured item ID), then the test fixture will revert to the original content of the item upon the test fixture disposal.
 

--- a/src/Arcus.Testing.Storage.Cosmos/Arcus.Testing.Storage.Cosmos.csproj
+++ b/src/Arcus.Testing.Storage.Cosmos/Arcus.Testing.Storage.Cosmos.csproj
@@ -5,7 +5,7 @@
     <RootNamespace>Arcus.Testing</RootNamespace>
     <Authors>Arcus</Authors>
     <Company>Arcus</Company>
-    <Description>Provides capabilities during testing of Azure Cosmos storage interactions</Description>
+    <Description>Provides capabilities during testing of Azure Cosmos DB storage interactions</Description>
     <Copyright>Copyright (c) Arcus</Copyright>
     <PackageProjectUrl>https://github.com/arcus-azure/arcus.testing</PackageProjectUrl>
     <RepositoryUrl>https://github.com/arcus-azure/arcus.testing</RepositoryUrl>

--- a/src/Arcus.Testing.Storage.Cosmos/MongoDbConnection.cs
+++ b/src/Arcus.Testing.Storage.Cosmos/MongoDbConnection.cs
@@ -12,7 +12,7 @@ using MongoDB.Driver;
 namespace Arcus.Testing
 {
     /// <summary>
-    /// Represents how the test infrastructure connects with the Azure Cosmos MongoDb resource.
+    /// Represents how the test infrastructure connects with the Azure Cosmos DB for MongoDB resource.
     /// </summary>
     internal static class MongoDbConnection
     {
@@ -35,7 +35,7 @@ namespace Arcus.Testing
             const string scope = "https://management.azure.com/.default";
             var tokenProvider = new DefaultAzureCredential();
 
-            logger.LogTrace("[Test:Setup] Request access token for Azure Cosmos MongoDb resource at scope '{Url}'", scope);
+            logger.LogTrace("[Test:Setup] Request access token for Azure Cosmos DB for MongoDB resource at scope '{Url}'", scope);
             return await tokenProvider.GetTokenAsync(new TokenRequestContext(scopes: new[] { scope }));
         }
 
@@ -47,7 +47,7 @@ namespace Arcus.Testing
             ILogger logger)
         {
             var listConnectionStringUrl = $"https://management.azure.com/{cosmosDbResourceId}/listConnectionStrings?api-version=2021-04-15";
-            logger.LogTrace("[Test:Setup] Request access for Azure Cosmos MongoDb resource at '{Url}'", listConnectionStringUrl);
+            logger.LogTrace("[Test:Setup] Request access for Azure Cosmos DB for MongoDB resource at '{Url}'", listConnectionStringUrl);
 
             using var request = new HttpRequestMessage(HttpMethod.Post, listConnectionStringUrl);
             request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken.Token);
@@ -59,7 +59,7 @@ namespace Arcus.Testing
             {
                 throw new RequestFailedException(
                     (int) response.StatusCode,
-                    $"[Test:Setup] Cannot contact Azure Cosmos MongoDb collection named '{collectionName}' at database '{databaseName}' in account '{cosmosDbResourceId.Name}', " +
+                    $"[Test:Setup] Cannot contact Azure Cosmos DB for MongoDB collection named '{collectionName}' at database '{databaseName}' in account '{cosmosDbResourceId.Name}', " +
                     $"because the test host could not successfully request access from the resource at '{listConnectionStringUrl}': {responseBody}");
             }
 
@@ -85,12 +85,12 @@ namespace Arcus.Testing
             }
             catch (JsonException exception)
             {
-                logger.LogError(exception, "[Test:Setup] Failed to parse the response for Azure Cosmos MongoDb access due to a deserialization failure: {Message}", exception.Message);
+                logger.LogError(exception, "[Test:Setup] Failed to parse the response for Azure Cosmos DB for MongoDB access due to a deserialization failure: {Message}", exception.Message);
                 throw;
             }
 
             throw new JsonException(
-                $"[Test:Setup] Failed to parse the response for Azure Cosmos MongoDb access as there does not exists any access information in the response: {responseBody}");
+                $"[Test:Setup] Failed to parse the response for Azure Cosmos DB for MongoDB access as there does not exists any access information in the response: {responseBody}");
         }
     }
 }

--- a/src/Arcus.Testing.Storage.Cosmos/NoSqlExtraction.cs
+++ b/src/Arcus.Testing.Storage.Cosmos/NoSqlExtraction.cs
@@ -8,7 +8,7 @@ using Microsoft.Azure.Cosmos;
 namespace Arcus.Testing
 {
     /// <summary>
-    /// Represents how the NoSql-related information is extracted from items.
+    /// Represents how the Azure Cosmos DB for NoSQL-related information is extracted from items.
     /// </summary>
     internal static class NoSqlExtraction
     {
@@ -24,14 +24,14 @@ namespace Arcus.Testing
             if (node is not JsonObject item || !item.TryGetPropertyValue("id", out JsonNode idNode) || idNode is not JsonValue id)
             {
                 throw new NotSupportedException(
-                    $"[Test:Setup] Cannot temporary insert/delete NoSql items in NoSql container as no required 'id' JSON property was found for the {typeDescription}, " +
+                    $"[Test:Setup] Cannot temporary insert/delete NoSQL items in Azure Cosmos DB for NoSQL container as no required 'id' JSON property was found for the {typeDescription}, " +
                     $"please make sure that there exists such a property in the type (Microsoft uses Newtonsoft.Json behind the scenes)");
             }
 
             if (!id.TryGetValue(out string itemId) || string.IsNullOrWhiteSpace(itemId))
             {
                 throw new InvalidOperationException(
-                    $"[Test:Setup] Cannot temporary insert NoSql item because the 'id' property of the serialized {typeDescription} is blank, " +
+                    $"[Test:Setup] Cannot temporary insert NoSQL item because the 'id' property of the serialized {typeDescription} is blank, " +
                     $"please provide an unique identifier to your item model");
             }
 

--- a/src/Arcus.Testing.Storage.Cosmos/NoSqlItemParser.cs
+++ b/src/Arcus.Testing.Storage.Cosmos/NoSqlItemParser.cs
@@ -6,12 +6,12 @@ using Microsoft.Azure.Cosmos;
 namespace Arcus.Testing
 {
     /// <summary>
-    /// Represents how NoSql-items are parsed.
+    /// Represents how Azure Cosmos DB for NoSQL-items are parsed.
     /// </summary>
     internal static class NoSqlItemParser
     {
         /// <summary>
-        /// Parse a raw <paramref name="json"/> NoSql item to a typed <typeparamref name="TItem"/>.
+        /// Parse a raw <paramref name="json"/> NoSQL item to a typed <typeparamref name="TItem"/>.
         /// </summary>
         internal static TItem Parse<TItem>(CosmosClient client, NoSqlItem json, TestPhase phase)
         {
@@ -25,7 +25,7 @@ namespace Arcus.Testing
             if (client.ClientOptions.Serializer is null)
             {
                 throw new InvalidOperationException(
-                    $"{prefix} Cannot match the NoSql item because the Cosmos client used has no JSON item serializer configured");
+                    $"{prefix} Cannot match the Azure Cosmos DB for NoSQL item because the Azure Cosmos DB client used has no JSON item serializer configured");
             }
 
             using var body = new MemoryStream(Encoding.UTF8.GetBytes(json.Content.ToString()));
@@ -34,7 +34,7 @@ namespace Arcus.Testing
             if (item is null)
             {
                 throw new InvalidOperationException(
-                    $"{prefix} Cannot match the NoSql item because the configured JSON item serializer returned 'null' when deserializing '{typeof(TItem).Name}'");
+                    $"{prefix} Cannot match the Azure Cosmos DB for NoSQL item because the configured JSON item serializer returned 'null' when deserializing '{typeof(TItem).Name}'");
             }
 
             return item;

--- a/src/Arcus.Testing.Storage.Cosmos/TemporaryMongoDbCollection.cs
+++ b/src/Arcus.Testing.Storage.Cosmos/TemporaryMongoDbCollection.cs
@@ -28,19 +28,19 @@ namespace Arcus.Testing
     public class OnSetupMongoDbCollectionOptions
     {
         /// <summary>
-        /// Gets the configurable setup option on what to do with existing MongoDb documents in the Azure MongoDb collection upon the test fixture creation.
+        /// Gets the configurable setup option on what to do with existing MongoDB documents in the Azure Cosmos DB for MongoDB collection upon the test fixture creation.
         /// </summary>
         internal OnSetupMongoDbCollection Documents { get; private set; }
 
         /// <summary>
-        /// Gets the filter expression that determines if MongoDb documents should be cleaned
+        /// Gets the filter expression that determines if MongoDB documents should be cleaned
         /// when the <see cref="Documents"/> is configured as <see cref="OnSetupMongoDbCollection.CleanIfMatched"/>.
         /// </summary>
         internal FilterDefinition<BsonDocument> IsMatched { get; private set; } = Builders<BsonDocument>.Filter.Where(_ => false);
 
         /// <summary>
-        /// (default) Configures the <see cref="TemporaryMongoDbCollection"/> to leave all MongoDb documents untouched
-        /// that already existed upon the test fixture creation, when there was already an Azure MongoDb collection available.
+        /// (default) Configures the <see cref="TemporaryMongoDbCollection"/> to leave all MongoDB documents untouched
+        /// that already existed upon the test fixture creation, when there was already an Azure Cosmos DB for MongoDB collection available.
         /// </summary>
         public OnSetupMongoDbCollectionOptions LeaveAllDocuments()
         {
@@ -49,7 +49,8 @@ namespace Arcus.Testing
         }
 
         /// <summary>
-        /// Configures the <see cref="TemporaryMongoDbCollection"/> to delete all the already existing MongoDb documents upon the test fixture creation.
+        /// Configures the <see cref="TemporaryMongoDbCollection"/> to delete all the already existing MongoDB documents
+        /// in an Azure Cosmos DB for MongoDB collection upon the test fixture creation.
         /// </summary>
         public OnSetupMongoDbCollectionOptions CleanAllDocuments()
         {
@@ -58,14 +59,14 @@ namespace Arcus.Testing
         }
 
         /// <summary>
-        /// Configures the <see cref="TemporaryMongoDbCollection"/> to delete the MongoDb documents
-        /// upon the test fixture creation that matched the configured <paramref name="filter"/>.
+        /// Configures the <see cref="TemporaryMongoDbCollection"/> to delete the MongoDB documents
+        /// in an Azure Cosmos DB for MongoDB collection upon the test fixture creation that matched the configured <paramref name="filter"/>.
         /// </summary>
         /// <remarks>
         ///     Multiple calls will aggregate together in an OR expression.
         /// </remarks>
-        /// <typeparam name="T">The type of the documents in the MongoDb collection.</typeparam>
-        /// <param name="filter">The filter expression to match documents that should be removed.</param>
+        /// <typeparam name="T">The type of the documents in the Azure Cosmos DB for MongoDB collection.</typeparam>
+        /// <param name="filter">The filter expression to match MongoDB documents that should be removed.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="filter"/> is <c>null</c>.</exception>
         public OnSetupMongoDbCollectionOptions CleanMatchingDocuments<T>(Expression<Func<T, bool>> filter)
         {
@@ -74,14 +75,14 @@ namespace Arcus.Testing
         }
 
         /// <summary>
-        /// Configures the <see cref="TemporaryMongoDbCollection"/> to delete the MongoDb documents
-        /// upon the test fixture creation that matched the configured <paramref name="filter"/>.
+        /// Configures the <see cref="TemporaryMongoDbCollection"/> to delete the MongoDB documents
+        /// in an Azure Cosmos DB for MongoDB collection upon the test fixture creation that matched the configured <paramref name="filter"/>.
         /// </summary>
         /// <remarks>
         ///     Multiple calls will aggregate together in an OR expression.
         /// </remarks>
         /// <typeparam name="TDocument">The type of the documents in the MongoDb collection.</typeparam>
-        /// <param name="filter">The filter expression to match documents that should be removed.</param>
+        /// <param name="filter">The filter expression to match MongoDB documents that should be removed.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="filter"/> is <c>null</c>.</exception>
         public OnSetupMongoDbCollectionOptions CleanMatchingDocuments<TDocument>(FilterDefinition<TDocument> filter)
         {
@@ -104,19 +105,20 @@ namespace Arcus.Testing
     public class OnTeardownMongoDbCollectionOptions
     {
         /// <summary>
-        /// Gets the configurable setup option on what to do with existing MongoDb documents in the Azure MongoDb collection upon the test fixture deletion.
+        /// Gets the configurable setup option on what to do with existing MongoDB documents in the Azure Cosmos DB for MongoDB collection upon the test fixture deletion.
         /// </summary>
         internal OnTeardownMongoDbCollection Documents { get; private set; }
 
         /// <summary>
-        /// Gets the filter expression that determines if MongoDb documents should be cleaned
+        /// Gets the filter expression that determines if MongoDB documents should be cleaned
         /// when the <see cref="Documents"/> is configured as <see cref="OnTeardownMongoDbCollection.CleanIfMatched"/>.
         /// </summary>
         internal FilterDefinition<BsonDocument> IsMatched { get; private set; } = Builders<BsonDocument>.Filter.Where(_ => false);
 
         /// <summary>
-        /// (default for cleaning documents) Configures the <see cref="TemporaryMongoDbCollection"/> to only delete the MongoDb documents upon disposal
-        /// if the document was inserted by the test fixture (using <see cref="TemporaryMongoDbCollection.UpsertDocumentAsync{TDocument}"/>).
+        /// (default for cleaning documents) Configures the <see cref="TemporaryMongoDbCollection"/> to only delete the MongoBb documents
+        /// in an Azure Cosmos DB for MongoDB collection upon disposal if the document was inserted by the test fixture
+        /// (using <see cref="TemporaryMongoDbCollection.UpsertDocumentAsync{TDocument}"/>).
         /// </summary>
         [Obsolete("Will be removed in v3, please use the " + nameof(CleanUpsertedDocuments) + "instead that provides exactly the same functionality")]
         public OnTeardownMongoDbCollectionOptions CleanCreatedDocuments()
@@ -125,8 +127,9 @@ namespace Arcus.Testing
         }
 
         /// <summary>
-        /// (default for cleaning documents) Configures the <see cref="TemporaryMongoDbCollection"/> to only delete or revert the MongoDb documents upon disposal
-        /// if the document was upserted by the test fixture (using <see cref="TemporaryMongoDbCollection.UpsertDocumentAsync{TDocument}"/>).
+        /// (default for cleaning documents) Configures the <see cref="TemporaryMongoDbCollection"/> to only delete or revert the MongoDB documents
+        /// in an Azure Cosmos DB for MongoDB collection upon disposal if the document was upserted by the test fixture
+        /// (using <see cref="TemporaryMongoDbCollection.UpsertDocumentAsync{TDocument}"/>).
         /// </summary>
         public OnTeardownMongoDbCollectionOptions CleanUpsertedDocuments()
         {
@@ -135,7 +138,8 @@ namespace Arcus.Testing
         }
 
         /// <summary>
-        /// Configures the <see cref="TemporaryMongoDbCollection"/> to delete all the MongoDb documents upon disposal - even if the test fixture didn't insert them.
+        /// Configures the <see cref="TemporaryMongoDbCollection"/> to delete all the MongoDB documents
+        /// in an Azure Cosmos DB for MongoDB collection upon disposal - even if the test fixture didn't insert them.
         /// </summary>
         public OnTeardownMongoDbCollectionOptions CleanAllDocuments()
         {
@@ -144,15 +148,16 @@ namespace Arcus.Testing
         }
 
         /// <summary>
-        /// Configures the <see cref="TemporaryMongoDbCollection"/> to delete the MongoDb documents upon disposal that matched the configured <paramref name="filter"/>.
+        /// Configures the <see cref="TemporaryMongoDbCollection"/> to delete the MongoDB documents
+        /// in an Azure Cosmos DB for MongoDB collection upon disposal that matched the configured <paramref name="filter"/>.
         /// </summary>
         /// <remarks>
-        ///     The matching of documents only happens on MongoDb documents that were created outside the scope of the test fixture.
+        ///     The matching of documents only happens on MongoDB documents that were created outside the scope of the test fixture.
         ///     All documents created by the test fixture will be deleted or reverted upon disposal, even if the documents do not match of the filters.
         ///     This follows the 'clean environment' principle where the test fixture should clean up after itself and not linger around any state it created.
         /// </remarks>
-        /// <typeparam name="TDocument">The type of the documents in the MongoDb collection.</typeparam>
-        /// <param name="filter">The filter expression to match documents that should be removed.</param>
+        /// <typeparam name="TDocument">The type of the documents in the MongoDB collection.</typeparam>
+        /// <param name="filter">The filter expression to match MongoDB documents that should be removed.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="filter"/> is <c>null</c>.</exception>
         public OnTeardownMongoDbCollectionOptions CleanMatchingDocuments<TDocument>(Expression<Func<TDocument, bool>> filter)
         {
@@ -161,15 +166,16 @@ namespace Arcus.Testing
         }
 
         /// <summary>
-        /// Configures the <see cref="TemporaryMongoDbCollection"/> to delete the MongoDb documents upon disposal that matched the configured <paramref name="filter"/>.
+        /// Configures the <see cref="TemporaryMongoDbCollection"/> to delete the MongoDB documents
+        /// in an Azure Cosmos DB for MongoDB collection upon disposal that matched the configured <paramref name="filter"/>.
         /// </summary>
         /// <remarks>
-        ///     The matching of documents only happens on MongoDb documents that were created outside the scope of the test fixture.
+        ///     The matching of documents only happens on MongoDB documents that were created outside the scope of the test fixture.
         ///     All documents created by the test fixture will be deleted or reverted upon disposal, even if the documents do not match one of the filters.
         ///     This follows the 'clean environment' principle where the test fixture should clean up after itself and not linger around any state it created.
         /// </remarks>
-        /// <typeparam name="TDocument">The type of the documents in the MongoDb collection.</typeparam>
-        /// <param name="filter">The filter expression to match documents that should be removed.</param>
+        /// <typeparam name="TDocument">The type of the documents in the MongoDB collection.</typeparam>
+        /// <param name="filter">The filter expression to match MongoDB documents that should be removed.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="filter"/> is <c>null</c>.</exception>
         public OnTeardownMongoDbCollectionOptions CleanMatchingDocuments<TDocument>(FilterDefinition<TDocument> filter)
         {
@@ -203,7 +209,7 @@ namespace Arcus.Testing
     }
 
     /// <summary>
-    /// Represents a temporary Azure Cosmos MongoDb collection that will be deleted after the instance is disposed.
+    /// Represents a temporary Azure Cosmos DB for MongoDB collection that will be deleted after the instance is disposed.
     /// </summary>
     public class TemporaryMongoDbCollection : IAsyncDisposable
     {
@@ -233,7 +239,7 @@ namespace Arcus.Testing
         }
 
         /// <summary>
-        /// Gets the unique name of the MongoDb collection, currently available on Azure Cosmos.
+        /// Gets the unique name of the MongoDB collection, currently available on Azure Cosmos DB.
         /// </summary>
         public string Name { get; }
 
@@ -243,10 +249,10 @@ namespace Arcus.Testing
         public OnTeardownMongoDbCollectionOptions OnTeardown => _options.OnTeardown;
 
         /// <summary>
-        /// Creates a new instance of the <see cref="TemporaryMongoDbCollection"/> which creates a new Azure Cosmos MongoDb collection if it doesn't exist yet.
+        /// Creates a new instance of the <see cref="TemporaryMongoDbCollection"/> which creates a new Azure Cosmos DB for MongoDB collection if it doesn't exist yet.
         /// </summary>
         /// <param name="cosmosDbResourceId">
-        ///   <para>The resource ID pointing towards the Azure Cosmos account.</para>
+        ///   <para>The resource ID pointing towards the Azure Cosmos DB account.</para>
         ///   <para>The resource ID can be constructed with the <see cref="CosmosDBAccountResource.CreateResourceIdentifier"/>:</para>
         ///   <example>
         ///     <code>
@@ -255,9 +261,9 @@ namespace Arcus.Testing
         ///     </code>
         ///   </example>
         /// </param>
-        /// <param name="databaseName">The name of the MongoDb database in which the collection should be created.</param>
-        /// <param name="collectionName">The unique name of the MongoDb collection.</param>
-        /// <param name="logger">The logger to write diagnostic information during the lifetime of the MongoDb collection.</param>
+        /// <param name="databaseName">The name of the MongoDB database in which the collection should be created.</param>
+        /// <param name="collectionName">The unique name of the MongoDB collection.</param>
+        /// <param name="logger">The logger to write diagnostic information during the lifetime of the MongoDB collection.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="cosmosDbResourceId"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="databaseName"/> or <paramref name="collectionName"/> is blank.</exception>
         public static async Task<TemporaryMongoDbCollection> CreateIfNotExistsAsync(
@@ -270,10 +276,10 @@ namespace Arcus.Testing
         }
 
         /// <summary>
-        /// Creates a new instance of the <see cref="TemporaryMongoDbCollection"/> which creates a new Azure Cosmos MongoDb collection if it doesn't exist yet.
+        /// Creates a new instance of the <see cref="TemporaryMongoDbCollection"/> which creates a new Azure Cosmos DB for MongoDB collection if it doesn't exist yet.
         /// </summary>
         /// <param name="cosmosDbResourceId">
-        ///   <para>The resource ID pointing towards the Azure Cosmos account.</para>
+        ///   <para>The resource ID pointing towards the Azure Cosmos DB account.</para>
         ///   <para>The resource ID can be constructed with the <see cref="CosmosDBAccountResource.CreateResourceIdentifier"/>:</para>
         ///   <example>
         ///     <code>
@@ -282,9 +288,9 @@ namespace Arcus.Testing
         ///     </code>
         ///   </example>
         /// </param>
-        /// <param name="databaseName">The name of the MongoDb database in which the collection should be created.</param>
-        /// <param name="collectionName">The unique name of the MongoDb collection.</param>
-        /// <param name="logger">The logger to write diagnostic information during the lifetime of the MongoDb collection.</param>
+        /// <param name="databaseName">The name of the MongoDB database in which the collection should be created.</param>
+        /// <param name="collectionName">The unique name of the MongoDB collection.</param>
+        /// <param name="logger">The logger to write diagnostic information during the lifetime of the MongoDB collection.</param>
         /// <param name="configureOptions">The additional options to manipulate the behavior of the test fixture during its lifetime.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="cosmosDbResourceId"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="databaseName"/> or <paramref name="collectionName"/> is blank.</exception>
@@ -307,11 +313,11 @@ namespace Arcus.Testing
         }
 
         /// <summary>
-        /// Creates a new instance of the <see cref="TemporaryMongoDbCollection"/> which creates a new Azure Cosmos MongoDb collection if it doesn't exist yet.
+        /// Creates a new instance of the <see cref="TemporaryMongoDbCollection"/> which creates a new Azure Cosmos DB for MongoDB collection if it doesn't exist yet.
         /// </summary>
-        /// <param name="database">The client to the MongoDb database in which the collection should be created.</param>
-        /// <param name="collectionName">The unique name of the MongoDb collection.</param>
-        /// <param name="logger">The logger to write diagnostic information during the lifetime of the MongoDb collection.</param>
+        /// <param name="database">The client to the MongoDB database in which the collection should be created.</param>
+        /// <param name="collectionName">The unique name of the MongoDB collection.</param>
+        /// <param name="logger">The logger to write diagnostic information during the lifetime of the MongoDB collection.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="database"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="collectionName"/> is blank.</exception>
         public static async Task<TemporaryMongoDbCollection> CreateIfNotExistsAsync(IMongoDatabase database, string collectionName, ILogger logger)
@@ -320,11 +326,11 @@ namespace Arcus.Testing
         }
 
         /// <summary>
-        /// Creates a new instance of the <see cref="TemporaryMongoDbCollection"/> which creates a new Azure Cosmos MongoDb collection if it doesn't exist yet.
+        /// Creates a new instance of the <see cref="TemporaryMongoDbCollection"/> which creates a new Azure Cosmos DB for MongoDB collection if it doesn't exist yet.
         /// </summary>
-        /// <param name="database">The client to the MongoDb database in which the collection should be created.</param>
-        /// <param name="collectionName">The unique name of the MongoDb collection.</param>
-        /// <param name="logger">The logger to write diagnostic information during the lifetime of the MongoDb collection.</param>
+        /// <param name="database">The client to the MongoDB database in which the collection should be created.</param>
+        /// <param name="collectionName">The unique name of the MongoDB collection.</param>
+        /// <param name="logger">The logger to write diagnostic information during the lifetime of the MongoDB collection.</param>
         /// <param name="configureOptions">The additional options to manipulate the behavior of the test fixture during its lifetime.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="database"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="collectionName"/> is blank.</exception>
@@ -348,13 +354,13 @@ namespace Arcus.Testing
             using IAsyncCursor<string> collectionNames = await database.ListCollectionNamesAsync(listOptions);
             if (await collectionNames.AnyAsync())
             {
-                logger.LogDebug("[Test:Setup] Use already existing Azure Cosmos MongoDb '{CollectionName}' collection in database '{DatabaseName}'", collectionName, database.DatabaseNamespace.DatabaseName);
+                logger.LogDebug("[Test:Setup] Use already existing Azure Cosmos DB for MongoDB '{CollectionName}' collection in database '{DatabaseName}'", collectionName, database.DatabaseNamespace.DatabaseName);
 
                 await CleanCollectionOnSetupAsync(database, collectionName, options, logger);
                 return new TemporaryMongoDbCollection(createdByUs: false, collectionName, database, logger, options);
             }
 
-            logger.LogDebug("[Test:Setup] Create new Azure Cosmos MongoDb '{CollectionName}' collection in database '{DatabaseName}'", collectionName, database.DatabaseNamespace.DatabaseName);
+            logger.LogDebug("[Test:Setup] Create new Azure Cosmos DB MongoDB '{CollectionName}' collection in database '{DatabaseName}'", collectionName, database.DatabaseNamespace.DatabaseName);
             await database.CreateCollectionAsync(collectionName);
 
             return new TemporaryMongoDbCollection(createdByUs: true, collectionName, database, logger, options);
@@ -371,13 +377,13 @@ namespace Arcus.Testing
 
             if (options.OnSetup.Documents is OnSetupMongoDbCollection.CleanIfExisted)
             {
-                logger.LogDebug("[Test:Setup] Clean all documents in Azure Cosmos MongoDb collection '{DatabaseName}/{CollectionName}'", database.DatabaseNamespace.DatabaseName, collectionName);
+                logger.LogDebug("[Test:Setup] Clean all documents in Azure Cosmos DB MongoDB collection '{DatabaseName}/{CollectionName}'", database.DatabaseNamespace.DatabaseName, collectionName);
                 await collection.DeleteManyAsync(Builders<BsonDocument>.Filter.Empty);
             }
 
             if (options.OnSetup.Documents is OnSetupMongoDbCollection.CleanIfMatched)
             {
-                logger.LogDebug("[Test:Setup] Clean all matching documents in Azure Cosmos MongoDb collection '{DatabaseName}/{CollectionName}'", database.DatabaseNamespace.DatabaseName, collectionName);
+                logger.LogDebug("[Test:Setup] Clean all matching documents in Azure Cosmos DB MongoDB collection '{DatabaseName}/{CollectionName}'", database.DatabaseNamespace.DatabaseName, collectionName);
                 await collection.DeleteManyAsync(options.OnSetup.IsMatched);
             }
         }
@@ -392,14 +398,14 @@ namespace Arcus.Testing
         }
 
         /// <summary>
-        /// Inserts a temporary <paramref name="document"/> to the MongoDb collection.
+        /// Inserts a temporary <paramref name="document"/> to the Azure Cosmos DB for MongoDB collection.
         /// </summary>
         /// <remarks>
-        ///     All documents inserted via the temporary collection will always be removed when the collection disposes,
+        ///     All MongoDB documents inserted via the temporary collection will always be removed when the collection disposes,
         ///     regardless of what teardown options were configured on the collection.
         /// </remarks>
-        /// <typeparam name="TDocument">The type of the document in the MongoDb collection.</typeparam>
-        /// <param name="document">The document to upload to the MongoDb collection.</param>
+        /// <typeparam name="TDocument">The type of the document in the MongoDB collection.</typeparam>
+        /// <param name="document">The document to upload to the MongoDB collection.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="document"/> is <c>null</c>.</exception>
         [Obsolete("Will be removed in v3, please use the " + nameof(UpsertDocumentAsync) + "instead that provides exactly the same functionality")]
         public async Task AddDocumentAsync<TDocument>(TDocument document)
@@ -408,14 +414,14 @@ namespace Arcus.Testing
         }
 
         /// <summary>
-        /// Adds a new or replaces an existing document in the Azure MongoDb collection (a.k.a. UPSERT).
+        /// Adds a new or replaces an existing document in the Azure Cosmos DB for MongoDB collection (a.k.a. UPSERT).
         /// </summary>
         /// <remarks>
         ///     ⚡ Any items upserted via this call will always be deleted (if new) or reverted (if existing)
         ///     when the <see cref="TemporaryMongoDbCollection"/> is disposed.
         /// </remarks>
-        /// <typeparam name="TDocument">The type of the document in the MongoDb collection.</typeparam>
-        /// <param name="document">The document to upload to the MongoDb collection.</param>
+        /// <typeparam name="TDocument">The type of the document in the MongoDB collection.</typeparam>
+        /// <param name="document">The document to upload to the MongoDB collection.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="document"/> is <c>null</c>.</exception>
         public async Task UpsertDocumentAsync<TDocument>(TDocument document)
         {
@@ -438,7 +444,7 @@ namespace Arcus.Testing
             {
                 disposables.Add(AsyncDisposable.Create(async () =>
                 {
-                    _logger.LogDebug("[Test:Teardown] Delete Azure Cosmos MongoDb '{CollectionName}' collection in database '{DatabaseName}'", Name, _database.DatabaseNamespace.DatabaseName);
+                    _logger.LogDebug("[Test:Teardown] Delete Azure Cosmos DB for MongoDB '{CollectionName}' collection in database '{DatabaseName}'", Name, _database.DatabaseNamespace.DatabaseName);
                     await _database.DropCollectionAsync(Name);
                 }));
             }
@@ -464,13 +470,13 @@ namespace Arcus.Testing
 
             if (_options.OnTeardown.Documents is OnTeardownMongoDbCollection.CleanAll)
             {
-                _logger.LogDebug("[Test:Teardown] Clean all documents in Azure Cosmos MongoDb '{DatabaseName}/{CollectionName}' collection", _database.DatabaseNamespace.DatabaseName, Name);
+                _logger.LogDebug("[Test:Teardown] Clean all documents in Azure Cosmos DB for MongoDB '{DatabaseName}/{CollectionName}' collection", _database.DatabaseNamespace.DatabaseName, Name);
                 await collection.DeleteManyAsync(Builders<BsonDocument>.Filter.Empty);
             }
 
             if (_options.OnTeardown.Documents is OnTeardownMongoDbCollection.CleanIfMatched)
             {
-                _logger.LogDebug("[Test:Teardown] Clean all matching documents in Azure Cosmos MongoDb '{DatabaseName}/{CollectionName}' collection", _database.DatabaseNamespace.DatabaseName, Name);
+                _logger.LogDebug("[Test:Teardown] Clean all matching documents in Azure Cosmos DB for MongoDB '{DatabaseName}/{CollectionName}' collection", _database.DatabaseNamespace.DatabaseName, Name);
                 await collection.DeleteManyAsync(_options.OnTeardown.IsMatched);
             }
         }

--- a/src/Arcus.Testing.Storage.Cosmos/TemporaryMongoDbDocument.cs
+++ b/src/Arcus.Testing.Storage.Cosmos/TemporaryMongoDbDocument.cs
@@ -13,7 +13,7 @@ using MongoDB.Driver;
 namespace Arcus.Testing
 {
     /// <summary>
-    /// Represents a temporary Azure Cosmos MongoDb document that will be deleted after the instance is disposed.
+    /// Represents a temporary Azure Cosmos DB for MongoDB document that will be deleted after the instance is disposed.
     /// </summary>
     public class TemporaryMongoDbDocument : IAsyncDisposable
     {
@@ -46,15 +46,15 @@ namespace Arcus.Testing
         }
 
         /// <summary>
-        /// Gets the current ID of the document.
+        /// Gets the current ID of the MongoDB document.
         /// </summary>
         public BsonValue Id { get; }
 
         /// <summary>
-        /// Inserts a temporary document to an Azure Cosmos MongoDb collection.
+        /// Inserts a temporary document to an Azure Cosmos DB for MongoDB collection.
         /// </summary>
         /// <param name="cosmosDbResourceId">
-        ///   <para>The resource ID pointing towards the Azure Cosmos account.</para>
+        ///   <para>The resource ID pointing towards the Azure Cosmos DB account.</para>
         ///   <para>The resource ID can be constructed with the <see cref="CosmosDBAccountResource.CreateResourceIdentifier"/>:</para>
         ///   <example>
         ///     <code>
@@ -63,9 +63,9 @@ namespace Arcus.Testing
         ///     </code>
         ///   </example>
         /// </param>
-        /// <param name="databaseName">The name of the MongoDb database in which the collection resides where the document should be created.</param>
-        /// <param name="collectionName">The name of the MongoDb collection in which the document should be created.</param>
-        /// <param name="document">The document that should be temporarily inserted into the MongoDb collection.</param>
+        /// <param name="databaseName">The name of the MongoDB database in which the collection resides where the document should be created.</param>
+        /// <param name="collectionName">The name of the MongoDB collection in which the document should be created.</param>
+        /// <param name="document">The document that should be temporarily inserted into the MongoDB collection.</param>
         /// <param name="logger">The logger to write diagnostic information during the lifetime of the MongoDb document.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="cosmosDbResourceId"/> or <paramref name="document"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="databaseName"/> or the <paramref name="collectionName"/> is blank.</exception>
@@ -82,10 +82,10 @@ namespace Arcus.Testing
         }
 
         /// <summary>
-        /// Inserts a temporary document to an Azure Cosmos MongoDb collection.
+        /// Inserts a temporary document to an Azure Cosmos DB for MongoDB collection.
         /// </summary>
-        /// <param name="collection">The collection client to interact with the MongoDb collection.</param>
-        /// <param name="document">The document that should be temporarily inserted into the MongoDb collection.</param>
+        /// <param name="collection">The collection client to interact with the MongoDB collection.</param>
+        /// <param name="document">The document that should be temporarily inserted into the MongoDB collection.</param>
         /// <param name="logger">The logger to write diagnostic information during the lifetime of the MongoDb document.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="collection"/> or the <paramref name="document"/> is <c>null</c>.</exception>
         [Obsolete("Will be removed in v3, please use the " + nameof(UpsertDocumentAsync) + "instead that provides exactly the same functionality")]
@@ -95,13 +95,13 @@ namespace Arcus.Testing
         }
 
         /// <summary>
-        /// Creates a new or replaces an existing document in an Azure Cosmos MongoDb collection.
+        /// Creates a new or replaces an existing document in an Azure Cosmos DB for MongoDB collection.
         /// </summary>
         /// <remarks>
         ///     ⚡ Document will be deleted (if new) or reverted (if existing) when the <see cref="TemporaryMongoDbDocument"/> is disposed.
         /// </remarks>
         /// <param name="cosmosDbResourceId">
-        ///   <para>The resource ID pointing towards the Azure Cosmos account.</para>
+        ///   <para>The resource ID pointing towards the Azure Cosmos DB account.</para>
         ///   <para>The resource ID can be constructed with the <see cref="CosmosDBAccountResource.CreateResourceIdentifier"/>:</para>
         ///   <example>
         ///     <code>
@@ -110,10 +110,10 @@ namespace Arcus.Testing
         ///     </code>
         ///   </example>
         /// </param>
-        /// <param name="databaseName">The name of the MongoDb database in which the collection resides where the document should be created.</param>
-        /// <param name="collectionName">The name of the MongoDb collection in which the document should be created.</param>
-        /// <param name="document">The document that should be temporarily inserted into the MongoDb collection.</param>
-        /// <param name="logger">The logger to write diagnostic information during the lifetime of the MongoDb document.</param>
+        /// <param name="databaseName">The name of the MongoDB database in which the collection resides where the document should be created.</param>
+        /// <param name="collectionName">The name of the MongoDB collection in which the document should be created.</param>
+        /// <param name="document">The document that should be temporarily inserted into the MongoDB collection.</param>
+        /// <param name="logger">The logger to write diagnostic information during the lifetime of the MongoDB document.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="cosmosDbResourceId"/> or <paramref name="document"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="databaseName"/> or the <paramref name="collectionName"/> is blank.</exception>
         public static async Task<TemporaryMongoDbDocument> UpsertDocumentAsync<TDocument>(
@@ -138,14 +138,14 @@ namespace Arcus.Testing
         }
 
         /// <summary>
-        /// Creates a new or replaces an existing document in an Azure Cosmos MongoDb collection.
+        /// Creates a new or replaces an existing document in an Azure Cosmos DB for MongoDB collection.
         /// </summary>
         /// <remarks>
         ///     ⚡ Document will be deleted (if new) or reverted (if existing) when the <see cref="TemporaryMongoDbDocument"/> is disposed.
         /// </remarks>
-        /// <param name="collection">The collection client to interact with the MongoDb collection.</param>
-        /// <param name="document">The document that should be temporarily inserted into the MongoDb collection.</param>
-        /// <param name="logger">The logger to write diagnostic information during the lifetime of the MongoDb document.</param>
+        /// <param name="collection">The collection client to interact with the MongoDB collection.</param>
+        /// <param name="document">The document that should be temporarily inserted into the MongoDB collection.</param>
+        /// <param name="logger">The logger to write diagnostic information during the lifetime of the MongoDB document.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="collection"/> or the <paramref name="document"/> is <c>null</c>.</exception>
         public static async Task<TemporaryMongoDbDocument> UpsertDocumentAsync<TDocument>(IMongoCollection<TDocument> collection, TDocument document, ILogger logger)
         {
@@ -167,20 +167,20 @@ namespace Arcus.Testing
             if (matchingDocs.Count > 1)
             {
                 throw new InvalidOperationException(
-                    $"[Test:Setup] Cannot temporary insert a document in the MongoDb collection '{collection.CollectionNamespace.FullName}' " +
+                    $"[Test:Setup] Cannot temporary insert a document in the Azure Cosmos DB for MongoDB collection '{collection.CollectionNamespace.FullName}' " +
                     $"as the passed filter expression for document type '{typeof(TDocument).Name}' matches more than a single document, " +
                     $"please stricken the filter expression so that it only matches a single document, if you want to temporary replace the document");
             }
 
             if (matchingDocs.Count is 0)
             {
-                logger.LogDebug("[Test:Setup] Insert new Azure Cosmos MongoDb '{DocumentType}' document '{DocumentId}' in collection '{DatabaseName}/{CollectionName}'", typeof(TDocument).Name, BsonTypeMapper.MapToDotNetValue(id), collection.Database.DatabaseNamespace.DatabaseName, collection.CollectionNamespace.FullName);
+                logger.LogDebug("[Test:Setup] Insert new Azure Cosmos DB for MongoDB '{DocumentType}' document '{DocumentId}' in collection '{DatabaseName}/{CollectionName}'", typeof(TDocument).Name, BsonTypeMapper.MapToDotNetValue(id), collection.Database.DatabaseNamespace.DatabaseName, collection.CollectionNamespace.FullName);
 
                 await collectionBson.InsertOneAsync(bson);
                 return new TemporaryMongoDbDocument(id, typeof(TDocument), findOneDocument, originalDoc: null, collectionBson, logger);
             }
 
-            logger.LogDebug("[Test:Setup] Replace Azure Cosmos MongoDb '{DocumentType}' document '{DocumentId}' in collection '{DatabaseName}/{CollectionName}'", typeof(TDocument).Name, BsonTypeMapper.MapToDotNetValue(id), collection.Database.DatabaseNamespace.DatabaseName, collection.CollectionNamespace.FullName);
+            logger.LogDebug("[Test:Setup] Replace Azure Cosmos DB for MongoDB '{DocumentType}' document '{DocumentId}' in collection '{DatabaseName}/{CollectionName}'", typeof(TDocument).Name, BsonTypeMapper.MapToDotNetValue(id), collection.Database.DatabaseNamespace.DatabaseName, collection.CollectionNamespace.FullName);
 
             BsonDocument originalDoc = matchingDocs.Single();
             await collectionBson.FindOneAndReplaceAsync(findOneDocument, bson);
@@ -194,7 +194,7 @@ namespace Arcus.Testing
             if (classMap.IdMemberMap is null)
             {
                 throw new InvalidOperationException(
-                    $"[Test:Setup] Cannot temporary insert a document in the MongoDb collection '{collection.CollectionNamespace.FullName}' " +
+                    $"[Test:Setup] Cannot temporary insert a document in the Azure Cosmos DB for MongoDB collection '{collection.CollectionNamespace.FullName}' " +
                     $"as the passed document type '{typeof(TDocument).Name}' has no member map defined for the '_id' property, " +
                     $"please see the MongoDb documentation for more information on this required property: https://www.mongodb.com/docs/drivers/csharp/current/fundamentals/crud/write-operations/insert/#the-_id-field");
             }
@@ -231,7 +231,7 @@ namespace Arcus.Testing
             {
                 disposables.Add(AsyncDisposable.Create(async () =>
                 {
-                    _logger.LogDebug("[Test:Teardown] Delete Azure Cosmos MongoDb '{DocumentType}' document '{DocumentId}' in collection '{DatabaseName}/{CollectionName}'", _documentType.Name, id, _collection.Database.DatabaseNamespace.DatabaseName, _collection.CollectionNamespace.FullName);
+                    _logger.LogDebug("[Test:Teardown] Delete Azure Cosmos DB for MongoDB '{DocumentType}' document '{DocumentId}' in collection '{DatabaseName}/{CollectionName}'", _documentType.Name, id, _collection.Database.DatabaseNamespace.DatabaseName, _collection.CollectionNamespace.FullName);
                     await _collection.DeleteOneAsync(_filter);
                 }));
             }
@@ -239,7 +239,7 @@ namespace Arcus.Testing
             {
                 disposables.Add(AsyncDisposable.Create(async () =>
                 {
-                    _logger.LogDebug("[Test:Teardown] Revert replaced Azure Cosmos MongoDb '{DocumentType}' document '{DocumentId}' in collection '{DatabaseName}/{CollectionName}'", _documentType.Name, id, _collection.Database.DatabaseNamespace.DatabaseName, _collection.CollectionNamespace.FullName);
+                    _logger.LogDebug("[Test:Teardown] Revert replaced Azure Cosmos DB for MongoDB '{DocumentType}' document '{DocumentId}' in collection '{DatabaseName}/{CollectionName}'", _documentType.Name, id, _collection.Database.DatabaseNamespace.DatabaseName, _collection.CollectionNamespace.FullName);
                     await _collection.ReplaceOneAsync(_filter, _originalDoc);
                 }));
             }

--- a/src/Arcus.Testing.Storage.Cosmos/TemporaryNoSqlContainer.cs
+++ b/src/Arcus.Testing.Storage.Cosmos/TemporaryNoSqlContainer.cs
@@ -29,7 +29,7 @@ namespace Arcus.Testing
     internal enum OnTeardownNoSqlContainer { CleanIfUpserted = 0, CleanAll, CleanIfMatched }
 
     /// <summary>
-    /// Represents a generic dictionary-like type which defines an arbitrary set of properties on a NoSql item as key-value pairs.
+    /// Represents a generic dictionary-like type which defines an arbitrary set of properties on an Azure Cosmos DB for NoSQL item as key-value pairs.
     /// </summary>
     public class NoSqlItem
     {
@@ -59,7 +59,7 @@ namespace Arcus.Testing
         public PartitionKey PartitionKey { get; }
 
         /// <summary>
-        /// Gets the complete custom user-defined content of the stored NoSql item.
+        /// Gets the complete custom user-defined content of the stored NoSQL item.
         /// </summary>
         public JsonNode Content { get; }
     }
@@ -72,13 +72,13 @@ namespace Arcus.Testing
         private readonly List<Func<CosmosClient, NoSqlItem, bool>> _filters = [];
 
         /// <summary>
-        /// Gets the configurable setup option on what to do with existing NoSql items in the Azure NoSql container upon the test fixture creation.
+        /// Gets the configurable setup option on what to do with existing NoSQL items in the Azure NoSql container upon the test fixture creation.
         /// </summary>
         internal OnSetupNoSqlContainer Items { get; private set; }
 
         /// <summary>
-        /// (default) Configures the <see cref="TemporaryNoSqlContainer"/> to leave all NoSql items untouched
-        /// that already existed upon the test fixture creation, when there was already an Azure NoSql container available.
+        /// (default) Configures the <see cref="TemporaryNoSqlContainer"/> to leave all NoSQL items untouched
+        /// that already existed upon the test fixture creation, when there was already an Azure Cosmos DB for NoSQL container available.
         /// </summary>
         public OnSetupNoSqlContainerOptions LeaveAllItems()
         {
@@ -87,7 +87,8 @@ namespace Arcus.Testing
         }
 
         /// <summary>
-        /// Configures the <see cref="TemporaryNoSqlContainer"/> to delete all the already existing NoSql items upon the test fixture creation.
+        /// Configures the <see cref="TemporaryNoSqlContainer"/> to delete all the already existing NoSQL items
+        /// in an Azure Cosmos DB for NoSql container upon the test fixture creation.
         /// </summary>
         public OnSetupNoSqlContainerOptions CleanAllItems()
         {
@@ -96,13 +97,13 @@ namespace Arcus.Testing
         }
 
         /// <summary>
-        /// Configures the <see cref="TemporaryNoSqlContainer"/> to delete the NoSql items
-        /// upon the test fixture creation that match any of the configured <paramref name="filters"/>.
+        /// Configures the <see cref="TemporaryNoSqlContainer"/> to delete the NoSQL items
+        /// in an Azure Cosmos DB for NoSql container upon the test fixture creation that match any of the configured <paramref name="filters"/>.
         /// </summary>
         /// <remarks>
         ///     Multiple calls will be aggregated together in an OR expression.
         /// </remarks>
-        /// <param name="filters">The filters to match NoSql items that should be removed.</param>
+        /// <param name="filters">The filters to match NoSQL items that should be removed.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="filters"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when one or more <paramref name="filters"/> is <c>null</c>.</exception>
         public OnSetupNoSqlContainerOptions CleanMatchingItems(params Func<NoSqlItem, bool>[] filters)
@@ -121,14 +122,14 @@ namespace Arcus.Testing
         }
 
         /// <summary>
-        /// Configures the <see cref="TemporaryNoSqlContainer"/> to delete the NoSql items
-        /// upon the test fixture creation that match any of the configured <paramref name="filters"/>.
+        /// Configures the <see cref="TemporaryNoSqlContainer"/> to delete the NoSQL items
+        /// in an Azure Cosmos DB for NoSql container upon the test fixture creation that match any of the configured <paramref name="filters"/>.
         /// </summary>
         /// <remarks>
         ///     Multiple calls will be aggregated together in an OR expression.
         /// </remarks>
-        /// <typeparam name="TItem">The custom type of the NoSql item.</typeparam>
-        /// <param name="filters">The filters to match NoSql items that should be removed.</param>
+        /// <typeparam name="TItem">The custom type of the NoSQL item.</typeparam>
+        /// <param name="filters">The filters to match NoSQL items that should be removed.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="filters"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when one or more <paramref name="filters"/> is <c>null</c>.</exception>
         public OnSetupNoSqlContainerOptions CleanMatchingItems<TItem>(params Func<TItem, bool>[] filters)
@@ -170,13 +171,13 @@ namespace Arcus.Testing
         private readonly List<Func<CosmosClient, NoSqlItem, bool>> _filters = [];
 
         /// <summary>
-        /// Gets the configurable setup option on what to do with existing NoSql items in the Azure NoSql container upon the test fixture deletion.
+        /// Gets the configurable setup option on what to do with existing NoSQL items in the Azure NoSql container upon the test fixture deletion.
         /// </summary>
         internal OnTeardownNoSqlContainer Items { get; private set; }
 
         /// <summary>
-        /// (default for cleaning items) Configures the <see cref="TemporaryNoSqlContainer"/> to only delete the NoSql items upon disposal
-        /// if the item was upserted by the test fixture (using <see cref="TemporaryNoSqlContainer.AddItemAsync{TItem}"/>).
+        /// (default for cleaning items) Configures the <see cref="TemporaryNoSqlContainer"/> to only delete the NoSQL items
+        /// in an Azure Cosmos DB for NoSQL container upon disposal if the item was upserted by the test fixture (using <see cref="TemporaryNoSqlContainer.AddItemAsync{TItem}"/>).
         /// </summary>
         [Obsolete("Will be removed in v3, please use " + nameof(CleanUpsertedItems) + " instead that provides exactly the same on-teardown functionality")]
         public OnTeardownNoSqlContainerOptions CleanCreatedItems()
@@ -185,8 +186,8 @@ namespace Arcus.Testing
         }
 
         /// <summary>
-        /// (default for cleaning items) Configures the <see cref="TemporaryNoSqlContainer"/> to only delete or revert the NoSql items upon disposal
-        /// if the item was upserted by the test fixture (using <see cref="TemporaryNoSqlContainer.UpsertItemAsync{TItem}"/>).
+        /// (default for cleaning items) Configures the <see cref="TemporaryNoSqlContainer"/> to only delete or revert the NoSQL items
+        /// in an Azure Cosmos DB for NoSQL container upon disposal if the item was upserted by the test fixture (using <see cref="TemporaryNoSqlContainer.UpsertItemAsync{TItem}"/>).
         /// </summary>
         public OnTeardownNoSqlContainerOptions CleanUpsertedItems()
         {
@@ -195,7 +196,8 @@ namespace Arcus.Testing
         }
 
         /// <summary>
-        /// Configures the <see cref="TemporaryNoSqlContainer"/> to delete all the NoSql items upon disposal - even if the test fixture didn't add them.
+        /// Configures the <see cref="TemporaryNoSqlContainer"/> to delete all the NoSQL items
+        /// in an Azure Cosmos DB for NoSQL container upon disposal - even if the test fixture didn't add them.
         /// </summary>
         public OnTeardownNoSqlContainerOptions CleanAllItems()
         {
@@ -204,15 +206,15 @@ namespace Arcus.Testing
         }
 
         /// <summary>
-        /// Configures the <see cref="TemporaryNoSqlContainer"/> to delete the NoSql items
-        /// upon disposal that match any of the configured <paramref name="filters"/>.
+        /// Configures the <see cref="TemporaryNoSqlContainer"/> to delete the NoSQL items
+        /// in an Azure Cosmos DB for NoSQL container upon disposal that match any of the configured <paramref name="filters"/>.
         /// </summary>
         /// <remarks>
-        ///     The matching of items only happens on NoSql items that were created outside the scope of the test fixture.
+        ///     The matching of items only happens on NoSQL items that were created outside the scope of the test fixture.
         ///     All items created by the test fixture will be deleted or reverted upon disposal, even if the items do not match one of the filters.
         ///     This follows the 'clean environment' principle where the test fixture should clean up after itself and not linger around any state it created.
         /// </remarks>
-        /// <param name="filters">The filters  to match NoSql items that should be removed.</param>
+        /// <param name="filters">The filters  to match NoSQL items that should be removed.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="filters"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="filters"/> contains <c>null</c>.</exception>
         public OnTeardownNoSqlContainerOptions CleanMatchingItems(params Func<NoSqlItem, bool>[] filters)
@@ -231,16 +233,16 @@ namespace Arcus.Testing
         }
 
         /// <summary>
-        /// Configures the <see cref="TemporaryNoSqlContainer"/> to delete the NoSql items
-        /// upon disposal that match any of the configured <paramref name="filters"/>.
+        /// Configures the <see cref="TemporaryNoSqlContainer"/> to delete the NoSQL items
+        /// in an Azure Cosmos DB for NoSQL container upon disposal that match any of the configured <paramref name="filters"/>.
         /// </summary>
         /// <remarks>
-        ///     The matching of items only happens on NoSql items that were created outside the scope of the test fixture.
+        ///     The matching of items only happens on NoSQL items that were created outside the scope of the test fixture.
         ///     All items upserted by the test fixture will be deleted or reverted upon disposal, even if the items do not match one of the filters.
         ///     This follows the 'clean environment' principle where the test fixture should clean up after itself and not linger around any state it created.
         /// </remarks>
-        /// <typeparam name="TItem">The custom type of the NoSql item.</typeparam>
-        /// <param name="filters">The filters  to match NoSql items that should be removed.</param>
+        /// <typeparam name="TItem">The custom type of the NoSQL item.</typeparam>
+        /// <param name="filters">The filters  to match NoSQL items that should be removed.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="filters"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="filters"/> contains <c>null</c>.</exception>
         public OnTeardownNoSqlContainerOptions CleanMatchingItems<TItem>(params Func<TItem, bool>[] filters)
@@ -292,7 +294,7 @@ namespace Arcus.Testing
     }
 
     /// <summary>
-    /// Represents a temporary Azure Cosmos NoSql container that will be deleted after the instance is disposed.
+    /// Represents a temporary Azure Cosmos DB for NoSQL container that will be deleted after the instance is disposed.
     /// </summary>
     public class TemporaryNoSqlContainer : IAsyncDisposable
     {
@@ -326,12 +328,12 @@ namespace Arcus.Testing
         }
 
         /// <summary>
-        /// Gets the unique name of the NoSql container, currently available on Azure Cosmos.
+        /// Gets the unique name of the NoSQL container, currently available on Azure Cosmos DB.
         /// </summary>
         public string Name => Client.Id;
 
         /// <summary>
-        /// Gets the client to interact with the NoSql container.
+        /// Gets the client to interact with the Azure Cosmos DB for NoSQL container.
         /// </summary>
         public Container Client { get; }
 
@@ -341,10 +343,10 @@ namespace Arcus.Testing
         public OnTeardownNoSqlContainerOptions OnTeardown => _options.OnTeardown;
 
         /// <summary>
-        /// Creates a new instance of the <see cref="TemporaryNoSqlContainer"/> which creates a new Azure Cosmos NoSql container if it doesn't exist yet.
+        /// Creates a new instance of the <see cref="TemporaryNoSqlContainer"/> which creates a new Azure Cosmos DB NoSQL container if it doesn't exist yet.
         /// </summary>
         /// <param name="cosmosDbAccountResourceId">
-        ///   <para>The resource ID of the Azure Cosmos resource where the temporary NoSql container should be created.</para>
+        ///   <para>The resource ID of the Azure Cosmos DB resource where the temporary NoSQL container should be created.</para>
         ///   <para>The resource ID can be constructed with the <see cref="CosmosDBAccountResource.CreateResourceIdentifier"/>:</para>
         ///   <example>
         ///     <code>
@@ -353,10 +355,10 @@ namespace Arcus.Testing
         ///     </code>
         ///   </example>
         /// </param>
-        /// <param name="databaseName">The name of the existing NoSql database in the Azure Cosmos resource.</param>
-        /// <param name="containerName">The name of the NoSql container to be created within the Azure Cosmos resource.</param>
-        /// <param name="partitionKeyPath">The path to the partition key of the NoSql item which describes how the items should be partitioned.</param>
-        /// <param name="logger">The logger instance to write diagnostic information during the lifetime of the NoSql container.</param>
+        /// <param name="databaseName">The name of the existing NoSQL database in the Azure Cosmos DB resource.</param>
+        /// <param name="containerName">The name of the NoSQL container to be created within the Azure Cosmos DB resource.</param>
+        /// <param name="partitionKeyPath">The path to the partition key of the NoSQL item which describes how the items should be partitioned.</param>
+        /// <param name="logger">The logger instance to write diagnostic information during the lifetime of the NoSQL container.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="cosmosDbAccountResourceId"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">
         ///     Thrown when the <paramref name="databaseName"/>, <paramref name="containerName"/>, or the <paramref name="partitionKeyPath"/> is blank.
@@ -378,10 +380,10 @@ namespace Arcus.Testing
         }
 
         /// <summary>
-        /// Creates a new instance of the <see cref="TemporaryNoSqlContainer"/> which creates a new Azure Cosmos NoSql container if it doesn't exist yet.
+        /// Creates a new instance of the <see cref="TemporaryNoSqlContainer"/> which creates a new Azure Cosmos DB for NoSql container if it doesn't exist yet.
         /// </summary>
         /// <param name="cosmosDbAccountResourceId">
-        ///   <para>The resource ID of the Azure Cosmos resource where the temporary NoSql container should be created.</para>
+        ///   <para>The resource ID of the Azure Cosmos DB resource where the temporary NoSQL container should be created.</para>
         ///   <para>The resource ID can be constructed with the <see cref="CosmosDBAccountResource.CreateResourceIdentifier"/>:</para>
         ///   <example>
         ///     <code>
@@ -390,10 +392,10 @@ namespace Arcus.Testing
         ///     </code>
         ///   </example>
         /// </param>
-        /// <param name="databaseName">The name of the existing NoSql database in the Azure Cosmos resource.</param>
-        /// <param name="containerName">The name of the NoSql container to be created within the Azure Cosmos resource.</param>
-        /// <param name="partitionKeyPath">The path to the partition key of the NoSql item which describes how the items should be partitioned.</param>
-        /// <param name="logger">The logger instance to write diagnostic information during the lifetime of the NoSql container.</param>
+        /// <param name="databaseName">The name of the existing NoSQL database in the Azure Cosmos resource.</param>
+        /// <param name="containerName">The name of the NoSQL container to be created within the Azure Cosmos DB resource.</param>
+        /// <param name="partitionKeyPath">The path to the partition key of the NoSQL item which describes how the items should be partitioned.</param>
+        /// <param name="logger">The logger instance to write diagnostic information during the lifetime of the NoSQL container.</param>
         /// <param name="configureOptions">The additional options to manipulate the behavior of the test fixture.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="cosmosDbAccountResourceId"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">
@@ -418,10 +420,10 @@ namespace Arcus.Testing
         }
 
         /// <summary>
-        /// Creates a new instance of the <see cref="TemporaryNoSqlContainer"/> which creates a new Azure Cosmos NoSql container if it doesn't exist yet.
+        /// Creates a new instance of the <see cref="TemporaryNoSqlContainer"/> which creates a new Azure Cosmos DB for NoSQL container if it doesn't exist yet.
         /// </summary>
         /// <param name="cosmosDbAccountResourceId">
-        ///   <para>The resource ID of the Azure Cosmos resource where the temporary NoSql container should be created.</para>
+        ///   <para>The resource ID of the Azure Cosmos DB resource where the temporary NoSQL container should be created.</para>
         ///   <para>The resource ID can be constructed with the <see cref="CosmosDBAccountResource.CreateResourceIdentifier"/>:</para>
         ///   <example>
         ///     <code>
@@ -430,11 +432,11 @@ namespace Arcus.Testing
         ///     </code>
         ///   </example>
         /// </param>
-        /// <param name="credential">The credential implementation to authenticate with the Azure Cosmos resource.</param>
-        /// <param name="databaseName">The name of the existing NoSql database in the Azure Cosmos resource.</param>
-        /// <param name="containerName">The name of the NoSql container to be created within the Azure Cosmos resource.</param>
+        /// <param name="credential">The credential implementation to authenticate with the Azure Cosmos DB resource.</param>
+        /// <param name="databaseName">The name of the existing NoSQL database in the Azure Cosmos DB resource.</param>
+        /// <param name="containerName">The name of the NoSQL container to be created within the Azure Cosmos DB resource.</param>
         /// <param name="partitionKeyPath">The path to the partition key of the NoSql item which describes how the items should be partitioned.</param>
-        /// <param name="logger">The logger instance to write diagnostic information during the lifetime of the NoSql container.</param>
+        /// <param name="logger">The logger instance to write diagnostic information during the lifetime of the NoSQL container.</param>
         /// <exception cref="ArgumentNullException">
         ///     Thrown when the <paramref name="cosmosDbAccountResourceId"/> or the <paramref name="credential"/> is <c>null</c>.
         /// </exception>
@@ -460,10 +462,10 @@ namespace Arcus.Testing
         }
 
         /// <summary>
-        /// Creates a new instance of the <see cref="TemporaryNoSqlContainer"/> which creates a new Azure Cosmos NoSql container if it doesn't exist yet.
+        /// Creates a new instance of the <see cref="TemporaryNoSqlContainer"/> which creates a new Azure Cosmos DB for NoSQL container if it doesn't exist yet.
         /// </summary>
         /// <param name="cosmosDbAccountResourceId">
-        ///   <para>The resource ID of the Azure Cosmos resource where the temporary NoSql container should be created.</para>
+        ///   <para>The resource ID of the Azure Cosmos DB resource where the temporary NoSQL container should be created.</para>
         ///   <para>The resource ID can be constructed with the <see cref="CosmosDBAccountResource.CreateResourceIdentifier"/>:</para>
         ///   <example>
         ///     <code>
@@ -472,11 +474,11 @@ namespace Arcus.Testing
         ///     </code>
         ///   </example>
         /// </param>
-        /// <param name="credential">The credential implementation to authenticate with the Azure Cosmos resource.</param>
-        /// <param name="databaseName">The name of the existing NoSql database in the Azure Cosmos resource.</param>
-        /// <param name="containerName">The name of the NoSql container to be created within the Azure Cosmos resource.</param>
-        /// <param name="partitionKeyPath">The path to the partition key of the NoSql item which describes how the items should be partitioned.</param>
-        /// <param name="logger">The logger instance to write diagnostic information during the lifetime of the NoSql container.</param>
+        /// <param name="credential">The credential implementation to authenticate with the Azure Cosmos DB resource.</param>
+        /// <param name="databaseName">The name of the existing NoSQL database in the Azure Cosmos DB resource.</param>
+        /// <param name="containerName">The name of the NoSQL container to be created within the Azure Cosmos DB resource.</param>
+        /// <param name="partitionKeyPath">The path to the partition key of the NoSQL item which describes how the items should be partitioned.</param>
+        /// <param name="logger">The logger instance to write diagnostic information during the lifetime of the NoSQL container.</param>
         /// <param name="configureOptions">The additional options to manipulate the behavior of the test fixture.</param>
         /// <exception cref="ArgumentNullException">
         ///     Thrown when the <paramref name="cosmosDbAccountResourceId"/> or the <paramref name="credential"/> is <c>null</c>.
@@ -511,7 +513,7 @@ namespace Arcus.Testing
 
             if (await database.GetCosmosDBSqlContainers().ExistsAsync(containerName))
             {
-                logger.LogDebug("[Test:Setup] Use already existing Azure Cosmos NoSql '{ContainerName}' container in database '{DatabaseName}'", containerName, databaseName);
+                logger.LogDebug("[Test:Setup] Use already existing Azure Cosmos DB for NoSQL '{ContainerName}' container in database '{DatabaseName}'", containerName, databaseName);
                 await CleanContainerOnSetupAsync(containerClient, options, logger);
 
                 CosmosDBSqlContainerResource container = await database.GetCosmosDBSqlContainerAsync(containerName);
@@ -519,7 +521,7 @@ namespace Arcus.Testing
             }
             else
             {
-                logger.LogDebug("[Test:Setup] Create new Azure Cosmos NoSql '{ContainerName}' container in database '{DatabaseName}'", containerName, databaseName);
+                logger.LogDebug("[Test:Setup] Create new Azure Cosmos DB for NoSQL '{ContainerName}' container in database '{DatabaseName}'", containerName, databaseName);
 
                 var properties = new ContainerProperties(containerName, partitionKeyPath);
                 CosmosDBSqlContainerResource container = await CreateNewNoSqlContainerAsync(cosmosDb, database, properties);
@@ -569,13 +571,13 @@ namespace Arcus.Testing
             {
                 await ForEachItemAsync(container, async (id, partitionKey, _) =>
                 {
-                    logger.LogDebug("[Test:Setup] Delete Azure Cosmos NoSql item '{ItemId}' {PartitionKey} in container '{DatabaseName}/{ContainerName}'", id, partitionKey, container.Database.Id, container.Id);
+                    logger.LogDebug("[Test:Setup] Delete NoSQL item '{ItemId}' {PartitionKey} in Azure Cosmos DB for NoSQL container '{DatabaseName}/{ContainerName}'", id, partitionKey, container.Database.Id, container.Id);
                     using ResponseMessage response = await container.DeleteItemStreamAsync(id, partitionKey);
 
                     if (!response.IsSuccessStatusCode && response.StatusCode != HttpStatusCode.NotFound)
                     {
                         throw new RequestFailedException(
-                            $"[Test:Setup] Failed to delete Azure Cosmos NoSql item '{id}' {partitionKey} in container '{container.Database.Id}/{container.Id}' " +
+                            $"[Test:Setup] Failed to delete NoSQL item '{id}' {partitionKey} in Azure Cosmos DB for NoSQL container '{container.Database.Id}/{container.Id}' " +
                             $"since the delete operation responded with a failure: {(int) response.StatusCode} {response.StatusCode}: {response.ErrorMessage}");
                     }
                 });
@@ -586,13 +588,13 @@ namespace Arcus.Testing
                 {
                     if (options.OnSetup.IsMatched(id, key, doc, container.Database.Client))
                     {
-                        logger.LogDebug("[Test:Setup] Delete matched Azure Cosmos NoSql item '{ItemId}' {PartitionKey} in container '{DatabaseName}/{ContainerName}'", id, key, container.Database.Id, container.Id);
+                        logger.LogDebug("[Test:Setup] Delete matched NoSQL item '{ItemId}' {PartitionKey} in Azure Cosmos DB for NoSQL container '{DatabaseName}/{ContainerName}'", id, key, container.Database.Id, container.Id);
                         using ResponseMessage response = await container.DeleteItemStreamAsync(id, key);
 
                         if (!response.IsSuccessStatusCode && response.StatusCode != HttpStatusCode.NotFound)
                         {
                             throw new RequestFailedException(
-                                $"[Test:Setup] Failed to delete matched Azure Cosmos NoSql item '{id}' {key} in container '{container.Database.Id}/{container.Id}' " +
+                                $"[Test:Setup] Failed to delete matched NoSQL item '{id}' {key} in Azure Cosmos DB for NoSQL container '{container.Database.Id}/{container.Id}' " +
                                 $"since the delete operation responded with a failure: {(int) response.StatusCode} {response.StatusCode}: {response.ErrorMessage}");
                         }
                     }
@@ -603,8 +605,8 @@ namespace Arcus.Testing
         /// <summary>
         /// Adds a temporary NoSql item to the current container instance.
         /// </summary>
-        /// <typeparam name="T">The custom NoSql model.</typeparam>
-        /// <param name="item">The item to create in the NoSql container.</param>
+        /// <typeparam name="T">The custom NoSQL model.</typeparam>
+        /// <param name="item">The item to create in the NoSQL container.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="item"/> is <c>null</c>.</exception>
         [Obsolete("Will be removed in v3, please use the " + nameof(UpsertItemAsync) + "instead that provides exactly the same functionality")]
         public async Task AddItemAsync<T>(T item)
@@ -613,13 +615,13 @@ namespace Arcus.Testing
         }
 
         /// <summary>
-        /// Adds a new or replaces an existing NoSql item in the Azure NoSql container (a.k.a. UPSERT).
+        /// Adds a new or replaces an existing NoSQL item in the Azure Cosmos DB for NoSQL container (a.k.a. UPSERT).
         /// </summary>
         /// <remarks>
         ///     ⚡ Any items upserted via this call will always be deleted (if new) or reverted (if existing)
         ///     when the <see cref="TemporaryNoSqlContainer"/> is disposed.
         /// </remarks>
-        /// <param name="item">The item to create in the NoSql container.</param>
+        /// <param name="item">The item to create in the Azure Cosmos DB for NoSQL container.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="item"/> is <c>null</c>.</exception>
         public async Task UpsertItemAsync<TItem>(TItem item)
         {
@@ -640,7 +642,7 @@ namespace Arcus.Testing
             {
                 disposables.Add(AsyncDisposable.Create(async () =>
                 {
-                    _logger.LogDebug("[Test:Teardown] Delete Azure Cosmos NoSql '{ContainerName}' container in database '{DatabaseName}'", _container.Id.Name, _container.Id.Parent?.Name);
+                    _logger.LogDebug("[Test:Teardown] Delete Azure Cosmos DB for NoSQL '{ContainerName}' container in database '{DatabaseName}'", _container.Id.Name, _container.Id.Parent?.Name);
                     await _container.DeleteAsync(WaitUntil.Completed);
                 }));
             }
@@ -667,13 +669,13 @@ namespace Arcus.Testing
                 {
                     disposables.Add(AsyncDisposable.Create(async () =>
                     {
-                        _logger.LogDebug("[Test:Teardown] Delete Azure Cosmos NoSql item '{ItemId}' {PartitionKey} in NoSql container '{DatabaseName}/{ContainerName}'", id, key, Client.Database.Id, Client.Id);
+                        _logger.LogDebug("[Test:Teardown] Delete NoSQL item '{ItemId}' {PartitionKey} in Azure Cosmos DB for NoSQL container '{DatabaseName}/{ContainerName}'", id, key, Client.Database.Id, Client.Id);
                         using ResponseMessage response = await Client.DeleteItemStreamAsync(id, key);
 
                         if (!response.IsSuccessStatusCode && response.StatusCode != HttpStatusCode.NotFound)
                         {
                             throw new RequestFailedException(
-                                $"[Test:Teardown] Failed to delete Azure Cosmos NoSql item '{id}' {key} in container '{Client.Database.Id}/{Client.Id}' " +
+                                $"[Test:Teardown] Failed to delete NoSQL item '{id}' {key} in Azure Cosmos DB for NoSQL container '{Client.Database.Id}/{Client.Id}' " +
                                 $"since the delete operation responded with a failure: {(int) response.StatusCode} {response.StatusCode}: {response.ErrorMessage}");
                         }
                     }));
@@ -689,13 +691,13 @@ namespace Arcus.Testing
                     {
                         if (_options.OnTeardown.IsMatched(id, key, doc, Client.Database.Client))
                         {
-                            _logger.LogDebug("[Test:Teardown] Delete Azure Cosmos NoSql item '{ItemId}' {PartitionKey} in NoSql container '{DatabaseName}/{ContainerName}'", id, key, Client.Database.Id, Client.Id);
+                            _logger.LogDebug("[Test:Teardown] Delete NoSQL item '{ItemId}' {PartitionKey} in Azure Cosmos DB for NoSQL container '{DatabaseName}/{ContainerName}'", id, key, Client.Database.Id, Client.Id);
                             using ResponseMessage response = await Client.DeleteItemStreamAsync(id, key);
 
                             if (!response.IsSuccessStatusCode && response.StatusCode != HttpStatusCode.NotFound)
                             {
                                 throw new RequestFailedException(
-                                    $"[Test:Teardown] Failed to delete matched Azure Cosmos NoSql item '{id}' {key} in container '{Client.Database.Id}/{Client.Id}' " +
+                                    $"[Test:Teardown] Failed to delete matched NoSQL item '{id}' {key} in Azure Cosmos DB for NoSQL container '{Client.Database.Id}/{Client.Id}' " +
                                     $"since the delete operation responded with a failure: {(int) response.StatusCode} {response.StatusCode}: {response.ErrorMessage}");
                             }
                         }

--- a/src/Arcus.Testing.Storage.Cosmos/TemporaryNoSqlItem.cs
+++ b/src/Arcus.Testing.Storage.Cosmos/TemporaryNoSqlItem.cs
@@ -13,7 +13,7 @@ using static Arcus.Testing.NoSqlExtraction;
 namespace Arcus.Testing
 {
     /// <summary>
-    /// Represents a temporary Azure Cosmos NoSql document that will be deleted after the instance is disposed.
+    /// Represents a temporary Azure Cosmos DB for NoSQL document that will be deleted after the instance is disposed.
     /// </summary>
     public class TemporaryNoSqlItem : IAsyncDisposable
     {
@@ -47,7 +47,7 @@ namespace Arcus.Testing
         }
 
         /// <summary>
-        /// Gets the unique identifier of this temporary NoSql item.
+        /// Gets the unique identifier of this temporary NoSQL item.
         /// </summary>
         public string Id { get; }
 
@@ -57,10 +57,10 @@ namespace Arcus.Testing
         public PartitionKey PartitionKey { get; }
 
         /// <summary>
-        /// Creates a temporary item to an Azure Cosmos NoSql container.
+        /// Creates a temporary item to an Azure Cosmos DB for NoSQL container.
         /// </summary>
-        /// <param name="container">The NoSql container where a temporary item should be created.</param>
-        /// <param name="item">The item to temporary create in the NoSql container.</param>
+        /// <param name="container">The NoSQL container where a temporary item should be created.</param>
+        /// <param name="item">The item to temporary create in the NoSQL container.</param>
         /// <param name="logger">The logger instance to write diagnostic information during the lifetime of the test fixture.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="container"/> is <c>null</c>.</exception>
         [Obsolete("Will be removed in v3.0, please use the " + nameof(UpsertItemAsync) + " instead which provides the exact same functionality")]
@@ -70,13 +70,13 @@ namespace Arcus.Testing
         }
 
         /// <summary>
-        /// Creates a new or replaces an existing NoSql item in an Azure Cosmos NoSql container.
+        /// Creates a new or replaces an existing NoSQL item in an Azure Cosmos DB for NoSQL container.
         /// </summary>
         /// <remarks>
         ///     ⚡ Item will be deleted (if new) or reverted (if existing) when the <see cref="TemporaryNoSqlItem"/> is disposed.
         /// </remarks>
-        /// <param name="container">The NoSql container where a temporary item should be created.</param>
-        /// <param name="item">The item to temporary create in the NoSql container.</param>
+        /// <param name="container">The NoSQL container where a temporary item should be created.</param>
+        /// <param name="item">The item to temporary create in the NoSQL container.</param>
         /// <param name="logger">The logger instance to write diagnostic information during the lifetime of the test fixture.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="container"/> is <c>null</c>.</exception>
         public static async Task<TemporaryNoSqlItem> UpsertItemAsync<TItem>(Container container, TItem item, ILogger logger)
@@ -107,20 +107,20 @@ namespace Arcus.Testing
             TItem item,
             ILogger logger)
         {
-            logger.LogTrace("[Test:Setup] Try replacing Azure Cosmos NoSql '{ItemType}' item '{ItemId}' in container '{DatabaseName}/{ContainerName}'...", typeof(TItem).Name, itemId, container.Database.Id, container.Id);
+            logger.LogTrace("[Test:Setup] Try replacing NoSQL '{ItemType}' item '{ItemId}' in Azure Cosmos DB For NoSQL container '{DatabaseName}/{ContainerName}'...", typeof(TItem).Name, itemId, container.Database.Id, container.Id);
             ItemResponse<TItem> response = await container.ReadItemAsync<TItem>(itemId, partitionKey);
 
             CosmosSerializer serializer = container.Database.Client.ClientOptions.Serializer;
             if (serializer is null)
             {
                 throw new InvalidOperationException(
-                    "[Test:Setup] Cannot temporary insert an Azure Cosmos NoSql item in a NoSql container because no JSON serializer was set in the Cosmos client options");
+                    $"[Test:Setup] Cannot temporary insert an NoSQL item in the Azure Cosmos DB for NoSQL container '{container.Database.Id}/{container.Id}' because no JSON serializer was set in the Cosmos DB client options");
             }
 
             TItem original = response.Resource;
             var originalItemStream = serializer.ToStream(original);
 
-            logger.LogDebug("[Test:Setup] Replace Azure Cosmos NoSql '{ItemType}' item '{ItemId}' in container '{DatabaseName}/{ContainerName}'", typeof(TItem).Name, itemId, container.Database.Id, container.Id);
+            logger.LogDebug("[Test:Setup] Replace NoSQL '{ItemType}' item '{ItemId}' in Azure Cosmos DB for NoSQL container '{DatabaseName}/{ContainerName}'", typeof(TItem).Name, itemId, container.Database.Id, container.Id);
             await container.ReplaceItemAsync(item, itemId, partitionKey);
 
             return new TemporaryNoSqlItem(container, itemId, partitionKey, typeof(TItem), createdByUs: false, originalItemStream, logger);
@@ -133,13 +133,13 @@ namespace Arcus.Testing
             TItem item,
             ILogger logger)
         {
-            logger.LogDebug("[Test:Setup] Insert new Azure Cosmos NoSql '{ItemType}' item '{ItemId}' to container '{DatabaseName}/{ContainerName}'", typeof(TItem).Name, itemId, container.Database.Id, container.Id);
+            logger.LogDebug("[Test:Setup] Insert new NoSQL '{ItemType}' item '{ItemId}' to Azure Cosmos DB for NoSQL container '{DatabaseName}/{ContainerName}'", typeof(TItem).Name, itemId, container.Database.Id, container.Id);
             ItemResponse<TItem> response = await container.CreateItemAsync(item);
 
             if (response.StatusCode != HttpStatusCode.Created)
             {
                 throw new RequestFailedException(
-                    (int) response.StatusCode, $"[Test:Setup] Unable to insert a new Azure Cosmos NoSql '{typeof(TItem).Name}' item into the container '{container.Database.Id}/{container.Id}': {response.StatusCode} - " + response.Diagnostics);
+                    (int) response.StatusCode, $"[Test:Setup] Unable to insert a new NoSQL '{typeof(TItem).Name}' item into the Azure Cosmos DB for NoSQL container '{container.Database.Id}/{container.Id}': {response.StatusCode} - " + response.Diagnostics);
             }
 
             return new TemporaryNoSqlItem(container, itemId, partitionKey, typeof(TItem), createdByUs: true, originalItemStream: null, logger);
@@ -157,13 +157,13 @@ namespace Arcus.Testing
             {
                 disposables.Add(AsyncDisposable.Create(async () =>
                 {
-                    _logger.LogDebug("[Test:Teardown] Delete Azure Cosmos NoSql '{ItemType}' item '{ItemId}' in container '{DatabaseName}/{ContainerName}'", _itemType.Name, Id, _container.Database.Id, _container.Id);
+                    _logger.LogDebug("[Test:Teardown] Delete NoSQL '{ItemType}' item '{ItemId}' in Azure Cosmos DB for NoSQL container '{DatabaseName}/{ContainerName}'", _itemType.Name, Id, _container.Database.Id, _container.Id);
                     using ResponseMessage response = await _container.DeleteItemStreamAsync(Id, PartitionKey);
 
                     if (!response.IsSuccessStatusCode && response.StatusCode != HttpStatusCode.NotFound)
                     {
                         throw new RequestFailedException(
-                            $"[Test:Teardown] Failed to delete Azure Cosmos NoSql '{_itemType.Name}' item '{Id}' {PartitionKey} in container '{_container.Database.Id}/{_container.Id}' " +
+                            $"[Test:Teardown] Failed to delete NoSQL '{_itemType.Name}' item '{Id}' {PartitionKey} in Azure Cosmos DB for NoSQL container '{_container.Database.Id}/{_container.Id}' " +
                             $"since the delete operation responded with a failure: {(int) response.StatusCode} {response.StatusCode}: {response.ErrorMessage}");
                     }
                 }));
@@ -172,13 +172,13 @@ namespace Arcus.Testing
             {
                 disposables.Add(AsyncDisposable.Create(async () =>
                 {
-                    _logger.LogDebug("[Test:Teardown] Revert replaced Azure Cosmos NoSql '{ItemType}' item '{ItemId}' in container '{DatabaseName}/{ContainerName}'", _itemType.Name, Id, _container.Database.Id, _container.Id);
+                    _logger.LogDebug("[Test:Teardown] Revert replaced NoSQL '{ItemType}' item '{ItemId}' in Azure Cosmos DB for NoSQL container '{DatabaseName}/{ContainerName}'", _itemType.Name, Id, _container.Database.Id, _container.Id);
                     using ResponseMessage response = await _container.ReplaceItemStreamAsync(_originalItemStream, Id, PartitionKey);
 
                     if (!response.IsSuccessStatusCode)
                     {
                         throw new RequestFailedException(
-                            $"[Test:Teardown] Failed to revert Azure Cosmos NoSql '{_itemType.Name}' item '{Id}' {PartitionKey} in container '{_container.Database.Id}/{_container.Id}' " +
+                            $"[Test:Teardown] Failed to revert NoSQL '{_itemType.Name}' item '{Id}' {PartitionKey} in Azure Cosmos DB for NoSQL container '{_container.Database.Id}/{_container.Id}' " +
                             $"since the replace operation responded with a failure: {(int) response.StatusCode} {response.StatusCode}: {response.ErrorMessage}");
                     }
                 }));


### PR DESCRIPTION
We used different naming conventions for Microsoft products in our code summary tags and feature documentation (i.e. `MongoDb` instead of `MongoDB`).

This PR tries to streamline these differences so that both the recent/preview documentation, logging, exception messages... all mention these products by their correct name.

Relates to #417 