### PR TITLE
chore(az.storage): use microsoft naming for storage package descriptions

### DIFF
--- a/src/Arcus.Testing.Storage.Blob/Arcus.Testing.Storage.Blob.csproj
+++ b/src/Arcus.Testing.Storage.Blob/Arcus.Testing.Storage.Blob.csproj
@@ -5,7 +5,7 @@
     <RootNamespace>Arcus.Testing</RootNamespace>
     <Authors>Arcus</Authors>
     <Company>Arcus</Company>
-    <Description>Provides capabilities during testing of Azure Blob storage interactions</Description>
+    <Description>Provides capabilities during testing of Azure Blob Storage interactions</Description>
     <Copyright>Copyright (c) Arcus</Copyright>
     <PackageProjectUrl>https://github.com/arcus-azure/arcus.testing</PackageProjectUrl>
     <RepositoryUrl>https://github.com/arcus-azure/arcus.testing</RepositoryUrl>

--- a/src/Arcus.Testing.Storage.File.Share/Arcus.Testing.Storage.File.Share.csproj
+++ b/src/Arcus.Testing.Storage.File.Share/Arcus.Testing.Storage.File.Share.csproj
@@ -5,7 +5,7 @@
     <RootNamespace>Arcus.Testing</RootNamespace>
     <Authors>Arcus</Authors>
     <Company>Arcus</Company>
-    <Description>Provides capabilities during testing of Azure File share storage interactions</Description>
+    <Description>Provides capabilities during testing of Azure Files share storage interactions</Description>
     <Copyright>Copyright (c) Arcus</Copyright>
     <PackageProjectUrl>https://github.com/arcus-azure/arcus.testing</PackageProjectUrl>
     <RepositoryUrl>https://github.com/arcus-azure/arcus.testing</RepositoryUrl>

--- a/src/Arcus.Testing.Storage.Table/Arcus.Testing.Storage.Table.csproj
+++ b/src/Arcus.Testing.Storage.Table/Arcus.Testing.Storage.Table.csproj
@@ -5,7 +5,7 @@
     <RootNamespace>Arcus.Testing</RootNamespace>
     <Authors>Arcus</Authors>
     <Company>Arcus</Company>
-    <Description>Provides capabilities during testing of Azure Table storage interactions</Description>
+    <Description>Provides capabilities during testing of Azure Table Storage interactions</Description>
     <Copyright>Copyright (c) Arcus</Copyright>
     <PackageProjectUrl>https://github.com/arcus-azure/arcus.testing</PackageProjectUrl>
     <RepositoryUrl>https://github.com/arcus-azure/arcus.testing</RepositoryUrl>


### PR DESCRIPTION
In a previous PR #418, the Microsoft naming conventions for Microsoft products were fixed in the feature documentation and code summary tags, but it was forgotten to change in the package description of those libraries.

This PR streamlines these naming conventions in the Azure Storage Account-related packages.
Relates to #417  