### PR TITLE
chore(style): apply .editorconfig on assert components

### DIFF
--- a/src/Arcus.Testing.Tests.Unit/Assert_/AssertXsltTests.cs
+++ b/src/Arcus.Testing.Tests.Unit/Assert_/AssertXsltTests.cs
@@ -67,7 +67,7 @@ namespace Arcus.Testing.Tests.Unit.Assert_
         public void TransformToJson_WithInvalidOutput_FailsWithDescription()
         {
             // Arrange
-            string xslt = 
+            string xslt =
                 "<xsl:stylesheet xmlns:xsl=\"http://www.w3.org/1999/XSL/Transform\" version=\"1.0\">" +
                 "<xsl:template match=\"/\"><root/></xsl:template></xsl:stylesheet>";
 
@@ -83,7 +83,7 @@ namespace Arcus.Testing.Tests.Unit.Assert_
         public void TransformToXml_WithInvalidOutput_FailsWithDescription()
         {
             // Arrange
-            string xslt = 
+            string xslt =
                 "<xsl:stylesheet xmlns:xsl=\"http://www.w3.org/1999/XSL/Transform\" version=\"1.0\">" +
                 "<xsl:template match=\"/\">{ \"root\": [] }</xsl:template></xsl:stylesheet>";
 
@@ -99,7 +99,7 @@ namespace Arcus.Testing.Tests.Unit.Assert_
         public void TransformToCsv_WithInvalidOutput_FailsWithDescription()
         {
             // Arrange
-            string xslt = 
+            string xslt =
                 "<xsl:stylesheet xmlns:xsl=\"http://www.w3.org/1999/XSL/Transform\" version=\"1.0\">" +
                 "<xsl:template match=\"/\">a;b;c\n1;3</xsl:template></xsl:stylesheet>";
 
@@ -116,7 +116,7 @@ namespace Arcus.Testing.Tests.Unit.Assert_
         public void Transform_WithInvalidTransformation_FailsWithDescription()
         {
             // Arrange
-            string xslt = 
+            string xslt =
                 "<xsl:stylesheet xmlns:xsl=\"http://www.w3.org/1999/XSL/Transform\" version=\"1.0\">" +
                     "<xsl:template match=\"/\"><xsl:message terminate=\"yes\">NotImplementedException</xsl:message></xsl:template></xsl:stylesheet>";
 
@@ -177,7 +177,7 @@ namespace Arcus.Testing.Tests.Unit.Assert_
             Assert.Contains(nameof(AssertXslt), exception.Message);
             Assert.Contains("XSLT contents", exception.Message);
         }
-        
+
         [Fact]
         public void TransformXml_WithoutArgs_Fails()
         {

--- a/src/Arcus.Testing.Tests.Unit/Assert_/Fixture/TestJson.cs
+++ b/src/Arcus.Testing.Tests.Unit/Assert_/Fixture/TestJson.cs
@@ -27,7 +27,7 @@ namespace Arcus.Testing.Tests.Unit.Assert_.Fixture
         /// <returns></returns>
         public static TestJson Generate()
         {
-            string json = 
+            string json =
                 Bogus.Random.Bool()
                     ? GenerateJsonObject()
                     : GenerateJsonArray();
@@ -202,7 +202,7 @@ namespace Arcus.Testing.Tests.Unit.Assert_.Fixture
 
             if (node is JsonObject obj)
             {
-                IDictionary<string, JsonNode> items = 
+                IDictionary<string, JsonNode> items =
                     Bogus.Random.Shuffle(obj)
                          .ToDictionary(p => p.Key, p => Shuffle(p.Value));
 

--- a/src/Arcus.Testing.Tests.Unit/Assert_/Fixture/TestXml.cs
+++ b/src/Arcus.Testing.Tests.Unit/Assert_/Fixture/TestXml.cs
@@ -26,7 +26,7 @@ namespace Arcus.Testing.Tests.Unit.Assert_.Fixture
         public static TestXml Generate()
         {
             var doc = new XmlDocument();
-            
+
             XmlElement root = doc.CreateElement(GenPrefix(), GenNodeName(), GenNamespace());
             Assert.All(GenAttributes(doc), a => root.Attributes.Append(a));
             doc.AppendChild(root);
@@ -39,7 +39,7 @@ namespace Arcus.Testing.Tests.Unit.Assert_.Fixture
                     return;
                 }
 
-                XmlElement[] children = 
+                XmlElement[] children =
                     Bogus.Make(Bogus.Random.Int(1, 5), GenNodeName)
                          .Select(name =>
                          {
@@ -207,7 +207,7 @@ namespace Arcus.Testing.Tests.Unit.Assert_.Fixture
         {
             if (Bogus.Random.Bool())
             {
-                
+
                 return doc.CreateAttribute(name ?? GenAttributeName());
             }
 
@@ -248,7 +248,7 @@ namespace Arcus.Testing.Tests.Unit.Assert_.Fixture
                 Bogus.Random.Int(1, 10),
                 () => _doc.CreateComment(Bogus.Lorem.Sentence()));
 
-            Assert.All(comments, 
+            Assert.All(comments,
                 comment => SelectRandomlyElement().AppendChild(comment));
         }
 
@@ -272,19 +272,19 @@ namespace Arcus.Testing.Tests.Unit.Assert_.Fixture
 
         private static XmlElement SelectRandomly(XmlElement node, Func<XmlElement, bool> filter)
         {
-            IEnumerable<XmlElement> elements = 
+            IEnumerable<XmlElement> elements =
                 node.ChildNodes.OfType<XmlElement>()
                     .Select(n => SelectRandomly(n, filter))
                     .Where(n => filter?.Invoke(n) ?? true)
                     .Concat(filter?.Invoke(node) ?? true ? new[] { node } : Array.Empty<XmlElement>());
-            
+
             return Bogus.PickRandom(elements);
         }
 
         public void Shuffle()
         {
             XmlNode shuffled = Shuffle(_doc.DocumentElement);
-            
+
             var xml = new XmlDocument();
             xml.LoadXml(shuffled.OuterXml);
             _doc = xml;
@@ -297,7 +297,7 @@ namespace Arcus.Testing.Tests.Unit.Assert_.Fixture
                 XmlAttribute[] attributes = Bogus.Random.Shuffle(
                     element.Attributes.OfType<XmlAttribute>()
                            .Where(a => a.NamespaceURI != "http://www.w3.org/2000/xmlns/")).ToArray();
-                
+
                 Assert.All(attributes, attr => element.RemoveAttribute(attr.Name));
 
                 foreach (XmlAttribute attr in attributes)


### PR DESCRIPTION
Since some components were added before we introduced `.editorconfig`, there were still some files left that violated - and so, halted us from using an automated - code style workflow.

This PR applies the current rules to the assert components.
Relates to #432 