### PR TITLE
chore(mcr): use microsoft naming conventions throughout (follow-up)

### DIFF
--- a/build/deploy-test-resources.yml
+++ b/build/deploy-test-resources.yml
@@ -12,7 +12,7 @@ parameters:
     displayName: 'Resource group name'
     default: arcus-testing-dev-we-rg
   - name: keyVaultName
-    displayName: 'Key vault name'
+    displayName: 'Key Vault name'
     default: 'arcus-testing-kv'
 
 variables:
@@ -55,13 +55,13 @@ stages:
                   --parameters location=westeurope `
                   --parameters dataFactoryName=${{ variables['Arcus.Testing.DataFactory.Name'] }} `
                   --parameters storageAccountName=${{ variables['Arcus.Testing.StorageAccount.Name'] }} `
-                  --parameters cosmosDb_mongoDb_name=${{ variables['Arcus.Testing.Cosmos.MongoDb.Name'] }} `
-                  --parameters cosmosDb_mongoDb_databaseName=${{ variables['Arcus.Testing.Cosmos.MongoDb.DatabaseName'] }} `
-                  --parameters cosmosDb_noSql_name=${{ variables['Arcus.Testing.Cosmos.NoSql.Name'] }} `
-                  --parameters cosmosDb_noSql_databaseName=${{ variables['Arcus.Testing.Cosmos.NoSql.DatabaseName'] }} `
+                  --parameters cosmosDbMongoDbName=${{ variables['Arcus.Testing.Cosmos.MongoDb.Name'] }} `
+                  --parameters cosmosDbMongoDbDatabaseName=${{ variables['Arcus.Testing.Cosmos.MongoDb.DatabaseName'] }} `
+                  --parameters cosmosDbnoSqlName=${{ variables['Arcus.Testing.Cosmos.NoSql.Name'] }} `
+                  --parameters cosmosDbNoSqlDatabaseName=${{ variables['Arcus.Testing.Cosmos.NoSql.DatabaseName'] }} `
                   --parameters serviceBusNamespaceName=${{ variables['Arcus.Testing.ServiceBus.Namespace'] }} `
                   --parameters keyVaultName=${{ parameters.keyVaultName }} `
-                  --parameters servicePrincipal_objectId=$objectId
+                  --parameters servicePrincipalObjectId=$objectId
 
                 $accountKey = (az storage account keys list --account-name ${{ variables['Arcus.Testing.StorageAccount.Name'] }} | ConvertFrom-Json)[0].value
                 az keyvault secret set --name ${{ variables['Arcus.Testing.StorageAccount.Key.SecretName'] }} --value $accountKey --vault-name ${{ parameters.keyVaultName }}

--- a/build/templates/test-resources.bicep
+++ b/build/templates/test-resources.bicep
@@ -1,32 +1,32 @@
 // Define the location for the deployment of the components.
 param location string
 
-// Define the name of the DataFactory resource that will be created.
+// Define the name of the Azure Data Factory resource that will be created.
 param dataFactoryName string
 
 // Define the name of the storage account that will be created.
 param storageAccountName string
 
-// Define the name of the CosmosDb MongoDb database account that will be created.
-param cosmosDb_mongoDb_name string
+// Define the name of the Cosmos DB for MongoDB database account that will be created.
+param cosmosDbMongoDbName string
 
-// Define the name of the CosmosDb MongoDb database that will be created.
-param cosmosDb_mongoDb_databaseName string
+// Define the name of the Cosmos DB for MongoDB database that will be created.
+param cosmosDbMongoDbDatabaseName string
 
-// Define the name of the CosmosDb NoSql database account that will be created.
-param cosmosDb_noSql_name string
+// Define the name of the Cosmos DB for NoSQL database account that will be created.
+param cosmosDbNoSqlName string
 
-// Define the name of the CosmosDb NoSql database that will be created.
-param cosmosDb_noSql_databaseName string
+// Define the name of the Cosmos DB for NoSQL database that will be created.
+param cosmosDbNoSqlDatabaseName string
 
-// Define the name of the Service bus namespace resource that will be created.
+// Define the name of the Service Bus namespace resource that will be created.
 param serviceBusNamespaceName string
 
-// Define the name of the key vault where the necessary secrets will be stored to access the deployed test resources.
+// Define the name of the Key Vault where the necessary secrets will be stored to access the deployed test resources.
 param keyVaultName string
 
-// Define the Service Principal ID that needs access full access to the deployed resource group.
-param servicePrincipal_objectId string
+// Define the service principal ID that needs access full access to the deployed resource group.
+param servicePrincipalObjectId string
 
 module factory 'br/public:avm/res/data-factory/factory:0.4.0' = {
   name: 'dataFactoryDeployment'
@@ -51,11 +51,11 @@ module storageAccount 'br/public:avm/res/storage/storage-account:0.9.1' = {
     }
     roleAssignments: [
       {
-        principalId: servicePrincipal_objectId
+        principalId: servicePrincipalObjectId
         roleDefinitionIdOrName: 'Storage Blob Data Contributor'
       }
       {
-        principalId: servicePrincipal_objectId
+        principalId: servicePrincipalObjectId
         roleDefinitionIdOrName: 'Storage Table Data Contributor'
       }
     ]
@@ -65,7 +65,7 @@ module storageAccount 'br/public:avm/res/storage/storage-account:0.9.1' = {
 module cosmosDb_mongoDb 'br/public:avm/res/document-db/database-account:0.6.0' = {
   name: 'cosmosMongoDbDeployment'
   params: {
-    name: cosmosDb_mongoDb_name
+    name: cosmosDbMongoDbName
     location: location
     enableFreeTier: true
     capabilitiesToAdd: [
@@ -74,12 +74,12 @@ module cosmosDb_mongoDb 'br/public:avm/res/document-db/database-account:0.6.0' =
     ]
     mongodbDatabases: [
       {
-        name: cosmosDb_mongoDb_databaseName
+        name: cosmosDbMongoDbDatabaseName
       }
     ]
     roleAssignments: [
       {
-        principalId: servicePrincipal_objectId
+        principalId: servicePrincipalObjectId
         roleDefinitionIdOrName: 'DocumentDB Account Contributor'
       }
     ]
@@ -90,7 +90,7 @@ module cosmosDb_mongoDb 'br/public:avm/res/document-db/database-account:0.6.0' =
 module cosmosDb_noSql 'br/public:avm/res/document-db/database-account:0.6.0' = {
   name: 'cosmosNoSqlDeployment'
   params: {
-    name: cosmosDb_noSql_name
+    name: cosmosDbNoSqlName
     location: location
     disableLocalAuth: false
     capabilitiesToAdd: [
@@ -98,17 +98,17 @@ module cosmosDb_noSql 'br/public:avm/res/document-db/database-account:0.6.0' = {
     ]
     sqlDatabases: [
       {
-        name: cosmosDb_noSql_databaseName
+        name: cosmosDbNoSqlDatabaseName
       }
     ]
     roleAssignments: [
       {
-        principalId: servicePrincipal_objectId
+        principalId: servicePrincipalObjectId
         roleDefinitionIdOrName: 'DocumentDB Account Contributor'
       }
     ]
     sqlRoleAssignmentsPrincipalIds: [
-      servicePrincipal_objectId
+      servicePrincipalObjectId
     ]
     sqlRoleDefinitions: [
       {
@@ -141,7 +141,7 @@ module serviceBusNamespace 'br/public:avm/res/service-bus/namespace:0.10.1' = {
     zoneRedundant: false
     roleAssignments: [
       {
-        principalId: servicePrincipal_objectId
+        principalId: servicePrincipalObjectId
         roleDefinitionIdOrName: 'Azure Service Bus Data Owner'
       }
     ]
@@ -155,7 +155,7 @@ module vault 'br/public:avm/res/key-vault/vault:0.6.1' = {
     location: location
     roleAssignments: [
       {
-        principalId: servicePrincipal_objectId
+        principalId: servicePrincipalObjectId
         roleDefinitionIdOrName: 'Key Vault Secrets officer'
       }
     ]

--- a/docs/preview/03-Features/01-core.md
+++ b/docs/preview/03-Features/01-core.md
@@ -76,7 +76,7 @@ var config = TestConfig.Create((options, IConfigurationBuilder builder) =>
 ```
 
 :::tip
