### PR TITLE
chore(style): apply .editorconfig on sb components

### DIFF
--- a/src/Arcus.Testing.Messaging.ServiceBus/ServiceBusMessageFilter.cs
+++ b/src/Arcus.Testing.Messaging.ServiceBus/ServiceBusMessageFilter.cs
@@ -144,7 +144,7 @@ namespace Arcus.Testing
                     ? _client.CreateReceiver(_entityName, options)
                     : _client.CreateReceiver(_entityName, _subscriptionName, options);
 
-            IReadOnlyList<ServiceBusReceivedMessage> messages = 
+            IReadOnlyList<ServiceBusReceivedMessage> messages =
                 await receiver.PeekMessagesAsync(_maxMessages, cancellationToken: cancellationToken);
 
             return messages.Where(msg => _predicates.All(predicate => predicate(msg))).ToList();

--- a/src/Arcus.Testing.Messaging.ServiceBus/TemporaryQueue.cs
+++ b/src/Arcus.Testing.Messaging.ServiceBus/TemporaryQueue.cs
@@ -77,7 +77,7 @@ namespace Arcus.Testing
 
             MaxWaitTime = maxWaitTime;
             Messages = OnSetupQueue.DeadLetterMessages;
-            
+
             return this;
         }
 
@@ -128,7 +128,7 @@ namespace Arcus.Testing
 
             MaxWaitTime = maxWaitTime;
             Messages = OnSetupQueue.CompleteMessages;
-            
+
             return this;
         }
 
@@ -290,7 +290,7 @@ namespace Arcus.Testing
 
             MaxWaitTime = maxWaitTime;
             Messages = OnTeardownQueue.CompleteMessages;
-            
+
             return this;
         }
 
@@ -390,9 +390,9 @@ namespace Arcus.Testing
             _adminClient = adminClient;
             _messagingClient = messagingClient;
             _messagingClientCreatedByUs = messagingClientCreatedByUs;
-            
+
             _queueCreatedByUs = queueCreatedByUs;
-            
+
             _options = options ?? new TemporaryQueueOptions();
             _logger = logger ?? NullLogger.Instance;
 
@@ -461,7 +461,7 @@ namespace Arcus.Testing
             var credential = new DefaultAzureCredential();
             var adminClient = new ServiceBusAdministrationClient(fullyQualifiedNamespace, credential);
             var messagingClient = new ServiceBusClient(fullyQualifiedNamespace, credential);
-            
+
             return await CreateIfNotExistsAsync(adminClient, messagingClient, messagingClientCreatedByUs: true, queueName, logger, configureOptions);
         }
 

--- a/src/Arcus.Testing.Messaging.ServiceBus/TemporaryTopic.cs
+++ b/src/Arcus.Testing.Messaging.ServiceBus/TemporaryTopic.cs
@@ -75,7 +75,7 @@ namespace Arcus.Testing
 
             MaxWaitTime = maxWaitTime;
             Messages = OnSetupMessagesTopic.DeadLetterMessages;
-            
+
             return this;
         }
 
@@ -96,7 +96,7 @@ namespace Arcus.Testing
             return this;
         }
 
-         /// <summary>
+        /// <summary>
         /// Configures the <see cref="TemporaryTopic"/> to complete any pre-existing messages on all available topic subscriptions
         /// upon the creation of the test fixture.
         /// </summary>
@@ -120,10 +120,10 @@ namespace Arcus.Testing
         public OnSetupTemporaryTopicOptions CompleteMessages(TimeSpan maxWaitTime)
         {
             ArgumentOutOfRangeException.ThrowIfLessThan(maxWaitTime, TimeSpan.Zero);
-            
+
             MaxWaitTime = maxWaitTime;
             Messages = OnSetupMessagesTopic.CompleteMessages;
-            
+
             return this;
         }
 
