### PR TITLE
chore(style): apply .editorconfig on storage components

### DIFF
--- a/src/Arcus.Testing.Storage.Cosmos/MongoDbConnection.cs
+++ b/src/Arcus.Testing.Storage.Cosmos/MongoDbConnection.cs
@@ -1,11 +1,11 @@
 ﻿using System.Collections.Generic;
-using System.Net.Http.Headers;
 using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Text.Json;
 using System.Threading.Tasks;
+using Azure;
 using Azure.Core;
 using Azure.Identity;
-using Azure;
 using Microsoft.Extensions.Logging;
 using MongoDB.Driver;
 
@@ -40,10 +40,10 @@ namespace Arcus.Testing
         }
 
         private static async Task<string> RequestConnectionStringsAsync(
-            ResourceIdentifier cosmosDbResourceId, 
-            string databaseName, 
-            string collectionName, 
-            AccessToken accessToken, 
+            ResourceIdentifier cosmosDbResourceId,
+            string databaseName,
+            string collectionName,
+            AccessToken accessToken,
             ILogger logger)
         {
             var listConnectionStringUrl = $"https://management.azure.com/{cosmosDbResourceId}/listConnectionStrings?api-version=2021-04-15";
@@ -51,10 +51,10 @@ namespace Arcus.Testing
 
             using var request = new HttpRequestMessage(HttpMethod.Post, listConnectionStringUrl);
             request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken.Token);
-            
+
             using HttpResponseMessage response = await HttpClient.SendAsync(request);
             string responseBody = await response.Content.ReadAsStringAsync();
-            
+
             if (!response.IsSuccessStatusCode)
             {
                 throw new RequestFailedException(

--- a/src/Arcus.Testing.Tests.Integration/Storage/TemporaryBlobContainerTests.cs
+++ b/src/Arcus.Testing.Tests.Integration/Storage/TemporaryBlobContainerTests.cs
@@ -3,7 +3,6 @@ using System.Threading.Tasks;
 using Arcus.Testing.Tests.Integration.Storage.Fixture;
 using Azure.Storage.Blobs;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Arcus.Testing.Tests.Integration.Storage
 {

--- a/src/Arcus.Testing.Tests.Integration/Storage/TemporaryShareDirectoryTests.cs
+++ b/src/Arcus.Testing.Tests.Integration/Storage/TemporaryShareDirectoryTests.cs
@@ -10,7 +10,6 @@ using Bogus;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
-using Xunit.Abstractions;
 using DirClient = Azure.Storage.Files.Shares.ShareDirectoryClient;
 using FileClient = Azure.Storage.Files.Shares.ShareFileClient;
 

--- a/src/Arcus.Testing.Tests.Integration/Storage/TemporaryShareFileTests.cs
+++ b/src/Arcus.Testing.Tests.Integration/Storage/TemporaryShareFileTests.cs
@@ -4,7 +4,6 @@ using System.Text;
 using System.Threading.Tasks;
 using Azure.Storage.Files.Shares;
 using Xunit;
-using Xunit.Abstractions;
 using DirClient = Azure.Storage.Files.Shares.ShareDirectoryClient;
 using FileClient = Azure.Storage.Files.Shares.ShareFileClient;
 


### PR DESCRIPTION
Since some components were added before we introduced `.editorconfig`, there were still some files left that violated - and so, halted us from using an automated - code style workflow.

This PR applies the current rules to the storage components.
Relates to #432 