-By using the `IConfigurationBuilder` overload, other possible configuration sources are available to include, like [environment variables](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/configuration#evcp), but also [Azure Key vault secrets](https://learn.microsoft.com/en-us/aspnet/core/security/key-vault-configuration).
+By using the `IConfigurationBuilder` overload, other possible configuration sources are available to include, like [environment variables](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/configuration#evcp), but also [Azure Key Vault secrets](https://learn.microsoft.com/en-us/aspnet/core/security/key-vault-configuration).
 :::
 
 It can also be used as a base for your custom configuration, by inheriting from the `TestConfig`:

--- a/docs/preview/03-Features/04-Azure/04-Storage/02-cosmos.mdx
+++ b/docs/preview/03-Features/04-Azure/04-Storage/02-cosmos.mdx
@@ -91,7 +91,7 @@ await TemporaryMongoDbCollection.CreateIfNotExistsAsync(..., options =>
 
     // Delete all MongoDB documents that matches any of the configured filters,
     // upon the test fixture disposal, even if the test fixture didn't upserted them.
-    // ⚠️ MongoDb documents upserted by the test fixture will be deleted/reverted, even if the documents don't match the configured filters.
+    // ⚠️ MongoDB documents upserted by the test fixture will be deleted/reverted, even if the documents don't match the configured filters.
     options.OnTeardown.CleanMatchingDocuments(
       Builders<Shipment>.Filter.Eq(s => s.BoatName, "The Alice"));
 
@@ -181,7 +181,7 @@ await container.UpsertItemAsync(new Shipment { Id = "123", BoatName = "The Alice
 ```
 
 :::praise
-The `TemporaryNoSqlContainer` will always remove/revert any NoSql items that were upserted via the temporary container itself with the `container.UpsertItemAsync`. This follows the 'clean environment' testing principal that any test should not leave any state it created behind after the test has run.
+The `TemporaryNoSqlContainer` will always remove/revert any NoSQL items that were upserted via the temporary container itself with the `container.UpsertItemAsync`. This follows the 'clean environment' testing principal that any test should not leave any state it created behind after the test has run.
 :::
 
 #### Customization
@@ -202,14 +202,14 @@ await TemporaryNoSqlContainer.CreateIfNotExistsAsync(..., options =>
     options.OnSetup.CleanAllItems();
 
     // Delete all NoSQL items that matches any of the configured filters,
-    // upon the test fixture creation, when there was already a NoSql container available.
+    // upon the test fixture creation, when there was already a NoSQL container available.
     options.OnSetup.CleanMatchingItems((NoSqlItem item) => item.Id == "123");
     options.OnSetup.CleanMatchingItems((Shipment item) => item.BoatName == "The Alice");
     
     // Options related to when the test fixture is teared down.
     // --------------------------------------------------------
 
-    // (Default) Delete/Revert all NoSql items that were upserted by the test fixture.
+    // (Default) Delete/Revert all NoSQL items that were upserted by the test fixture.
     options.OnTeardown.CleanUpsertedItems();
 
     // Delete all NoSQL items upon the test fixture disposal,
@@ -218,7 +218,7 @@ await TemporaryNoSqlContainer.CreateIfNotExistsAsync(..., options =>
 
     // Delete all NoSQL items that matches any of the configured filters,
     // upon the test fixture disposal, even if the test fixture didn't upserted them.
-    // ⚠️ NoSql items upserted by the test fixture will be deleted/reverted, even if the items don't match the configured filters.
+    // ⚠️ NoSQL items upserted by the test fixture will be deleted/reverted, even if the items don't match the configured filters.
     options.OnTeardown.CleanMatchingItems((NoSqlItem item) => item.Id == "123"); 
     options.OnTeardown.CleanMatchingItems((Shipment item) => item.BoatName == "The Alice");
 });

--- a/docs/preview/03-Features/04-Azure/06-Integration/01-data-factory.mdx
+++ b/docs/preview/03-Features/04-Azure/06-Integration/01-data-factory.mdx
@@ -11,7 +11,7 @@ The following functionality is available when installing this package:
 PM> Install-Package -Name Arcus.Testing.Integration.DataFactory
 ```
 
-## Temporary DataFlow debug session
+## Temporary data flow debug session
 The `TemporaryDataFlowDebugSession` test fixture provides an answer to automatically tracking the process of an Azure Data Factory data flow under test. More information on data flow debugging can be found on [Mapping data flow Debug Mode](https://learn.microsoft.com/en-us/azure/data-factory/concepts-data-flow-debug-mode?tabs=data-factory).
 
 The test fixture instance is meant to be used across tests. By all using the same instance, the performance of the tests is greatly improved.
@@ -231,7 +231,7 @@ await session.RunDataFlowAsync(..., options =>
     options.AddDataFlowParameter("<name>", "'<value>'");
 
     // Adds a dataset parameter to the data flow upon starting.
-    // 👀 Note that the source or sink name should be the "Output stream name" of the source or sink dataset in the data flow, not the actual DataSet name.
+    // 👀 Note that the source or sink name should be the "Output stream name" of the source or sink dataset in the data flow, not the actual dataset name.
     // For more info: https://learn.microsoft.com/en-us/azure/data-factory/data-flow-source#source-settings
     options.AddDataSetParameter("<source-or-sink-name>", "<parameter-name>", "<parameter-value>");
 
@@ -241,7 +241,7 @@ await session.RunDataFlowAsync(..., options =>
     options.AddFlowlet("<flowlet-name>");
 
     // Add additional linked services to the debug session.
-    // 💡 This can be useful to add, for example, an additional Key vault linked services for certain authentication types of datasets.
+    // 💡 This can be useful to add, for example, an additional Key Vault linked services for certain authentication types of datasets.
     options.AddLinkedService("datafactory_sales_keyvaultLS");
 
     // The maximum amount of rows to include in the preview response (default: 100 rows).
@@ -253,7 +253,7 @@ await session.RunDataFlowAsync(..., options =>
 When the `RunDataFlow` method gives obscure Microsoft failures, it might be a problem with missing linked services that are being passed to the debug session. By default, all datasets are loaded automatically, but additional dependent linked services might not. 
 :::
 
-## Run a Data pipeline
+## Run an Azure Data Factory pipeline
 Arcus does not provide any additional functionality to run a pipeline and wait for its result, as all this can be easily done with the [`Azure.ResourceManager.DataFactory`](https://learn.microsoft.com/en-us/dotnet/api/overview/azure/resourcemanager.datafactory-readme?view=azure-dotnet) and [`Arcus.Testing.Core`](../../01-core.md) packages:
 
 ```csharp
@@ -273,5 +273,5 @@ DataFactoryPipelineRunInfo finalStatus =
               .Until(current => current.Status == "Succeeded")
               .Every(TimeSpan.FromSeconds(5))
               .Timeout(TimeSpan.FromMinutes(1))
-              .FailWith("DataFactory pipeline did not succeeded within the expected time frame");
+              .FailWith("Azure Data Factory pipeline did not succeeded within the expected time frame");
 ```

--- a/docs/preview/04-Guidance/migrate-from-testing-framework-to-arcus-testing-v1.0.mdx
+++ b/docs/preview/04-Guidance/migrate-from-testing-framework-to-arcus-testing-v1.0.mdx
@@ -285,7 +285,7 @@ arguments.AddExtensionObject("mycompany.azure.common.extensions.components", map
 ```
 
 ## Replace `Codit.Testing.DataFactory` with `Arcus.Testing.Integration.DataFactory`
-The `Codit.Testing.DataFactory` handled start/stop functionality on DataFlow/Pipelines in DataFactory with and without debug sessions. Testing DataFlow's and managing debug sessions is now fully managed with `Arcus.Testing.Integration.DataFactory`.
+The `Codit.Testing.DataFactory` handled start/stop functionality on data flow/Pipelines in Azure Data Factory with and without debug sessions. Testing data flows and managing debug sessions is now fully managed with `Arcus.Testing.Integration.DataFactory`.
 
 Start by installing this library:
 ```powershell
@@ -358,7 +358,7 @@ Starting DataFlow's in a debug session is now linked to the `TemporaryDataFlowDe
 ### Run a Data pipeline
 Arcus does not provide any additional functionality to run a pipeline and wait for its result, as all this can be easily done with the [`Azure.ResourceManager.DataFactory`](https://learn.microsoft.com/en-us/dotnet/api/overview/azure/resourcemanager.datafactory-readme?view=azure-dotnet) and [`Arcus.Testing.Core`](../03-Features/01-core.md) packages.
 
-> 🔗 See the [feature documentation](../03-Features/04-Azure/06-Integration/01-data-factory.mdx) for more information on testing DataFactory functionality.
+> 🔗 See the [feature documentation](../03-Features/04-Azure/06-Integration/01-data-factory.mdx) for more information on testing Azure Data Factory functionality.
 
 ## Replace storage account interactions
 
@@ -473,7 +473,7 @@ Start by installing this library:
 PM > Install-Package -Name Arcus.Testing.Storage.Cosmos
 ```
 
-### Interact with a NoSql container
+### Interact with a NoSQL container
 The testing framework separated storage operations, which are now collected in a single `TemporaryNoSqlContainer` test fixture. Based on the needs of the test, the fixture can be adapted. Interacting with the container can be done with the Azure SDK.
 
 ```diff
@@ -503,4 +503,4 @@ The testing framework separated storage operations, which are now collected in a
 + await container.AddItemAsync(<model>);
 ```
 
-> 🔗 See the [feature documentation](../03-Features/04-Azure/04-Storage/02-cosmos.mdx) for more information on interacting with Cosmos NoSql storage.
+> 🔗 See the [feature documentation](../03-Features/04-Azure/04-Storage/02-cosmos.mdx) for more information on interacting with Cosmos DB for NoSQL storage.

--- a/docs/preview/04-Guidance/migrate-from-v1-to-v2.md
+++ b/docs/preview/04-Guidance/migrate-from-v1-to-v2.md
@@ -89,7 +89,7 @@ TemporaryNoSqlContainer.CreateIfNotExistsAsync(..., options =>
 ```
 
 ### `NoSqlItemFilter` ➡️ `Func<NoSqlItem, bool>`
-Previous versions had a dedicated type called `NoSqlItemFilter` to filter out certain Azure Cosmos NoSql items subject for deletion during the setup/teardown of the container. The type has been removed in v2 in favor of a built-in delegation.
+Previous versions had a dedicated type called `NoSqlItemFilter` to filter out certain Azure Cosmos DB for NoSQL items subject for deletion during the setup/teardown of the container. The type has been removed in v2 in favor of a built-in delegation.
 
 ```diff
 TemporaryNoSqlContainer.CreateIfNoExistsAsync(..., options =>

--- a/docs/versioned_docs/version-v2.0.0/03-Features/01-core.md
+++ b/docs/versioned_docs/version-v2.0.0/03-Features/01-core.md
@@ -76,7 +76,7 @@ var config = TestConfig.Create((options, IConfigurationBuilder builder) =>
 ```
 
 :::tip
-By using the `IConfigurationBuilder` overload, other possible configuration sources are available to include, like [environment variables](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/configuration#evcp), but also [Azure Key vault secrets](https://learn.microsoft.com/en-us/aspnet/core/security/key-vault-configuration).
+By using the `IConfigurationBuilder` overload, other possible configuration sources are available to include, like [environment variables](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/configuration#evcp), but also [Azure Key Vault secrets](https://learn.microsoft.com/en-us/aspnet/core/security/key-vault-configuration).
 :::
 
 It can also be used as a base for your custom configuration, by inheriting from the `TestConfig`:

--- a/docs/versioned_docs/version-v2.0.0/03-Features/04-Azure/04-Storage/02-cosmos.mdx
+++ b/docs/versioned_docs/version-v2.0.0/03-Features/04-Azure/04-Storage/02-cosmos.mdx
@@ -91,7 +91,7 @@ await TemporaryMongoDbCollection.CreateIfNotExistsAsync(..., options =>
 
     // Delete all MongoDB documents that matches any of the configured filters,
     // upon the test fixture disposal, even if the test fixture didn't upserted them.
-    // ⚠️ MongoDb documents upserted by the test fixture will be deleted/reverted, even if the documents don't match the configured filters.
+    // ⚠️ MongoDB documents upserted by the test fixture will be deleted/reverted, even if the documents don't match the configured filters.
     options.OnTeardown.CleanMatchingDocuments(
       Builders<Shipment>.Filter.Eq(s => s.BoatName, "The Alice"));
 

--- a/docs/versioned_docs/version-v2.0.0/03-Features/04-Azure/06-Integration/01-data-factory.mdx
+++ b/docs/versioned_docs/version-v2.0.0/03-Features/04-Azure/06-Integration/01-data-factory.mdx
@@ -11,7 +11,7 @@ The following functionality is available when installing this package:
 PM> Install-Package -Name Arcus.Testing.Integration.DataFactory
 ```
 
-## Temporary DataFlow debug session
+## Temporary data flow debug session
 The `TemporaryDataFlowDebugSession` test fixture provides an answer to automatically tracking the process of an Azure Data Factory data flow under test. More information on data flow debugging can be found on [Mapping data flow Debug Mode](https://learn.microsoft.com/en-us/azure/data-factory/concepts-data-flow-debug-mode?tabs=data-factory).
 
 The test fixture instance is meant to be used across tests. By all using the same instance, the performance of the tests is greatly improved.
@@ -231,12 +231,12 @@ await session.RunDataFlowAsync(..., options =>
     options.AddDataFlowParameter("<name>", "'<value>'");
 
     // Adds a dataset parameter to the data flow upon starting.
-    // 👀 Note that the source or sink name should be the "Output stream name" of the source or sink dataset in the data flow, not the actual DataSet name.
+    // 👀 Note that the source or sink name should be the "Output stream name" of the source or sink dataset in the data flow, not the actual dataset name.
     // For more info: https://learn.microsoft.com/en-us/azure/data-factory/data-flow-source#source-settings
     options.AddDataSetParameter("<source-or-sink-name>", "<parameter-name>", "<parameter-value>");
 
     // Add additional linked services to the debug session.
-    // 💡 This can be useful to add, for example, an additional Key vault linked services for certain authentication types of datasets.
+    // 💡 This can be useful to add, for example, an additional Key Vault linked services for certain authentication types of datasets.
     options.AddLinkedService("datafactory_sales_keyvaultLS");
 
     // The maximum amount of rows to include in the preview response (default: 100 rows).
@@ -248,7 +248,7 @@ await session.RunDataFlowAsync(..., options =>
 When the `RunDataFlow` method gives obscure Microsoft failures, it might be a problem with missing linked services that are being passed to the debug session. By default, all datasets are loaded automatically, but additional dependent linked services might not. 
 :::
 
-## Run a Data pipeline
+## Run an Azure Data Factory pipeline
 Arcus does not provide any additional functionality to run a pipeline and wait for its result, as all this can be easily done with the [`Azure.ResourceManager.DataFactory`](https://learn.microsoft.com/en-us/dotnet/api/overview/azure/resourcemanager.datafactory-readme?view=azure-dotnet) and [`Arcus.Testing.Core`](../../01-core.md) packages:
 
 ```csharp
@@ -268,5 +268,5 @@ DataFactoryPipelineRunInfo finalStatus =
               .Until(current => current.Status == "Succeeded")
               .Every(TimeSpan.FromSeconds(5))
               .Timeout(TimeSpan.FromMinutes(1))
-              .FailWith("DataFactory pipeline did not succeeded within the expected time frame");
+              .FailWith("Azure Data Factory pipeline did not succeeded within the expected time frame");
 ```

--- a/docs/versioned_docs/version-v2.0.0/04-Guidance/migrate-from-testing-framework-to-arcus-testing-v1.0.mdx
+++ b/docs/versioned_docs/version-v2.0.0/04-Guidance/migrate-from-testing-framework-to-arcus-testing-v1.0.mdx
@@ -285,7 +285,7 @@ arguments.AddExtensionObject("mycompany.azure.common.extensions.components", map
 ```
 
 ## Replace `Codit.Testing.DataFactory` with `Arcus.Testing.Integration.DataFactory`
-The `Codit.Testing.DataFactory` handled start/stop functionality on DataFlow/Pipelines in DataFactory with and without debug sessions. Testing DataFlow's and managing debug sessions is now fully managed with `Arcus.Testing.Integration.DataFactory`.
+The `Codit.Testing.DataFactory` handled start/stop functionality on data flow/pipelines in Azure Data Factory with and without debug sessions. Testing data flows and managing debug sessions is now fully managed with `Arcus.Testing.Integration.DataFactory`.
 
 Start by installing this library:
 ```powershell
@@ -321,8 +321,8 @@ Arcus wraps the start/stop functionality previously defined in the testing frame
 +     await TemporaryDataFlowDebugSession.StartDebugSessionAsync(resourceId, logger);
 ```
 
-### Run a DataFlow in debug session
-Starting DataFlow's in a debug session is now linked to the `TemporaryDataFlowDebugSession` test fixture. A method is available to run a particular DataFlow, while expecting the result to become available in a passed-in sink.
+### Run a data flow in debug session
+Starting data flows in a debug session is now linked to the `TemporaryDataFlowDebugSession` test fixture. A method is available to run a particular data flow, while expecting the result to become available in a passed-in sink.
 
 ```diff
 - using Codit.Testing.DataFactory;
@@ -358,7 +358,7 @@ Starting DataFlow's in a debug session is now linked to the `TemporaryDataFlowDe
 ### Run a Data pipeline
 Arcus does not provide any additional functionality to run a pipeline and wait for its result, as all this can be easily done with the [`Azure.ResourceManager.DataFactory`](https://learn.microsoft.com/en-us/dotnet/api/overview/azure/resourcemanager.datafactory-readme?view=azure-dotnet) and [`Arcus.Testing.Core`](../03-Features/01-core.md) packages.
 
-> 🔗 See the [feature documentation](../03-Features/04-Azure/06-Integration/01-data-factory.mdx) for more information on testing DataFactory functionality.
+> 🔗 See the [feature documentation](../03-Features/04-Azure/06-Integration/01-data-factory.mdx) for more information on testing Azure Data Factory functionality.
 
 ## Replace storage account interactions
 
@@ -473,7 +473,7 @@ Start by installing this library:
 PM > Install-Package -Name Arcus.Testing.Storage.Cosmos
 ```
 
-### Interact with a NoSql container
+### Interact with a NoSQL container
 The testing framework separated storage operations, which are now collected in a single `TemporaryNoSqlContainer` test fixture. Based on the needs of the test, the fixture can be adapted. Interacting with the container can be done with the Azure SDK.
 
 ```diff

--- a/docs/versioned_docs/version-v2.0.0/04-Guidance/migrate-from-v1-to-v2.md
+++ b/docs/versioned_docs/version-v2.0.0/04-Guidance/migrate-from-v1-to-v2.md
@@ -89,7 +89,7 @@ TemporaryNoSqlContainer.CreateIfNotExistsAsync(..., options =>
 ```
 
 ### `NoSqlItemFilter` ➡️ `Func<NoSqlItem, bool>`
-Previous versions had a dedicated type called `NoSqlItemFilter` to filter out certain Azure Cosmos NoSql items subject for deletion during the setup/teardown of the container. The type has been removed in v2 in favor of a built-in delegation.
+Previous versions had a dedicated type called `NoSqlItemFilter` to filter out certain Azure Cosmos NoSQL items subject for deletion during the setup/teardown of the container. The type has been removed in v2 in favor of a built-in delegation.
 
 ```diff
 TemporaryNoSqlContainer.CreateIfNoExistsAsync(..., options =>

--- a/docs/versioned_docs/version-v2.1.0/03-Features/01-core.md
+++ b/docs/versioned_docs/version-v2.1.0/03-Features/01-core.md
@@ -76,7 +76,7 @@ var config = TestConfig.Create((options, IConfigurationBuilder builder) =>
 ```
 
 :::tip
-By using the `IConfigurationBuilder` overload, other possible configuration sources are available to include, like [environment variables](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/configuration#evcp), but also [Azure Key vault secrets](https://learn.microsoft.com/en-us/aspnet/core/security/key-vault-configuration).
+By using the `IConfigurationBuilder` overload, other possible configuration sources are available to include, like [environment variables](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/configuration#evcp), but also [Azure Key Vault secrets](https://learn.microsoft.com/en-us/aspnet/core/security/key-vault-configuration).
 :::
 
 It can also be used as a base for your custom configuration, by inheriting from the `TestConfig`:

--- a/docs/versioned_docs/version-v2.1.0/03-Features/04-Azure/04-Storage/02-cosmos.mdx
+++ b/docs/versioned_docs/version-v2.1.0/03-Features/04-Azure/04-Storage/02-cosmos.mdx
@@ -91,7 +91,7 @@ await TemporaryMongoDbCollection.CreateIfNotExistsAsync(..., options =>
 
     // Delete all MongoDB documents that matches any of the configured filters,
     // upon the test fixture disposal, even if the test fixture didn't upserted them.
-    // ⚠️ MongoDb documents upserted by the test fixture will be deleted/reverted, even if the documents don't match the configured filters.
+    // ⚠️ MongoDB documents upserted by the test fixture will be deleted/reverted, even if the documents don't match the configured filters.
     options.OnTeardown.CleanMatchingDocuments(
       Builders<Shipment>.Filter.Eq(s => s.BoatName, "The Alice"));
 
@@ -181,7 +181,7 @@ await container.UpsertItemAsync(new Shipment { Id = "123", BoatName = "The Alice
 ```
 
 :::praise
-The `TemporaryNoSqlContainer` will always remove/revert any NoSql items that were upserted via the temporary container itself with the `container.UpsertItemAsync`. This follows the 'clean environment' testing principal that any test should not leave any state it created behind after the test has run.
+The `TemporaryNoSqlContainer` will always remove/revert any NoSQL items that were upserted via the temporary container itself with the `container.UpsertItemAsync`. This follows the 'clean environment' testing principal that any test should not leave any state it created behind after the test has run.
 :::
 
 #### Customization
@@ -202,14 +202,14 @@ await TemporaryNoSqlContainer.CreateIfNotExistsAsync(..., options =>
     options.OnSetup.CleanAllItems();
 
     // Delete all NoSQL items that matches any of the configured filters,
-    // upon the test fixture creation, when there was already a NoSql container available.
+    // upon the test fixture creation, when there was already a NoSQL container available.
     options.OnSetup.CleanMatchingItems((NoSqlItem item) => item.Id == "123");
     options.OnSetup.CleanMatchingItems((Shipment item) => item.BoatName == "The Alice");
     
     // Options related to when the test fixture is teared down.
     // --------------------------------------------------------
 
-    // (Default) Delete/Revert all NoSql items that were upserted by the test fixture.
+    // (Default) Delete/Revert all NoSQL items that were upserted by the test fixture.
     options.OnTeardown.CleanUpsertedItems();
 
     // Delete all NoSQL items upon the test fixture disposal,
@@ -218,7 +218,7 @@ await TemporaryNoSqlContainer.CreateIfNotExistsAsync(..., options =>
 
     // Delete all NoSQL items that matches any of the configured filters,
     // upon the test fixture disposal, even if the test fixture didn't upserted them.
-    // ⚠️ NoSql items upserted by the test fixture will be deleted/reverted, even if the items don't match the configured filters.
+    // ⚠️ NoSQL items upserted by the test fixture will be deleted/reverted, even if the items don't match the configured filters.
     options.OnTeardown.CleanMatchingItems((NoSqlItem item) => item.Id == "123"); 
     options.OnTeardown.CleanMatchingItems((Shipment item) => item.BoatName == "The Alice");
 });

--- a/docs/versioned_docs/version-v2.1.0/03-Features/04-Azure/06-Integration/01-data-factory.mdx
+++ b/docs/versioned_docs/version-v2.1.0/03-Features/04-Azure/06-Integration/01-data-factory.mdx
@@ -11,7 +11,7 @@ The following functionality is available when installing this package:
 PM> Install-Package -Name Arcus.Testing.Integration.DataFactory
 ```
 
-## Temporary DataFlow debug session
+## Temporary data flow debug session
 The `TemporaryDataFlowDebugSession` test fixture provides an answer to automatically tracking the process of an Azure Data Factory data flow under test. More information on data flow debugging can be found on [Mapping data flow Debug Mode](https://learn.microsoft.com/en-us/azure/data-factory/concepts-data-flow-debug-mode?tabs=data-factory).
 
 The test fixture instance is meant to be used across tests. By all using the same instance, the performance of the tests is greatly improved.
@@ -231,7 +231,7 @@ await session.RunDataFlowAsync(..., options =>
     options.AddDataFlowParameter("<name>", "'<value>'");
 
     // Adds a dataset parameter to the data flow upon starting.
-    // 👀 Note that the source or sink name should be the "Output stream name" of the source or sink dataset in the data flow, not the actual DataSet name.
+    // 👀 Note that the source or sink name should be the "Output stream name" of the source or sink dataset in the data flow, not the actual dataset name.
     // For more info: https://learn.microsoft.com/en-us/azure/data-factory/data-flow-source#source-settings
     options.AddDataSetParameter("<source-or-sink-name>", "<parameter-name>", "<parameter-value>");
 
@@ -241,7 +241,7 @@ await session.RunDataFlowAsync(..., options =>
     options.AddFlowlet("<flowlet-name>");
 
     // Add additional linked services to the debug session.
-    // 💡 This can be useful to add, for example, an additional Key vault linked services for certain authentication types of datasets.
+    // 💡 This can be useful to add, for example, an additional Key Vault linked services for certain authentication types of datasets.
     options.AddLinkedService("datafactory_sales_keyvaultLS");
 
     // The maximum amount of rows to include in the preview response (default: 100 rows).
@@ -253,7 +253,7 @@ await session.RunDataFlowAsync(..., options =>
 When the `RunDataFlow` method gives obscure Microsoft failures, it might be a problem with missing linked services that are being passed to the debug session. By default, all datasets are loaded automatically, but additional dependent linked services might not. 
 :::
 
-## Run a Data pipeline
+## Run an Azure Data Factory pipeline
 Arcus does not provide any additional functionality to run a pipeline and wait for its result, as all this can be easily done with the [`Azure.ResourceManager.DataFactory`](https://learn.microsoft.com/en-us/dotnet/api/overview/azure/resourcemanager.datafactory-readme?view=azure-dotnet) and [`Arcus.Testing.Core`](../../01-core.md) packages:
 
 ```csharp
@@ -273,5 +273,5 @@ DataFactoryPipelineRunInfo finalStatus =
               .Until(current => current.Status == "Succeeded")
               .Every(TimeSpan.FromSeconds(5))
               .Timeout(TimeSpan.FromMinutes(1))
-              .FailWith("DataFactory pipeline did not succeeded within the expected time frame");
+              .FailWith("Azure Data Factory pipeline did not succeeded within the expected time frame");
 ```

--- a/docs/versioned_docs/version-v2.1.0/04-Guidance/migrate-from-testing-framework-to-arcus-testing-v1.0.mdx
+++ b/docs/versioned_docs/version-v2.1.0/04-Guidance/migrate-from-testing-framework-to-arcus-testing-v1.0.mdx
@@ -285,7 +285,7 @@ arguments.AddExtensionObject("mycompany.azure.common.extensions.components", map
 ```
 
 ## Replace `Codit.Testing.DataFactory` with `Arcus.Testing.Integration.DataFactory`
-The `Codit.Testing.DataFactory` handled start/stop functionality on DataFlow/Pipelines in DataFactory with and without debug sessions. Testing DataFlow's and managing debug sessions is now fully managed with `Arcus.Testing.Integration.DataFactory`.
+The `Codit.Testing.DataFactory` handled start/stop functionality on DataFlow/Pipelines in Azure Data Factory with and without debug sessions. Testing DataFlow's and managing debug sessions is now fully managed with `Arcus.Testing.Integration.DataFactory`.
 
 Start by installing this library:
 ```powershell
@@ -358,7 +358,7 @@ Starting DataFlow's in a debug session is now linked to the `TemporaryDataFlowDe
 ### Run a Data pipeline
 Arcus does not provide any additional functionality to run a pipeline and wait for its result, as all this can be easily done with the [`Azure.ResourceManager.DataFactory`](https://learn.microsoft.com/en-us/dotnet/api/overview/azure/resourcemanager.datafactory-readme?view=azure-dotnet) and [`Arcus.Testing.Core`](../03-Features/01-core.md) packages.
 
-> 🔗 See the [feature documentation](../03-Features/04-Azure/06-Integration/01-data-factory.mdx) for more information on testing DataFactory functionality.
+> 🔗 See the [feature documentation](../03-Features/04-Azure/06-Integration/01-data-factory.mdx) for more information on testing Azure Data Factory functionality.
 
 ## Replace storage account interactions
 
@@ -473,7 +473,7 @@ Start by installing this library:
 PM > Install-Package -Name Arcus.Testing.Storage.Cosmos
 ```
 
-### Interact with a NoSql container
+### Interact with a NoSQL container
 The testing framework separated storage operations, which are now collected in a single `TemporaryNoSqlContainer` test fixture. Based on the needs of the test, the fixture can be adapted. Interacting with the container can be done with the Azure SDK.
 
 ```diff
@@ -503,4 +503,4 @@ The testing framework separated storage operations, which are now collected in a
 + await container.AddItemAsync(<model>);
 ```
 
-> 🔗 See the [feature documentation](../03-Features/04-Azure/04-Storage/02-cosmos.mdx) for more information on interacting with Cosmos NoSql storage.
+> 🔗 See the [feature documentation](../03-Features/04-Azure/04-Storage/02-cosmos.mdx) for more information on interacting with Cosmos DB for NoSQL storage.

--- a/docs/versioned_docs/version-v2.1.0/04-Guidance/migrate-from-v1-to-v2.md
+++ b/docs/versioned_docs/version-v2.1.0/04-Guidance/migrate-from-v1-to-v2.md
@@ -89,7 +89,7 @@ TemporaryNoSqlContainer.CreateIfNotExistsAsync(..., options =>
 ```
 
 ### `NoSqlItemFilter` ➡️ `Func<NoSqlItem, bool>`
-Previous versions had a dedicated type called `NoSqlItemFilter` to filter out certain Azure Cosmos NoSql items subject for deletion during the setup/teardown of the container. The type has been removed in v2 in favor of a built-in delegation.
+Previous versions had a dedicated type called `NoSqlItemFilter` to filter out certain Azure Cosmos NoSQL items subject for deletion during the setup/teardown of the container. The type has been removed in v2 in favor of a built-in delegation.
 
 ```diff
 TemporaryNoSqlContainer.CreateIfNoExistsAsync(..., options =>


### PR DESCRIPTION
Not all source files already used the Microsoft naming conventions for their products. This is a follow-up PR for previous PR's related to #417 .

This final PR should finally streamline this naming convention throughout.
Closes #417 