### PR TITLE
chore(analysis): applied code analysis results in data factory

### DIFF
--- a/src/Arcus.Testing.Integration.DataFactory/Arcus.Testing.Integration.DataFactory.csproj
+++ b/src/Arcus.Testing.Integration.DataFactory/Arcus.Testing.Integration.DataFactory.csproj
@@ -19,6 +19,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsNotAsErrors>$(WarningsNotAsErrors);NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>
+    <AnalysisMode>Recommended</AnalysisMode>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Arcus.Testing.Integration.DataFactory/DataFlowRunResult.cs
+++ b/src/Arcus.Testing.Integration.DataFactory/DataFlowRunResult.cs
@@ -529,7 +529,7 @@ namespace Arcus.Testing
             /// <summary>
             /// Loads the raw <paramref name="headerNames"/> and <paramref name="rows"/> to a validly parsed <see cref="CsvTable"/>.
             /// </summary>
-            internal static CsvTable Load(
+            internal static DataFlowPreviewCsvTable Load(
                 IEnumerable<string> headerNames,
                 IEnumerable<IEnumerable<string>> rows,
                 AssertCsvOptions options)

--- a/src/Arcus.Testing.Integration.DataFactory/DataFlowRunResult.cs
+++ b/src/Arcus.Testing.Integration.DataFactory/DataFlowRunResult.cs
@@ -106,7 +106,7 @@ namespace Arcus.Testing
         {
             if (!outputObj.TryGetPropertyValue("schema", out JsonNode headersNode)
                 || headersNode is not JsonValue header
-                || !header.ToString().StartsWith("output"))
+                || !header.ToString().StartsWith("output", StringComparison.InvariantCulture))
             {
                 throw new JsonException(
                     $"[Test] Cannot load the content of the Azure Data Factory preview expression as the headers are not available in the 'output.schema' node: {outputObj}, " +
@@ -417,7 +417,7 @@ namespace Arcus.Testing
         {
             if (!outputObj.TryGetPropertyValue("schema", out JsonNode headersNode)
                 || headersNode is not JsonValue headersValue
-                || !headersValue.ToString().StartsWith("output"))
+                || !headersValue.ToString().StartsWith("output", StringComparison.InvariantCulture))
             {
                 throw new CsvException(
                     $"[Test] Cannot load the content of the Azure Data Factory preview expression as the headers are not available in the 'output.schema' node: {outputObj}, " +

--- a/src/Arcus.Testing.Integration.DataFactory/DataFlowRunResult.cs
+++ b/src/Arcus.Testing.Integration.DataFactory/DataFlowRunResult.cs
@@ -527,7 +527,7 @@ namespace Arcus.Testing
             }
 
             /// <summary>
-            /// Loads the raw <paramref name="headerNames"/> and <paramref name="rows"/> to a validly parsed <see cref="CsvTable"/>.
+            /// Loads the raw <paramref name="headerNames"/> and <paramref name="rows"/> to a validly parsed <see cref="DataFlowPreviewCsvTable"/>.
             /// </summary>
             internal static DataFlowPreviewCsvTable Load(
                 IEnumerable<string> headerNames,


### PR DESCRIPTION
Applies the recommended code analysis rules for Roslyn analyzers in the `.DataFactory` library. This is mostly about placing the log message templates in 'source generated message templates'. Mostly marketed as being 'more performant', but in our case it also helps with maintaining/centralizing log message templates (setup/teardown format).

Partially related to #429 