### PR TITLE
chore(warning): resolve integration+unit test code warnings

### DIFF
--- a/src/Arcus.Testing.Tests.Integration/Core/TestConfigTests.cs
+++ b/src/Arcus.Testing.Tests.Integration/Core/TestConfigTests.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Arcus.Testing.Tests.Integration.Core.Fixture;
-using Bogus;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
 using Newtonsoft.Json.Linq;
@@ -19,7 +18,6 @@ namespace Arcus.Testing.Tests.Integration.Core
         private const string DefaultAppSettingsName = "appsettings.json",
                              DefaultLocalAppSettingsName = "appsettings.local.json";
 
-        private static readonly Faker Bogus = new();
         private readonly DisposableCollection _disposables = new(NullLogger.Instance);
 
         public TestConfigTests(ITestOutputHelper outputWriter) : base(outputWriter)

--- a/src/Arcus.Testing.Tests.Integration/Messaging/TemporaryQueueTests.cs
+++ b/src/Arcus.Testing.Tests.Integration/Messaging/TemporaryQueueTests.cs
@@ -4,7 +4,6 @@ using Arcus.Testing.Tests.Integration.Messaging.Configuration;
 using Arcus.Testing.Tests.Integration.Messaging.Fixture;
 using Azure.Messaging.ServiceBus;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Arcus.Testing.Tests.Integration.Messaging
 {
@@ -80,8 +79,8 @@ namespace Arcus.Testing.Tests.Integration.Messaging
             await serviceBus.ShouldDeadLetteredMessageAsync(queueName, messageDeadLetterBefore);
             await serviceBus.ShouldCompletedMessageAsync(queueName, messageCompleteBefore);
 
-            Assert.True(await temp.Messages.FromDeadLetter().Where(msg => msg.MessageId == messageDeadLetterBefore.MessageId).AnyAsync(), $"temp queue should have found dead-lettered message '{messageDeadLetterBefore.MessageId}'");
-            Assert.False(await temp.Messages.FromDeadLetter().Where(msg => msg.MessageId == messageCompleteBefore.MessageId).AnyAsync(), $"temp queue should not have found completed message '{messageCompleteBefore.MessageId}'");
+            Assert.True(await temp.Messages.FromDeadLetter().Where(msg => msg.MessageId == messageDeadLetterBefore.MessageId).AnyAsync(TestContext.Current.CancellationToken), $"temp queue should have found dead-lettered message '{messageDeadLetterBefore.MessageId}'");
+            Assert.False(await temp.Messages.FromDeadLetter().Where(msg => msg.MessageId == messageCompleteBefore.MessageId).AnyAsync(TestContext.Current.CancellationToken), $"temp queue should not have found completed message '{messageCompleteBefore.MessageId}'");
 
             ServiceBusMessage messageAfter = await serviceBus.WhenMessageSentAsync(queueName);
 

--- a/src/Arcus.Testing.Tests.Integration/Messaging/TemporaryTopicTests.cs
+++ b/src/Arcus.Testing.Tests.Integration/Messaging/TemporaryTopicTests.cs
@@ -4,7 +4,6 @@ using Arcus.Testing.Tests.Integration.Messaging.Configuration;
 using Arcus.Testing.Tests.Integration.Messaging.Fixture;
 using Azure.Messaging.ServiceBus;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Arcus.Testing.Tests.Integration.Messaging
 {
@@ -52,7 +51,7 @@ namespace Arcus.Testing.Tests.Integration.Messaging
             await serviceBus.ShouldLeaveMessageAsync(topicName, subscriptionName, messageBefore);
 
             ServiceBusMessage messageAfter = serviceBus.WhenMessageUnsent();
-            await temp.Sender.SendMessageAsync(messageAfter);
+            await temp.Sender.SendMessageAsync(messageAfter, TestContext.Current.CancellationToken);
 
             await temp.DisposeAsync();
             await serviceBus.ShouldHaveTopicAsync(topicName);
@@ -149,7 +148,7 @@ namespace Arcus.Testing.Tests.Integration.Messaging
             await serviceBus.ShouldLeaveMessageAsync(topicName, subscriptionName, messageBefore);
 
             ServiceBusMessage messageAfter = serviceBus.WhenMessageUnsent();
-            await temp.Sender.SendMessageAsync(messageAfter);
+            await temp.Sender.SendMessageAsync(messageAfter, TestContext.Current.CancellationToken);
 
             await temp.DisposeAsync();
             await serviceBus.ShouldDeadLetteredMessageAsync(topicName, subscriptionName, messageBefore);
@@ -183,7 +182,7 @@ namespace Arcus.Testing.Tests.Integration.Messaging
             await serviceBus.ShouldLeaveMessageAsync(topicName, subscriptionName, messageBefore1);
 
             ServiceBusMessage messageAfter = serviceBus.WhenMessageUnsent();
-            await temp.Sender.SendMessageAsync(messageAfter);
+            await temp.Sender.SendMessageAsync(messageAfter, TestContext.Current.CancellationToken);
 
             await temp.DisposeAsync();
             await serviceBus.ShouldCompletedMessageAsync(topicName, subscriptionName, messageBefore1);

--- a/src/Arcus.Testing.Tests.Integration/Storage/TemporaryBlobFileTests.cs
+++ b/src/Arcus.Testing.Tests.Integration/Storage/TemporaryBlobFileTests.cs
@@ -3,7 +3,6 @@ using System.Threading.Tasks;
 using Arcus.Testing.Tests.Integration.Storage.Fixture;
 using Azure.Storage.Blobs;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Arcus.Testing.Tests.Integration.Storage
 {
@@ -65,8 +64,10 @@ namespace Arcus.Testing.Tests.Integration.Storage
 
             TemporaryBlobFile temp =
                 Bogus.Random.Bool()
+#pragma warning disable CS0618 // Type or member is obsolete: currently still testing deprecated functionality.
                     ? await TemporaryBlobFile.UploadIfNotExistsAsync(client.Uri, blobName, blobContent, Logger)
                     : await TemporaryBlobFile.UploadIfNotExistsAsync(client.GetBlobClient(blobName), blobContent, Logger);
+#pragma warning restore CS0618 // Type or member is obsolete
 
             Assert.Equal(blobName, temp.Name);
             Assert.Equal(client.Name, temp.ContainerName);

--- a/src/Arcus.Testing.Tests.Integration/Storage/TemporaryMongoDbCollectionTests.cs
+++ b/src/Arcus.Testing.Tests.Integration/Storage/TemporaryMongoDbCollectionTests.cs
@@ -5,7 +5,6 @@ using Bogus;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization.Attributes;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Arcus.Testing.Tests.Integration.Storage
 {
@@ -51,7 +50,9 @@ namespace Arcus.Testing.Tests.Integration.Storage
 
             TemporaryMongoDbCollection collection = await WhenTempCollectionCreatedAsync(collectionName);
             Shipment createdByUs = CreateShipment();
+#pragma warning disable CS0618 // Type or member is obsolete: currently still testing deprecated functionality.
             await collection.AddDocumentAsync(createdByUs);
+#pragma warning restore CS0618 // Type or member is obsolete
 
             await context.ShouldStoreCollectionAsync(collectionName);
             await context.ShouldStoreDocumentAsync<Shipment>(collectionName, existingId);
@@ -187,7 +188,9 @@ namespace Arcus.Testing.Tests.Integration.Storage
                 options.OnSetup.CleanMatchingDocuments((Shipment s) => s.BoatName == matchedOnSetup.BoatName);
             });
             collection.OnTeardown.CleanAllDocuments();
+#pragma warning disable CS0618 // Type or member is obsolete: currently still testing deprecated functionality.
             await collection.AddDocumentAsync(createdByUs);
+#pragma warning restore CS0618 // Type or member is obsolete
 
             await context.ShouldNotStoreDocumentAsync<Shipment>(collectionName, matchedOnSetupId);
             await context.ShouldStoreDocumentAsync<Shipment>(collectionName, unmatchedOnSetupId);

--- a/src/Arcus.Testing.Tests.Integration/Storage/TemporaryMongoDbDocumentTests.cs
+++ b/src/Arcus.Testing.Tests.Integration/Storage/TemporaryMongoDbDocumentTests.cs
@@ -6,7 +6,6 @@ using MongoDB.Bson;
 using MongoDB.Bson.Serialization.Attributes;
 using MongoDB.Bson.Serialization.IdGenerators;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Arcus.Testing.Tests.Integration.Storage
 {
@@ -68,12 +67,14 @@ namespace Arcus.Testing.Tests.Integration.Storage
         private async Task<TemporaryMongoDbDocument> WhenTempDocumentCreatedAsync<TDoc>(string collectionName, TDoc doc)
             where TDoc : class
         {
+#pragma warning disable CS0618 // Type or member is obsolete: currently still testing deprecated functionality.
             return await TemporaryMongoDbDocument.InsertIfNotExistsAsync(
                 MongoDb.AccountResourceId,
                 MongoDb.DatabaseName,
                 collectionName,
                 doc,
                 Logger);
+#pragma warning restore CS0618 // Type or member is obsolete
         }
 
         public class Product
@@ -164,6 +165,8 @@ namespace Arcus.Testing.Tests.Integration.Storage
             await Assert.ThrowsAnyAsync<InvalidOperationException>(() => WhenTempDocumentCreatedAsync("<collection-name>", new DocWithoutId()));
         }
 
+#pragma warning disable S2094 // S2094: Types should not be empty - this is a test class to verify that the temporary document creation fails when no ID is present
         public class DocWithoutId { }
+#pragma warning restore S2094
     }
 }

