### PR TITLE
chore(analysis): applied code analysis results in service bus

### DIFF
--- a/src/Arcus.Testing.Messaging.ServiceBus/Arcus.Testing.Messaging.ServiceBus.csproj
+++ b/src/Arcus.Testing.Messaging.ServiceBus/Arcus.Testing.Messaging.ServiceBus.csproj
@@ -19,6 +19,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsNotAsErrors>$(WarningsNotAsErrors);NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>
+    <AnalysisMode>Recommended</AnalysisMode>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Arcus.Testing.Messaging.ServiceBus/ServiceBusMessageFilter.cs
+++ b/src/Arcus.Testing.Messaging.ServiceBus/ServiceBusMessageFilter.cs
@@ -84,9 +84,9 @@ namespace Arcus.Testing
         /// <remarks>
         ///     Deferred messages are also included as messages are peeked.
         /// </remarks>
-        public async Task<bool> AnyAsync()
+        public Task<bool> AnyAsync()
         {
-            return await AnyAsync(CancellationToken.None);
+            return AnyAsync(CancellationToken.None);
         }
 
         /// <summary>
@@ -101,7 +101,7 @@ namespace Arcus.Testing
         public async Task<bool> AnyAsync(CancellationToken cancellationToken)
         {
             List<ServiceBusReceivedMessage> messages = await ToListAsync(cancellationToken);
-            return messages.Any();
+            return messages.Count > 0;
         }
 
         /// <summary>
@@ -118,9 +118,9 @@ namespace Arcus.Testing
         /// <remarks>
         ///     Deferred messages are also included as messages are peeked.
         /// </remarks>
-        public async Task<List<ServiceBusReceivedMessage>> ToListAsync()
+        public Task<List<ServiceBusReceivedMessage>> ToListAsync()
         {
-            return await ToListAsync(CancellationToken.None);
+            return ToListAsync(CancellationToken.None);
         }
 
         /// <summary>


### PR DESCRIPTION
Applies the recommended code analysis rules for Roslyn analyzers in the `.ServiceBus` library. This is mostly about placing the log message templates in 'source generated message templates'. Mostly marketed as being 'more performant', but in our case it also helps with maintaining/centralizing log message templates (setup/teardown format).

Partially related to #429 