### PR TITLE
chore(analysis): applied code analysis results in logging

### DIFF
--- a/src/Arcus.Testing.Logging.MSTest/Arcus.Testing.Logging.MSTest.csproj
+++ b/src/Arcus.Testing.Logging.MSTest/Arcus.Testing.Logging.MSTest.csproj
@@ -19,6 +19,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsNotAsErrors>$(WarningsNotAsErrors);NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>
+    <AnalysisMode>Recommended</AnalysisMode>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Arcus.Testing.Logging.MSTest/Extensions/ILoggerBuilderExtensions.cs
+++ b/src/Arcus.Testing.Logging.MSTest/Extensions/ILoggerBuilderExtensions.cs
@@ -27,14 +27,9 @@ namespace Microsoft.Extensions.Logging
         }
 
         [ProviderAlias("MSTest")]
-        private sealed class MSTestLoggerProvider : ILoggerProvider
+        private sealed class MSTestLoggerProvider(TestContext context) : ILoggerProvider
         {
-            private readonly ILogger _logger;
-
-            public MSTestLoggerProvider(TestContext context)
-            {
-                _logger = new MSTestLogger(context);
-            }
+            private readonly ILogger _logger = new MSTestLogger(context);
 
             public ILogger CreateLogger(string categoryName)
             {

--- a/src/Arcus.Testing.Logging.MSTest/MSTestLogger.cs
+++ b/src/Arcus.Testing.Logging.MSTest/MSTestLogger.cs
@@ -29,7 +29,7 @@ namespace Arcus.Testing
         /// <param name="eventId">Id of the event.</param>
         /// <param name="state">The entry to be written. Can be also an object.</param>
         /// <param name="exception">The exception related to this entry.</param>
-        /// <param name="formatter">Function to create a <see cref="T:System.String" /> message of the <paramref name="state" /> and <paramref name="exception" />.</param>
+        /// <param name="formatter">Function to create a <see cref="String" /> message of the <paramref name="state" /> and <paramref name="exception" />.</param>
         /// <typeparam name="TState">The type of the object to be written.</typeparam>
         public void Log<TState>(
             LogLevel logLevel,
@@ -64,7 +64,7 @@ namespace Arcus.Testing
         /// </summary>
         /// <param name="state">The identifier for the scope.</param>
         /// <typeparam name="TState">The type of the state to begin scope for.</typeparam>
-        /// <returns>An <see cref="T:System.IDisposable" /> that ends the logical operation scope on dispose.</returns>
+        /// <returns>An <see cref="IDisposable" /> that ends the logical operation scope on dispose.</returns>
         public IDisposable BeginScope<TState>(TState state)
         {
             return null;

--- a/src/Arcus.Testing.Logging.NUnit/Arcus.Testing.Logging.NUnit.csproj
+++ b/src/Arcus.Testing.Logging.NUnit/Arcus.Testing.Logging.NUnit.csproj
@@ -19,6 +19,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsNotAsErrors>$(WarningsNotAsErrors);NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>
+    <AnalysisMode>Recommended</AnalysisMode>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Arcus.Testing.Logging.NUnit/Extensions/ILoggerBuilderExtensions.cs
+++ b/src/Arcus.Testing.Logging.NUnit/Extensions/ILoggerBuilderExtensions.cs
@@ -47,18 +47,11 @@ namespace Microsoft.Extensions.Logging
         }
 
         [ProviderAlias("NUnit")]
-        private sealed class NUnitLoggerProvider : ILoggerProvider
+        private sealed class NUnitLoggerProvider(NUnitTestLogger logger) : ILoggerProvider
         {
-            private readonly NUnitTestLogger _logger;
-
-            public NUnitLoggerProvider(NUnitTestLogger logger)
-            {
-                _logger = logger;
-            }
-
             public ILogger CreateLogger(string categoryName)
             {
-                return _logger;
+                return logger;
             }
 
             public void Dispose()

--- a/src/Arcus.Testing.Logging.NUnit/NUnitTestLogger.cs
+++ b/src/Arcus.Testing.Logging.NUnit/NUnitTestLogger.cs
@@ -91,7 +91,7 @@ namespace Arcus.Testing
         /// </summary>
         /// <param name="state">The identifier for the scope.</param>
         /// <typeparam name="TState">The type of the state to begin scope for.</typeparam>
-        /// <returns>An <see cref="T:System.IDisposable" /> that ends the logical operation scope on dispose.</returns>
+        /// <returns>An <see cref="IDisposable" /> that ends the logical operation scope on dispose.</returns>
         public IDisposable BeginScope<TState>(TState state)
         {
             return null;

--- a/src/Arcus.Testing.Logging.Xunit.v3/Arcus.Testing.Logging.Xunit.v3.csproj
+++ b/src/Arcus.Testing.Logging.Xunit.v3/Arcus.Testing.Logging.Xunit.v3.csproj
@@ -19,6 +19,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsNotAsErrors>$(WarningsNotAsErrors);NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>
+    <AnalysisMode>Recommended</AnalysisMode>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Arcus.Testing.Logging.Xunit.v3/Extensions/ILoggerBuilderExtensions.cs
+++ b/src/Arcus.Testing.Logging.Xunit.v3/Extensions/ILoggerBuilderExtensions.cs
@@ -26,14 +26,9 @@ namespace Microsoft.Extensions.Logging
         }
 
         [ProviderAlias("Xunit")]
-        private sealed class XunitLoggerProvider : ILoggerProvider
+        private sealed class XunitLoggerProvider(ITestOutputHelper outputWriter) : ILoggerProvider
         {
-            private readonly ILogger _logger;
-
-            internal XunitLoggerProvider(ITestOutputHelper outputWriter)
-            {
-                _logger = new XunitTestLogger(outputWriter);
-            }
+            private readonly ILogger _logger = new XunitTestLogger(outputWriter);
 
             /// <summary>
             /// Creates a new <see cref="ILogger" /> instance.

--- a/src/Arcus.Testing.Logging.Xunit.v3/XunitTestLogger.cs
+++ b/src/Arcus.Testing.Logging.Xunit.v3/XunitTestLogger.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using System.Text;
 using Microsoft.Extensions.Logging;
 using Xunit;
@@ -37,11 +38,11 @@ namespace Arcus.Testing
             string message = formatter(state, exception);
 
             var builder = new StringBuilder();
-            builder.Append($"{DateTimeOffset.UtcNow:s} {logLevel} > {message}");
+            builder.Append(CultureInfo.InvariantCulture, $"{DateTimeOffset.UtcNow:s} {logLevel} > {message}");
 
             if (exception is not null)
             {
-                builder.Append($": {exception}");
+                builder.Append(CultureInfo.InvariantCulture, $": {exception}");
             }
 
             _outputWriter.WriteLine(builder.ToString());

--- a/src/Arcus.Testing.Logging.Xunit/Arcus.Testing.Logging.Xunit.csproj
+++ b/src/Arcus.Testing.Logging.Xunit/Arcus.Testing.Logging.Xunit.csproj
@@ -19,6 +19,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsNotAsErrors>$(WarningsNotAsErrors);NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>
+    <AnalysisMode>Recommended</AnalysisMode>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Arcus.Testing.Logging.Xunit/Extensions/ILoggerBuilderExtensions.cs
+++ b/src/Arcus.Testing.Logging.Xunit/Extensions/ILoggerBuilderExtensions.cs
@@ -27,14 +27,9 @@ namespace Microsoft.Extensions.Logging
         }
 
         [ProviderAlias("Xunit")]
-        private sealed class XunitLoggerProvider : ILoggerProvider
+        private sealed class XunitLoggerProvider(ITestOutputHelper outputWriter) : ILoggerProvider
         {
-            private readonly ILogger _logger;
-
-            public XunitLoggerProvider(ITestOutputHelper outputWriter)
-            {
-                _logger = new XunitTestLogger(outputWriter);
-            }
+            private readonly ILogger _logger = new XunitTestLogger(outputWriter);
 
             public ILogger CreateLogger(string categoryName)
             {


### PR DESCRIPTION
Applies the recommended code analysis rules for Roslyn analyzers in the `.Logging.*` libraries. This is mostly about placing the log message templates in 'source generated message templates'. Mostly marketed as being 'more performant', but in our case it also helps with maintaining/centralizing log message templates (setup/teardown format).

Partially related to #429 