--- a/src/Arcus.Testing.Tests.Integration/Storage/TemporaryNoSqlContainerTests.cs
+++ b/src/Arcus.Testing.Tests.Integration/Storage/TemporaryNoSqlContainerTests.cs
@@ -6,7 +6,6 @@ using Bogus;
 using Microsoft.Azure.Cosmos;
 using Newtonsoft.Json;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Arcus.Testing.Tests.Integration.Storage
 {
@@ -216,7 +215,9 @@ namespace Arcus.Testing.Tests.Integration.Storage
         private static async Task<Ship> AddItemAsync(TemporaryNoSqlContainer container)
         {
             Ship item = CreateShip("own");
+#pragma warning disable CS0618 // Type or member is obsolete: currently still testing deprecated functionality.
             await container.AddItemAsync(item);
+#pragma warning restore CS0618 // Type or member is obsolete
 
             return item;
         }

--- a/src/Arcus.Testing.Tests.Integration/Storage/TemporaryNoSqlItemTests.cs
+++ b/src/Arcus.Testing.Tests.Integration/Storage/TemporaryNoSqlItemTests.cs
@@ -6,7 +6,6 @@ using Bogus;
 using Microsoft.Azure.Cosmos;
 using Newtonsoft.Json;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Arcus.Testing.Tests.Integration.Storage
 {
@@ -164,7 +163,7 @@ namespace Arcus.Testing.Tests.Integration.Storage
             Assert.Equal(expected.Category, actual.Category);
         }
 
-        private class Product : INoSqlItem<Product>
+        private sealed class Product : INoSqlItem<Product>
         {
             [JsonProperty(PropertyName = "id")]
             public string Id { get; set; }
@@ -214,7 +213,9 @@ namespace Arcus.Testing.Tests.Integration.Storage
             where T : INoSqlItem
         {
             container ??= context.Database.GetContainer(containerName);
+#pragma warning disable CS0618 // Type or member is obsolete: currently still testing deprecated functionality.
             var temp = await TemporaryNoSqlItem.InsertIfNotExistsAsync(container, item, Logger);
+#pragma warning restore CS0618 // Type or member is obsolete
 
             Assert.Equal(item.GetId(), temp.Id);
             Assert.Equal(item.GetPartitionKey(), temp.PartitionKey);

--- a/src/Arcus.Testing.Tests.Integration/Storage/TemporaryTableEntityTests.cs
+++ b/src/Arcus.Testing.Tests.Integration/Storage/TemporaryTableEntityTests.cs
@@ -1,12 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Arcus.Testing.Tests.Integration.Storage.Fixture;
 using Azure.Data.Tables;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Arcus.Testing.Tests.Integration.Storage
 {
@@ -79,7 +74,9 @@ namespace Arcus.Testing.Tests.Integration.Storage
 
         private async Task<TemporaryTableEntity> CreateTempTableEntityAsync(TableClient client, TableEntity entity)
         {
+#pragma warning disable CS0618 // Type or member is obsolete: currently still testing deprecated functionality.
             return await TemporaryTableEntity.AddIfNotExistsAsync(client.AccountName, client.Name, entity, Logger);
+#pragma warning restore CS0618 // Type or member is obsolete
         }
 
         private async Task<TableStorageTestContext> GivenTableStorageAsync()

--- a/src/Arcus.Testing.Tests.Integration/Storage/TemporaryTableTests.cs
+++ b/src/Arcus.Testing.Tests.Integration/Storage/TemporaryTableTests.cs
@@ -3,7 +3,6 @@ using System.Threading.Tasks;
 using Arcus.Testing.Tests.Integration.Storage.Fixture;
 using Azure.Data.Tables;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Arcus.Testing.Tests.Integration.Storage
 {
@@ -141,7 +140,7 @@ namespace Arcus.Testing.Tests.Integration.Storage
             // Assert
             await context.ShouldNotStoreTableEntityAsync(client, matchedEntity);
             await context.ShouldStoreTableEntityAsync(client, notMatchedEntity);
-            await client.AddEntityAsync(matchedEntity);
+            await client.AddEntityAsync(matchedEntity, TestContext.Current.CancellationToken);
 
             await temp.DisposeAsync();
             await context.ShouldStoreTableEntityAsync(client, matchedEntity);
@@ -219,7 +218,9 @@ namespace Arcus.Testing.Tests.Integration.Storage
         private static async Task<TableEntity> AddTableEntityAsync(TableStorageTestContext context, TemporaryTable table)
         {
             TableEntity entity = context.WhenTableEntityUnavailable();
+#pragma warning disable CS0618 // Type or member is obsolete: currently still testing deprecated functionality.
             await table.AddEntityAsync(entity);
+#pragma warning restore CS0618 // Type or member is obsolete
 
             return entity;
         }

--- a/src/Arcus.Testing.Tests.Unit/Storage/TemporaryBlobFileTests.cs
+++ b/src/Arcus.Testing.Tests.Unit/Storage/TemporaryBlobFileTests.cs
@@ -5,6 +5,8 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Xunit;
 
+#pragma warning disable CS0618 // Type or member is obsolete: currently still testing deprecated functionality.
+
 namespace Arcus.Testing.Tests.Unit.Storage
 {
     public class TemporaryBlobFileTests

--- a/src/Arcus.Testing.Tests.Unit/Storage/TemporaryMongoDbDocumentTests.cs
+++ b/src/Arcus.Testing.Tests.Unit/Storage/TemporaryMongoDbDocumentTests.cs
@@ -7,6 +7,8 @@ using MongoDB.Driver;
 using Moq;
 using Xunit;
 
+#pragma warning disable CS0618 // Type or member is obsolete: currently still testing deprecated functionality.
+
 namespace Arcus.Testing.Tests.Unit.Storage
 {
     extern alias ArcusXunitV3;

--- a/src/Arcus.Testing.Tests.Unit/Storage/TemporaryTableEntityTests.cs
+++ b/src/Arcus.Testing.Tests.Unit/Storage/TemporaryTableEntityTests.cs
@@ -5,6 +5,8 @@ using Azure.Identity;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
+#pragma warning disable CS0618 // Type or member is obsolete: currently still testing deprecated functionality.
+
 namespace Arcus.Testing.Tests.Unit.Storage
 {
     public class TemporaryTableEntityTests


### PR DESCRIPTION
The current code solution had some code warnings related to the new xUnit v3 package, using (our) deprecated code in tests, and duplicated `Bogus` property name.

This PR tries to resolve those warnings, which were solely coming from the integration and unit test projects.