@@ -284,7 +284,7 @@ namespace Arcus.Testing
 
             MaxWaitTime = maxWaitTime;
             Messages = OnTeardownMessagesTopic.CompleteMessages;
-            
+
             return this;
         }
 
@@ -386,7 +386,7 @@ namespace Arcus.Testing
             _messagingClientCreatedByUs = messagingClientCreatedByUs;
 
             _topicCreatedByUs = topicCreatedByUs;
-            
+
             _options = options ?? new TemporaryTopicOptions();
             _logger = logger;
 

--- a/src/Arcus.Testing.Messaging.ServiceBus/TemporaryTopicSubscription.cs
+++ b/src/Arcus.Testing.Messaging.ServiceBus/TemporaryTopicSubscription.cs
@@ -1,4 +1,4 @@
-﻿﻿using System;
+﻿using System;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Threading.Tasks;
@@ -203,7 +203,7 @@ namespace Arcus.Testing
 
             var options = new TemporaryTopicSubscriptionOptions();
             configureOptions?.Invoke(options);
-            
+
             CreateSubscriptionOptions createOptions = options.OnSetup.CreateSubscriptionOptions(topicName, subscriptionName);
 
             NamespaceProperties properties = await adminClient.GetNamespacePropertiesAsync();
@@ -282,7 +282,7 @@ namespace Arcus.Testing
                 }
                 else
                 {
-                    disposables.AddRange(_rules.Select(r => AsyncDisposable.Create(async () => 
+                    disposables.AddRange(_rules.Select(r => AsyncDisposable.Create(async () =>
                     {
                         if (await _client.RuleExistsAsync(TopicName, Name, r.Name))
                         {

--- a/src/Arcus.Testing.Tests.Integration/Messaging/Fixture/ServiceBusTestContext.cs
+++ b/src/Arcus.Testing.Tests.Integration/Messaging/Fixture/ServiceBusTestContext.cs
@@ -138,7 +138,7 @@ namespace Arcus.Testing.Tests.Integration.Messaging.Fixture
         {
             string ruleName = $"rule-{Guid.NewGuid()}";
             _ruleNames.Add((topicName, subscriptionName, ruleName));
-            
+
             return ruleName;
         }
 

--- a/src/Arcus.Testing.Tests.Integration/Messaging/TemporaryQueueTests.cs
+++ b/src/Arcus.Testing.Tests.Integration/Messaging/TemporaryQueueTests.cs
@@ -174,7 +174,7 @@ namespace Arcus.Testing.Tests.Integration.Messaging
         {
             string fullyQualifiedNamespace = Configuration.GetServiceBus().HostName;
 
-            var temp = 
+            var temp =
                 configureOptions is null
                     ? await TemporaryQueue.CreateIfNotExistsAsync(fullyQualifiedNamespace, queueName, Logger)
                     : await TemporaryQueue.CreateIfNotExistsAsync(fullyQualifiedNamespace, Bogus.Random.Guid().ToString(), Logger, configureOptions:

--- a/src/Arcus.Testing.Tests.Integration/Messaging/TemporaryTopicSubscriptionTests.cs
+++ b/src/Arcus.Testing.Tests.Integration/Messaging/TemporaryTopicSubscriptionTests.cs
@@ -1,10 +1,9 @@
-﻿﻿using System;
+﻿using System;
 using System.Threading.Tasks;
 using Arcus.Testing.Tests.Integration.Messaging.Configuration;
 using Arcus.Testing.Tests.Integration.Messaging.Fixture;
 using Azure.Messaging.ServiceBus.Administration;
 using Xunit;
-using Xunit.Abstractions;
 using static Azure.Messaging.ServiceBus.Administration.CreateRuleOptions;
 
 namespace Arcus.Testing.Tests.Integration.Messaging
@@ -59,10 +58,10 @@ namespace Arcus.Testing.Tests.Integration.Messaging
             // Assert
             await serviceBus.ShouldHaveTopicSubscriptionAsync(topicName, subscriptionName);
             await serviceBus.ShouldHaveTopicSubscriptionRuleAsync(topicName, subscriptionName, theirRuleName);
-            
+
             string ourRuleName = await temp.WhenRuleAvailableAsync();
             await serviceBus.ShouldHaveTopicSubscriptionRuleAsync(topicName, subscriptionName, ourRuleName);
-            
+
             await temp.DisposeAsync();
             await serviceBus.ShouldHaveTopicSubscriptionAsync(topicName, subscriptionName);
             await serviceBus.ShouldHaveTopicSubscriptionRuleAsync(topicName, subscriptionName, theirRuleName);
@@ -147,7 +146,7 @@ namespace Arcus.Testing.Tests.Integration.Messaging
         {
             string fullyQualifiedNamespace = Configuration.GetServiceBus().HostName;
 
-            var temp = 
+            var temp =
                 Bogus.Random.Bool()
                     ? await TemporaryTopicSubscription.CreateIfNotExistsAsync(fullyQualifiedNamespace, topicName, subscriptionName, Logger)
                     : await TemporaryTopicSubscription.CreateIfNotExistsAsync(fullyQualifiedNamespace, "otherTopic", subscriptionName, Logger, configureOptions: options =>

--- a/src/Arcus.Testing.Tests.Integration/Messaging/TemporaryTopicTests.cs
+++ b/src/Arcus.Testing.Tests.Integration/Messaging/TemporaryTopicTests.cs
@@ -23,7 +23,7 @@ namespace Arcus.Testing.Tests.Integration.Messaging
             await using var serviceBus = GivenServiceBus();
 
             string topicName = serviceBus.WhenTopicUnavailable();
-            
+
             // Act
             TemporaryTopic temp = await CreateTempTopicAsync(topicName);
 
@@ -220,7 +220,7 @@ namespace Arcus.Testing.Tests.Integration.Messaging
                         options.OnSetup.CreateTopicWith(topic => topic.Name = topicName);
                         configureOptions(options);
                     });
-            
+
             Assert.Equal(topicName, temp.Name);
             Assert.Equal(fullyQualifiedNamespace, temp.FullyQualifiedNamespace);
 

--- a/src/Arcus.Testing.Tests.Unit/Messaging/ServiceBus/TemporaryQueueTests.cs
+++ b/src/Arcus.Testing.Tests.Unit/Messaging/ServiceBus/TemporaryQueueTests.cs
@@ -37,7 +37,7 @@ namespace Arcus.Testing.Tests.Unit.Messaging.ServiceBus
             var messagingClient = new Mock<ServiceBusClient>();
             await Assert.ThrowsAnyAsync<ArgumentException>(() => TemporaryQueue.CreateIfNotExistsAsync(adminClient: null, messagingClient.Object, "<queue-name>", NullLogger.Instance));
             await Assert.ThrowsAnyAsync<ArgumentException>(() => TemporaryQueue.CreateIfNotExistsAsync(adminClient: null, messagingClient.Object, "<queue-name>", NullLogger.Instance, configureOptions: _ => { }));
-            
+
             var adminClient = new Mock<ServiceBusAdministrationClient>();
             await Assert.ThrowsAnyAsync<ArgumentException>(() => TemporaryQueue.CreateIfNotExistsAsync(adminClient.Object, messagingClient: null, "<queue-name>", NullLogger.Instance));
             await Assert.ThrowsAnyAsync<ArgumentException>(() => TemporaryQueue.CreateIfNotExistsAsync(adminClient.Object, messagingClient: null, "<queue-name>", NullLogger.Instance, configureOptions: _ => { }));


### PR DESCRIPTION
Since some components were added before we introduced `.editorconfig`, there were still some files left that violated - and so, halted us from using an automated - code style workflow.

This PR applies the current rules to the Service Bus components.
Relates to #432 