### PR TITLE
chore(style): apply .editorconfig on data factory components

### DIFF
--- a/src/Arcus.Testing.Integration.DataFactory/DataFlowRunResult.cs
+++ b/src/Arcus.Testing.Integration.DataFactory/DataFlowRunResult.cs
@@ -116,7 +116,7 @@ namespace Arcus.Testing
             var headersTxt = header.GetValue<string>();
             headersTxt = Regex.Replace(headersTxt, "^output\\(", string.Empty);
             headersTxt = headersTxt.Remove(headersTxt.Length - 1, 1);
-            headersTxt = 
+            headersTxt =
                 headersTxt.Replace("\\n", "")
                           .Replace(", ", ",")
                           .Replace(" as string[]", " as string")
@@ -129,7 +129,7 @@ namespace Arcus.Testing
                     $"[Test] Cannot load the content of the Azure Data Factory preview as the headers are not considered in a valid format: {headersTxt}, " +
                     $"consider parsing the raw run data yourself as this parsing only supports limited structures");
             }
-                
+
             (int _, PreviewHeader[] parsed) = ParseSchemeAsPreviewHeaders(startIndex: 0, headersTxt);
             return parsed;
         }
@@ -210,17 +210,17 @@ namespace Arcus.Testing
             return (-1, headers.ToArray());
         }
 
-         private static JsonNode ParseDataAsNode(PreviewHeader[] headers, JsonObject outputObj, DataPreviewJsonOptions options)
-         {
-             JsonArray dataArray = ParseDataAsArray(outputObj);
-             JsonNode[] results =
-                dataArray.Where(elem => elem is JsonArray)
-                         .Cast<JsonArray>()
-                         .Select(arr => FillJsonDataFromHeaders(headers, arr, options))
-                         .ToArray();
+        private static JsonNode ParseDataAsNode(PreviewHeader[] headers, JsonObject outputObj, DataPreviewJsonOptions options)
+        {
+            JsonArray dataArray = ParseDataAsArray(outputObj);
+            JsonNode[] results =
+               dataArray.Where(elem => elem is JsonArray)
+                        .Cast<JsonArray>()
+                        .Select(arr => FillJsonDataFromHeaders(headers, arr, options))
+                        .ToArray();
 
-            return results.Length == 1 
-                ? results[0] 
+            return results.Length == 1
+                ? results[0]
                 : JsonSerializer.SerializeToNode(results);
         }
 
@@ -244,17 +244,17 @@ namespace Arcus.Testing
                     case PreviewDataType.DirectValue:
                         result[headerName.Name] = ParseDirectValue(headerValue, options);
                         break;
-                    
+
                     case PreviewDataType.Array when headerValue is JsonArray arr:
                         JsonNode[] elements = arr.Cast<JsonArray>().Select(elem => FillJsonDataFromHeaders(headerName.Children, elem, options)).ToArray();
                         result[headerName.Name] = JsonSerializer.SerializeToNode(elements);
                         break;
-                    
+
                     case PreviewDataType.Object when headerValue is JsonArray inner:
                         JsonNode children = FillJsonDataFromHeaders(headerName.Children, inner, options);
                         result[headerName.Name] = JsonSerializer.SerializeToNode(children);
                         break;
-                    
+
                     default:
                         throw new JsonException(
                             $"[Test] Cannot load the content of the Azure Data Factory preview expression as the header and data is not representing the same types: {dataArray}, " +
@@ -415,8 +415,8 @@ namespace Arcus.Testing
 
         private static string[] ParseSchemeAsCsvHeaders(JsonObject outputObj)
         {
-            if (!outputObj.TryGetPropertyValue("schema", out JsonNode headersNode) 
-                || headersNode is not JsonValue headersValue 
+            if (!outputObj.TryGetPropertyValue("schema", out JsonNode headersNode)
+                || headersNode is not JsonValue headersValue
                 || !headersValue.ToString().StartsWith("output"))
             {
                 throw new CsvException(
@@ -522,7 +522,7 @@ namespace Arcus.Testing
                 string[] headerNames,
                 CsvRow[] rows,
                 string originalCsv,
-                AssertCsvOptions options) : base(headerNames, rows, originalCsv, options) 
+                AssertCsvOptions options) : base(headerNames, rows, originalCsv, options)
             {
             }
 

--- a/src/Arcus.Testing.Tests.Integration/Integration/DataFactory/TemporaryDataFlowDebugSessionTests.cs
+++ b/src/Arcus.Testing.Tests.Integration/Integration/DataFactory/TemporaryDataFlowDebugSessionTests.cs
@@ -1,6 +1,5 @@
 ﻿using System.Threading.Tasks;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Arcus.Testing.Tests.Integration.Integration.DataFactory
 {
@@ -22,13 +21,13 @@ namespace Arcus.Testing.Tests.Integration.Integration.DataFactory
         [Fact]
         public async Task StartDebugSession_WithActiveSession_SucceedsByReusingSession()
         {
-            await using (var otherSession = await TemporaryDataFlowDebugSession.StartDebugSessionAsync(DataFactory.ResourceId, Logger, 
+            await using (var otherSession = await TemporaryDataFlowDebugSession.StartDebugSessionAsync(DataFactory.ResourceId, Logger,
                 options => options.ActiveSessionId = _fixture.Value.SessionId))
             {
                 // Assert
                 Assert.Equal(_fixture.Value.SessionId, otherSession.SessionId);
             }
-            
+
             await _fixture.ShouldFindActiveSessionAsync(_fixture.Value.SessionId);
         }
     }

--- a/src/Arcus.Testing.Tests.Unit/Integration/DataFactory/Fixture/DataPreview.cs
+++ b/src/Arcus.Testing.Tests.Unit/Integration/DataFactory/Fixture/DataPreview.cs
@@ -27,7 +27,7 @@ namespace Arcus.Testing.Tests.Unit.Integration.DataFactory.Fixture
         {
             headersTxt = headersTxt.StartsWith("output(") ? headersTxt : $"output({headersTxt})";
             var data = Assert.IsType<JsonArray>(JsonNode.Parse(dataTxt));
-            
+
             return new DataPreview(headersTxt, data);
         }
 


### PR DESCRIPTION
Since some components were added before we introduced `.editorconfig`, there were still some files left that violated - and so, halted us from using an automated - code style workflow.

This PR applies the current rules to the Data Factory components.