### PR TITLE
chore(style): streamline collection expression '[]' + remarks

### DIFF
--- a/src/Arcus.Testing.Assert/AssertCsv.cs
+++ b/src/Arcus.Testing.Assert/AssertCsv.cs
@@ -46,8 +46,8 @@ namespace Arcus.Testing
     /// </summary>
     public class AssertCsvOptions
     {
-        private readonly Collection<string> _ignoredColumns = new();
-        private readonly Collection<int> _ignoredColumnIndexes = new();
+        private readonly Collection<string> _ignoredColumns = [];
+        private readonly Collection<int> _ignoredColumnIndexes = [];
         private int _maxInputCharacters = ReportBuilder.DefaultMaxInputCharacters;
         private string _newRow = Environment.NewLine;
         private AssertCsvHeader _header = AssertCsvHeader.Present;

--- a/src/Arcus.Testing.Assert/AssertJson.cs
+++ b/src/Arcus.Testing.Assert/AssertJson.cs
@@ -29,7 +29,7 @@ namespace Arcus.Testing
     /// </summary>
     public class AssertJsonOptions
     {
-        private readonly Collection<string> _ignoredNodeNames = new();
+        private readonly Collection<string> _ignoredNodeNames = [];
         private AssertJsonOrder _order = AssertJsonOrder.Ignore;
         private int _maxInputCharacters = ReportBuilder.DefaultMaxInputCharacters;
 

--- a/src/Arcus.Testing.Assert/AssertXml.cs
+++ b/src/Arcus.Testing.Assert/AssertXml.cs
@@ -30,7 +30,7 @@ namespace Arcus.Testing
     /// </summary>
     public class AssertXmlOptions
     {
-        private readonly Collection<string> _ignoredNodeNames = new();
+        private readonly Collection<string> _ignoredNodeNames = [];
         private AssertXmlOrder _order = AssertXmlOrder.Ignore;
         private int _maxInputCharacters = ReportBuilder.DefaultMaxInputCharacters;
 
@@ -410,7 +410,7 @@ namespace Arcus.Testing
                     ?.OfType<XmlAttribute>()
                     .Where(a => a.NamespaceURI != namespaceDefinition
                                 && !options.IgnoredNodeNames.Contains(a.LocalName))
-                    .ToArray() ?? Array.Empty<XmlAttribute>();
+                    .ToArray() ?? [];
         }
 
         /// <summary>

--- a/src/Arcus.Testing.Core/Poll.cs
+++ b/src/Arcus.Testing.Core/Poll.cs
@@ -30,7 +30,7 @@ namespace Arcus.Testing
     {
         private readonly Func<Task<TResult>> _getTargetWithResultAsync;
         private readonly PollOptions _options;
-        private readonly Collection<Func<TResult, bool>> _untilTargets = new();
+        private readonly Collection<Func<TResult, bool>> _untilTargets = [];
 
         internal Poll(Func<Task<TResult>> getTargetWithResultAsync, PollOptions options)
         {
@@ -174,7 +174,7 @@ namespace Arcus.Testing
         private TimeSpan _interval = TimeSpan.FromSeconds(1);
         private TimeSpan _timeout = TimeSpan.FromSeconds(30);
         private string _failureMessage = "operation did not succeed within the given time frame";
-        private readonly Collection<Func<Exception, bool>> _exceptionFilters = new();
+        private readonly Collection<Func<Exception, bool>> _exceptionFilters = [];
 
         /// <summary>
         /// Gets the default set of polling options.

--- a/src/Arcus.Testing.Core/TestConfig.cs
+++ b/src/Arcus.Testing.Core/TestConfig.cs
@@ -11,7 +11,7 @@ namespace Arcus.Testing
     /// </summary>
     public class TestConfigOptions
     {
-        private readonly Collection<string> _localAppSettingsNames = new() { "appsettings.local.json" };
+        private readonly Collection<string> _localAppSettingsNames = ["appsettings.local.json"];
 
         /// <summary>
         /// Override the default 'appsettings.json' JSON path where the test configuration values are retrieved from.

--- a/src/Arcus.Testing.Integration.DataFactory/DataFlowRunResult.cs
+++ b/src/Arcus.Testing.Integration.DataFactory/DataFlowRunResult.cs
@@ -317,7 +317,7 @@ namespace Arcus.Testing
 
             public static PreviewHeader CreateAsValue(string headerName)
             {
-                return new PreviewHeader(DirectValueTrail.Replace(headerName, ""), PreviewDataType.DirectValue, Array.Empty<PreviewHeader>());
+                return new PreviewHeader(DirectValueTrail.Replace(headerName, ""), PreviewDataType.DirectValue, []);
             }
 
             public static PreviewHeader CreateAsArray(string headerName, PreviewHeader[] parsed)
@@ -494,7 +494,7 @@ namespace Arcus.Testing
                               .ToArray();
             }
 
-            return new[] { dataArr.Select(n => AsCsvCell(n.ToString())).ToArray() };
+            return [dataArr.Select(n => AsCsvCell(n.ToString())).ToArray()];
         }
 
         private static JsonArray ParseDataAsArray(JsonObject outputObj)

--- a/src/Arcus.Testing.Integration.DataFactory/TemporaryDataFlowDebugSession.cs
+++ b/src/Arcus.Testing.Integration.DataFactory/TemporaryDataFlowDebugSession.cs
@@ -446,10 +446,10 @@ namespace Arcus.Testing
     {
         private int _maxRows = 100;
 
-        internal Collection<string> LinkedServiceNames { get; } = new();
+        internal Collection<string> LinkedServiceNames { get; } = [];
         internal IDictionary<string, BinaryData> DataFlowParameters { get; } = new Dictionary<string, BinaryData>();
         internal IDictionary<string, IDictionary<string, object>> DataSetParameters { get; } = new Dictionary<string, IDictionary<string, object>>();
-        internal Collection<string> FlowletNames { get; } = new();
+        internal Collection<string> FlowletNames { get; } = [];
 
         /// <summary>
         /// Adds a parameter to the data flow to run.

--- a/src/Arcus.Testing.Messaging.ServiceBus/ServiceBusMessageFilter.cs
+++ b/src/Arcus.Testing.Messaging.ServiceBus/ServiceBusMessageFilter.cs
@@ -17,7 +17,7 @@ namespace Arcus.Testing
     {
         private readonly string _entityName, _subscriptionName;
         private readonly ServiceBusClient _client;
-        private readonly Collection<Func<ServiceBusReceivedMessage, bool>> _predicates = new();
+        private readonly Collection<Func<ServiceBusReceivedMessage, bool>> _predicates = [];
 
         private bool _fromDeadLetter;
         private int _maxMessages = 100;

--- a/src/Arcus.Testing.Messaging.ServiceBus/TemporaryQueue.cs
+++ b/src/Arcus.Testing.Messaging.ServiceBus/TemporaryQueue.cs
@@ -21,8 +21,8 @@ namespace Arcus.Testing
     /// </summary>
     public class OnSetupTemporaryQueueOptions
     {
-        private readonly Collection<Action<CreateQueueOptions>> _configuredOptions = new();
-        private readonly Collection<Func<ServiceBusReceivedMessage, bool>> _shouldDeadLetterMessages = new(), _shouldCompleteMessages = new();
+        private readonly Collection<Action<CreateQueueOptions>> _configuredOptions = [];
+        private readonly Collection<Func<ServiceBusReceivedMessage, bool>> _shouldDeadLetterMessages = [], _shouldCompleteMessages = [];
 
         internal OnSetupQueue Messages { get; private set; }
         internal TimeSpan MaxWaitTime { get; private set; } = TimeSpan.FromSeconds(5);
@@ -183,7 +183,7 @@ namespace Arcus.Testing
     /// </summary>
     public class OnTeardownTemporaryQueueOptions
     {
-        private readonly Collection<Func<ServiceBusReceivedMessage, bool>> _shouldDeadLetterMessages = new(), _shouldCompleteMessages = new();
+        private readonly Collection<Func<ServiceBusReceivedMessage, bool>> _shouldDeadLetterMessages = [], _shouldCompleteMessages = [];
 
         private OnTeardownQueue Messages { get; set; }
 

--- a/src/Arcus.Testing.Messaging.ServiceBus/TemporaryTopic.cs
+++ b/src/Arcus.Testing.Messaging.ServiceBus/TemporaryTopic.cs
@@ -19,8 +19,8 @@ namespace Arcus.Testing
     /// </summary>
     public class OnSetupTemporaryTopicOptions
     {
-        private readonly Collection<Action<CreateTopicOptions>> _configuredOptions = new();
-        private readonly Collection<Func<ServiceBusReceivedMessage, bool>> _shouldCompleteMessages = new(), _shouldDeadLetterMessages = new();
+        private readonly Collection<Action<CreateTopicOptions>> _configuredOptions = [];
+        private readonly Collection<Func<ServiceBusReceivedMessage, bool>> _shouldCompleteMessages = [], _shouldDeadLetterMessages = [];
 
         internal OnSetupMessagesTopic Messages { get; private set; }
         internal TimeSpan MaxWaitTime { get; private set; } = TimeSpan.FromSeconds(5);
@@ -178,7 +178,7 @@ namespace Arcus.Testing
     /// </summary>
     public class OnTeardownTemporaryTopicOptions
     {
-        private readonly Collection<Func<ServiceBusReceivedMessage, bool>> _shouldCompleteMessages = new(), _shouldDeadLetterMessages = new();
+        private readonly Collection<Func<ServiceBusReceivedMessage, bool>> _shouldCompleteMessages = [], _shouldDeadLetterMessages = [];
 
         private OnTeardownMessagesTopic Messages { get; set; }
         private TimeSpan MaxWaitTime { get; set; } = TimeSpan.FromSeconds(5);
@@ -363,7 +363,7 @@ namespace Arcus.Testing
     {
         private readonly ServiceBusAdministrationClient _adminClient;
         private readonly ServiceBusClient _messagingClient;
-        private readonly Collection<TemporaryTopicSubscription> _subscriptions = new();
+        private readonly Collection<TemporaryTopicSubscription> _subscriptions = [];
 
         private readonly bool _topicCreatedByUs, _messagingClientCreatedByUs;
         private readonly TemporaryTopicOptions _options;

--- a/src/Arcus.Testing.Messaging.ServiceBus/TemporaryTopicSubscription.cs
+++ b/src/Arcus.Testing.Messaging.ServiceBus/TemporaryTopicSubscription.cs
@@ -14,7 +14,7 @@ namespace Arcus.Testing
     /// </summary>
     public class OnSetupTemporaryTopicSubscriptionOptions
     {
-        private readonly Collection<Action<CreateSubscriptionOptions>> _configureSubscriptionOptions = new();
+        private readonly Collection<Action<CreateSubscriptionOptions>> _configureSubscriptionOptions = [];
 
         /// <summary>
         /// Configures the <see cref="Azure.Messaging.ServiceBus.Administration.CreateSubscriptionOptions"/> used when the test fixture creates the topic subscription.
@@ -62,7 +62,7 @@ namespace Arcus.Testing
     public class TemporaryTopicSubscription : IAsyncDisposable
     {
         private readonly ServiceBusAdministrationClient _client;
-        private readonly Collection<CreateRuleOptions> _rules = new();
+        private readonly Collection<CreateRuleOptions> _rules = [];
 
         private readonly CreateSubscriptionOptions _options;
         private readonly bool _createdByUs;

--- a/src/Arcus.Testing.Storage.Blob/TemporaryBlobContainer.cs
+++ b/src/Arcus.Testing.Storage.Blob/TemporaryBlobContainer.cs
@@ -30,7 +30,7 @@ namespace Arcus.Testing
     /// </summary>
     public class OnSetupBlobContainerOptions
     {
-        private readonly List<Func<BlobItem, bool>> _filters = new();
+        private readonly List<Func<BlobItem, bool>> _filters = [];
 
         /// <summary>
         /// Gets the configurable setup option on what to do with existing Azure Blobs in the Azure Blob container upon the test fixture creation.
@@ -101,7 +101,7 @@ namespace Arcus.Testing
     /// </summary>
     public class OnTeardownBlobContainerOptions
     {
-        private readonly List<Func<BlobItem, bool>> _filters = new();
+        private readonly List<Func<BlobItem, bool>> _filters = [];
 
         /// <summary>
         /// Gets the configurable option on what to do with unlinked Azure Blobs in the Azure Blob container upon the disposal of the test fixture.
@@ -225,7 +225,7 @@ namespace Arcus.Testing
     /// </summary>
     public class TemporaryBlobContainer : IAsyncDisposable
     {
-        private readonly Collection<TemporaryBlobFile> _blobs = new();
+        private readonly Collection<TemporaryBlobFile> _blobs = [];
         private readonly bool _createdByUs;
         private readonly TemporaryBlobContainerOptions _options;
         private readonly ILogger _logger;

--- a/src/Arcus.Testing.Storage.Cosmos/TemporaryMongoDbCollection.cs
+++ b/src/Arcus.Testing.Storage.Cosmos/TemporaryMongoDbCollection.cs
@@ -152,9 +152,12 @@ namespace Arcus.Testing
         /// in an Azure Cosmos DB for MongoDB collection upon disposal that matched the configured <paramref name="filter"/>.
         /// </summary>
         /// <remarks>
+        ///   <para>Multiple calls will aggregate together in an OR expression.</para>
+        ///   <para>
         ///     The matching of documents only happens on MongoDB documents that were created outside the scope of the test fixture.
         ///     All documents created by the test fixture will be deleted or reverted upon disposal, even if the documents do not match of the filters.
         ///     This follows the 'clean environment' principle where the test fixture should clean up after itself and not linger around any state it created.
+        ///   </para>
         /// </remarks>
         /// <typeparam name="TDocument">The type of the documents in the MongoDB collection.</typeparam>
         /// <param name="filter">The filter expression to match MongoDB documents that should be removed.</param>
@@ -170,9 +173,12 @@ namespace Arcus.Testing
         /// in an Azure Cosmos DB for MongoDB collection upon disposal that matched the configured <paramref name="filter"/>.
         /// </summary>
         /// <remarks>
+        ///   <para>Multiple calls will aggregate together in an OR expression.</para>
+        ///   <para>
         ///     The matching of documents only happens on MongoDB documents that were created outside the scope of the test fixture.
-        ///     All documents created by the test fixture will be deleted or reverted upon disposal, even if the documents do not match one of the filters.
+        ///     All documents created by the test fixture will be deleted or reverted upon disposal, even if the documents do not match of the filters.
         ///     This follows the 'clean environment' principle where the test fixture should clean up after itself and not linger around any state it created.
+        ///   </para>
         /// </remarks>
         /// <typeparam name="TDocument">The type of the documents in the MongoDB collection.</typeparam>
         /// <param name="filter">The filter expression to match MongoDB documents that should be removed.</param>

--- a/src/Arcus.Testing.Storage.Cosmos/TemporaryNoSqlContainer.cs
+++ b/src/Arcus.Testing.Storage.Cosmos/TemporaryNoSqlContainer.cs
@@ -210,9 +210,12 @@ namespace Arcus.Testing
         /// in an Azure Cosmos DB for NoSQL container upon disposal that match any of the configured <paramref name="filters"/>.
         /// </summary>
         /// <remarks>
+        ///   <para>Multiple calls will be aggregated together in an OR expression.</para>
+        ///   <para>
         ///     The matching of items only happens on NoSQL items that were created outside the scope of the test fixture.
         ///     All items created by the test fixture will be deleted or reverted upon disposal, even if the items do not match one of the filters.
         ///     This follows the 'clean environment' principle where the test fixture should clean up after itself and not linger around any state it created.
+        ///   </para>
         /// </remarks>
         /// <param name="filters">The filters  to match NoSQL items that should be removed.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="filters"/> is <c>null</c>.</exception>
@@ -237,9 +240,12 @@ namespace Arcus.Testing
         /// in an Azure Cosmos DB for NoSQL container upon disposal that match any of the configured <paramref name="filters"/>.
         /// </summary>
         /// <remarks>
+        ///   <para>Multiple calls will be aggregated together in an OR expression.</para>
+        ///   <para>
         ///     The matching of items only happens on NoSQL items that were created outside the scope of the test fixture.
-        ///     All items upserted by the test fixture will be deleted or reverted upon disposal, even if the items do not match one of the filters.
+        ///     All items created by the test fixture will be deleted or reverted upon disposal, even if the items do not match one of the filters.
         ///     This follows the 'clean environment' principle where the test fixture should clean up after itself and not linger around any state it created.
+        ///   </para>
         /// </remarks>
         /// <typeparam name="TItem">The custom type of the NoSQL item.</typeparam>
         /// <param name="filters">The filters  to match NoSQL items that should be removed.</param>


### PR DESCRIPTION
This PR streamlines the use of the collection expression `[]` instead of the old `new()`, and during this streamlining, the summary remarks of both the MongoDB/NoSQL test fixtures were streamlined as well.

Closes #426 