### PR TITLE
chore(blob): use configureawait(false) in blob test fixtures

### DIFF
--- a/src/Arcus.Testing.Storage.Blob/Arcus.Testing.Storage.Blob.csproj
+++ b/src/Arcus.Testing.Storage.Blob/Arcus.Testing.Storage.Blob.csproj
@@ -19,7 +19,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsNotAsErrors>$(WarningsNotAsErrors);NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>
-    <AnalysisMode>Recommended</AnalysisMode>
+    <AnalysisMode>All</AnalysisMode>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Arcus.Testing.Storage.Blob/TemporaryBlobFile.cs
+++ b/src/Arcus.Testing.Storage.Blob/TemporaryBlobFile.cs
@@ -65,9 +65,9 @@ namespace Arcus.Testing
 #pragma warning disable S1133 // Will be removed in v3.0
         [Obsolete("Will be removed in v3.0, please use the " + nameof(UpsertFileAsync) + " instead which provides the exact same functionality")]
 #pragma warning restore S1133
-        public static async Task<TemporaryBlobFile> UploadIfNotExistsAsync(Uri blobContainerUri, string blobName, BinaryData blobContent, ILogger logger)
+        public static Task<TemporaryBlobFile> UploadIfNotExistsAsync(Uri blobContainerUri, string blobName, BinaryData blobContent, ILogger logger)
         {
-            return await UpsertFileAsync(blobContainerUri, blobName, blobContent, logger);
+            return UpsertFileAsync(blobContainerUri, blobName, blobContent, logger);
         }
 
         /// <summary>
@@ -80,9 +80,9 @@ namespace Arcus.Testing
 #pragma warning disable S1133 // Will be removed in v3.0
         [Obsolete("Will be removed in v3.0, please use the " + nameof(UpsertFileAsync) + " instead which provides the exact same functionality")]
 #pragma warning restore S1133
-        public static async Task<TemporaryBlobFile> UploadIfNotExistsAsync(BlobClient blobClient, BinaryData blobContent, ILogger logger)
+        public static Task<TemporaryBlobFile> UploadIfNotExistsAsync(BlobClient blobClient, BinaryData blobContent, ILogger logger)
         {
-            return await UpsertFileAsync(blobClient, blobContent, logger);
+            return UpsertFileAsync(blobClient, blobContent, logger);
         }
 
         /// <summary>
@@ -102,7 +102,7 @@ namespace Arcus.Testing
             ArgumentNullException.ThrowIfNull(blobContent);
             logger ??= NullLogger.Instance;
 
-            (bool createdByUs, BinaryData originalData) = await EnsureBlobContentCreatedAsync(blobClient, blobContent, logger);
+            (bool createdByUs, BinaryData originalData) = await EnsureBlobContentCreatedAsync(blobClient, blobContent, logger).ConfigureAwait(false);
 
             return new TemporaryBlobFile(blobClient, createdByUs, originalData, logger);
         }
@@ -123,7 +123,7 @@ namespace Arcus.Testing
         /// <param name="logger">The logger to write diagnostic messages during the upload process.</param>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="blobContainerUri"/> or the <paramref name="blobName"/> is blank.</exception>
         /// <exception cref="ArgumentNullException">Thrown when <paramref name="blobContainerUri"/> or the <paramref name="blobContent"/> is <c>null</c>.</exception>
-        public static async Task<TemporaryBlobFile> UpsertFileAsync(Uri blobContainerUri, string blobName, BinaryData blobContent, ILogger logger)
+        public static Task<TemporaryBlobFile> UpsertFileAsync(Uri blobContainerUri, string blobName, BinaryData blobContent, ILogger logger)
         {
             ArgumentNullException.ThrowIfNull(blobContainerUri);
             ArgumentException.ThrowIfNullOrWhiteSpace(blobName);
@@ -131,7 +131,7 @@ namespace Arcus.Testing
             var containerClient = new BlobContainerClient(blobContainerUri, new DefaultAzureCredential());
             BlobClient blobClient = containerClient.GetBlobClient(blobName);
 
-            return await UpsertFileAsync(blobClient, blobContent, logger);
+            return UpsertFileAsync(blobClient, blobContent, logger);
         }
 
         private static async Task<(bool createdByUs, BinaryData originalData)> EnsureBlobContentCreatedAsync(
@@ -139,18 +139,18 @@ namespace Arcus.Testing
             BinaryData newContent,
             ILogger logger)
         {
-            if (await client.ExistsAsync())
+            if (await client.ExistsAsync().ConfigureAwait(false))
             {
-                BlobDownloadResult originalContent = await client.DownloadContentAsync();
+                BlobDownloadResult originalContent = await client.DownloadContentAsync().ConfigureAwait(false);
 
                 logger.LogSetupReplaceFile(client.Name, client.AccountName, client.BlobContainerName);
-                await client.UploadAsync(newContent, overwrite: true);
+                await client.UploadAsync(newContent, overwrite: true).ConfigureAwait(false);
 
                 return (createdByUs: false, originalContent.Content);
             }
 
             logger.LogSetupUploadNewFile(client.Name, client.AccountName, client.BlobContainerName);
-            await client.UploadAsync(newContent);
+            await client.UploadAsync(newContent).ConfigureAwait(false);
 
             return (createdByUs: true, originalData: null);
         }
@@ -164,12 +164,12 @@ namespace Arcus.Testing
             if (_createdByUs)
             {
                 _logger.LogTeardownDeleteFile(Client.Name, Client.AccountName, Client.BlobContainerName);
-                await Client.DeleteIfExistsAsync();
+                await Client.DeleteIfExistsAsync().ConfigureAwait(false);
             }
             else if (_originalData != null)
             {
                 _logger.LogTeardownRevertFile(Client.Name, Client.AccountName, Client.BlobContainerName);
-                await Client.UploadAsync(_originalData, overwrite: true);
+                await Client.UploadAsync(_originalData, overwrite: true).ConfigureAwait(false);
             }
 
             GC.SuppressFinalize(this);


### PR DESCRIPTION
This PR activates 'All' Roslyn code analysis suggestions for the Blob test fixtures, which one of them is the `.ConfigureAwait(false)` recommendation for `async` constructs. It also makes sure that only necessary `async` constructs are `await`ed, and argument checkings are done synchronously.

Relates to #429 
Relates to #430