### PR TITLE
chore(analysis): applied code analysis results in files

### DIFF
--- a/src/Arcus.Testing.Storage.File.Share/Arcus.Testing.Storage.File.Share.csproj
+++ b/src/Arcus.Testing.Storage.File.Share/Arcus.Testing.Storage.File.Share.csproj
@@ -19,6 +19,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsNotAsErrors>$(WarningsNotAsErrors);NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>
+    <AnalysisMode>Recommended</AnalysisMode>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Applies the recommended code analysis rules for Roslyn analyzers in the `.File.Share` library. This is mostly about placing the log message templates in 'source generated message templates'. Mostly marketed as being 'more performant', but in our case it also helps with maintaining/centralizing log message templates (setup/teardown format).

Partially related to #429 