### PR TITLE
chore(df): apply df roslyn async analyzer suggestions

### DIFF
--- a/src/Arcus.Testing.Integration.DataFactory/Arcus.Testing.Integration.DataFactory.csproj
+++ b/src/Arcus.Testing.Integration.DataFactory/Arcus.Testing.Integration.DataFactory.csproj
@@ -19,7 +19,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsNotAsErrors>$(WarningsNotAsErrors);NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>
-    <AnalysisMode>Recommended</AnalysisMode>
+    <AnalysisMode>All</AnalysisMode>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Arcus.Testing.Integration.DataFactory/DataFlowRunResult.cs
+++ b/src/Arcus.Testing.Integration.DataFactory/DataFlowRunResult.cs
@@ -117,11 +117,11 @@ namespace Arcus.Testing
             headersTxt = Regex.Replace(headersTxt, "^output\\(", string.Empty);
             headersTxt = headersTxt.Remove(headersTxt.Length - 1, 1);
             headersTxt =
-                headersTxt.Replace("\\n", "")
-                          .Replace(", ", ",")
-                          .Replace(" as string[]", " as string")
-                          .Replace("{", "")
-                          .Replace("}", "");
+                headersTxt.Replace("\\n", "", StringComparison.InvariantCulture)
+                          .Replace(", ", ",", StringComparison.InvariantCulture)
+                          .Replace(" as string[]", " as string", StringComparison.InvariantCulture)
+                          .Replace("{", "", StringComparison.InvariantCulture)
+                          .Replace("}", "", StringComparison.InvariantCulture);
 
             if (Regex.IsMatch(headersTxt, ",( )*,"))
             {
@@ -402,7 +402,7 @@ namespace Arcus.Testing
                     $"consider parsing the raw run data yourself as this parsing only supports limited structures");
             }
 
-            JsonNode outputNode = JsonNode.Parse(outputJson.Replace("\n", ""));
+            JsonNode outputNode = JsonNode.Parse(outputJson.Replace("\n", "", StringComparison.InvariantCulture));
             if (outputNode is not JsonObject outputObj)
             {
                 throw new CsvException(
@@ -485,7 +485,7 @@ namespace Arcus.Testing
 
             string AsCsvCell(string value)
             {
-                return value.Replace("\\,", ",");
+                return value.Replace("\\,", ",", StringComparison.InvariantCulture);
             }
 
             if (dataArr.All(n => n is JsonArray arr && arr.All(elem => elem is JsonValue)))

--- a/src/Arcus.Testing.Integration.DataFactory/TemporaryDataFlowDebugSession.cs
+++ b/src/Arcus.Testing.Integration.DataFactory/TemporaryDataFlowDebugSession.cs
@@ -90,7 +90,7 @@ namespace Arcus.Testing
         {
             get
             {
-                ObjectDisposedException.ThrowIf(_isDisposed, typeof(TemporaryDataFlowDebugSession));
+                ObjectDisposedException.ThrowIf(_isDisposed, this);
                 return _sessionId;
             }
         }
@@ -273,7 +273,7 @@ namespace Arcus.Testing
             string targetSinkName,
             Action<RunDataFlowOptions> configureOptions)
         {
-            ObjectDisposedException.ThrowIf(_isDisposed, typeof(TemporaryDataFlowDebugSession));
+            ObjectDisposedException.ThrowIf(_isDisposed, this);
             ArgumentException.ThrowIfNullOrWhiteSpace(dataFlowName);
             ArgumentException.ThrowIfNullOrWhiteSpace(targetSinkName);
 

--- a/src/Arcus.Testing.Integration.DataFactory/TemporaryDataFlowDebugSession.cs
+++ b/src/Arcus.Testing.Integration.DataFactory/TemporaryDataFlowDebugSession.cs
@@ -266,7 +266,6 @@ namespace Arcus.Testing
             Action<RunDataFlowOptions> configureOptions)
         {
             ObjectDisposedException.ThrowIf(_isDisposed, typeof(TemporaryDataFlowDebugSession));
-
             ArgumentException.ThrowIfNullOrWhiteSpace(dataFlowName);
             ArgumentException.ThrowIfNullOrWhiteSpace(targetSinkName);
 

--- a/src/Arcus.Testing.Integration.DataFactory/TemporaryDataFlowDebugSession.cs
+++ b/src/Arcus.Testing.Integration.DataFactory/TemporaryDataFlowDebugSession.cs
@@ -265,10 +265,7 @@ namespace Arcus.Testing
             string targetSinkName,
             Action<RunDataFlowOptions> configureOptions)
         {
-            if (_isDisposed)
-            {
-                throw new ObjectDisposedException(nameof(TemporaryDataFlowDebugSession), "[Test:Teardown] cannot run data flow in a disposed Azure Data Factory debug session");
-            }
+            ObjectDisposedException.ThrowIf(_isDisposed, typeof(TemporaryDataFlowDebugSession));
 
             ArgumentException.ThrowIfNullOrWhiteSpace(dataFlowName);
             ArgumentException.ThrowIfNullOrWhiteSpace(targetSinkName);

--- a/src/Arcus.Testing.Integration.DataFactory/TemporaryDataFlowDebugSession.cs
+++ b/src/Arcus.Testing.Integration.DataFactory/TemporaryDataFlowDebugSession.cs
@@ -447,14 +447,13 @@ namespace Arcus.Testing
                 return;
             }
 
-            _isDisposed = true;
-
             if (_startedByUs)
             {
                 _logger.LogTeardownStopSession(DataFactory.Id.Name, _sessionId);
                 await DataFactory.DeleteDataFlowDebugSessionAsync(new DeleteDataFlowDebugSessionContent { SessionId = _sessionId }).ConfigureAwait(false);
             }
 
+            _isDisposed = true;
             GC.SuppressFinalize(this);
         }
     }

--- a/src/Arcus.Testing.Integration.DataFactory/TemporaryDataFlowDebugSession.cs
+++ b/src/Arcus.Testing.Integration.DataFactory/TemporaryDataFlowDebugSession.cs
@@ -85,9 +85,15 @@ namespace Arcus.Testing
         /// <summary>
         /// Gets the session ID of the active data flow debug session.
         /// </summary>
-        public Guid SessionId => _isDisposed
-            ? throw new ObjectDisposedException(nameof(TemporaryDataFlowDebugSession), "[Test:Teardown] cannot access Azure Data Factory debug session after it has been disposed")
-            : _sessionId;
+        /// <exception cref="ObjectDisposedException">Thrown when the test fixture was already teared down.</exception>
+        public Guid SessionId
+        {
+            get
+            {
+                ObjectDisposedException.ThrowIf(_isDisposed, typeof(TemporaryDataFlowDebugSession));
+                return _sessionId;
+            }
+        }
 
         /// <summary>
         /// Starts a new active Azure Data Factory data flow debug session for the given <paramref name="dataFactoryResourceId"/>.

--- a/src/Arcus.Testing.Integration.DataFactory/TemporaryDataFlowDebugSession.cs
+++ b/src/Arcus.Testing.Integration.DataFactory/TemporaryDataFlowDebugSession.cs
@@ -247,6 +247,7 @@ namespace Arcus.Testing
         /// <param name="dataFlowName">The name of the data flow to start.</param>
         /// <param name="targetSinkName">The name of the target sink to get the result from.</param>
         /// <returns>The final result of the data flow run.</returns>
+        /// <exception cref="ObjectDisposedException">Thrown when the test fixture was already teared down.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="dataFlowName"/> or <paramref name="targetSinkName"/> is blank.</exception>
         /// <exception cref="InvalidOperationException">Thrown when the data flow execution did not result in a successful status.</exception>
         /// <exception cref="RequestFailedException">Thrown when one or more interactions with the Azure DataFactory resource failed.</exception>
@@ -263,6 +264,7 @@ namespace Arcus.Testing
         /// <param name="targetSinkName">The name of the target sink to get the result from.</param>
         /// <param name="configureOptions">The function to configure the options of the data flow run.</param>
         /// <returns>The final result of the data flow run.</returns>
+        /// <exception cref="ObjectDisposedException">Thrown when the test fixture was already teared down.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="dataFlowName"/> or <paramref name="targetSinkName"/> is blank.</exception>
         /// <exception cref="InvalidOperationException">Thrown when the data flow execution did not result in a successful status.</exception>
         /// <exception cref="RequestFailedException">Thrown when one or more interactions with the Azure DataFactory resource failed.</exception>

--- a/src/Arcus.Testing.Tests.Integration/Integration/DataFactory/RunDataFlowTests.cs
+++ b/src/Arcus.Testing.Tests.Integration/Integration/DataFactory/RunDataFlowTests.cs
@@ -8,6 +8,7 @@ using Arcus.Testing.Tests.Core.Assert_.Fixture;
 using Arcus.Testing.Tests.Core.Integration.DataFactory;
 using Arcus.Testing.Tests.Integration.Fixture;
 using Arcus.Testing.Tests.Integration.Integration.DataFactory.Fixture;
+using Azure.Core;
 using Azure.Identity;
 using Azure.ResourceManager;
 using Azure.ResourceManager.DataFactory;
@@ -316,20 +317,20 @@ namespace Arcus.Testing.Tests.Integration.Integration.DataFactory
 
         public async Task ShouldFindActiveSessionAsync(Guid sessionId)
         {
-            bool isActive = await IsDebugSessionActiveAsync(sessionId);
+            bool isActive = await IsDebugSessionActiveAsync(DataFactory.ResourceId, sessionId);
             Assert.True(isActive, $"expected to have an active debug session in DataFactory '{DataFactory.Name}' for session ID: '{sessionId}', but got none");
         }
 
         public async Task ShouldNotFindActiveSessionAsync(Guid sessionId)
         {
-            bool isActive = await IsDebugSessionActiveAsync(sessionId);
+            bool isActive = await IsDebugSessionActiveAsync(DataFactory.ResourceId, sessionId);
             Assert.False(isActive, $"expected to remove active debug session '{sessionId}' in DataFactory '{DataFactory.Name}', but it's still active");
         }
 
-        private async Task<bool> IsDebugSessionActiveAsync(Guid sessionId)
+        public static async Task<bool> IsDebugSessionActiveAsync(ResourceIdentifier resourceId, Guid sessionId)
         {
             var armClient = new ArmClient(new DefaultAzureCredential());
-            DataFactoryResource resource = armClient.GetDataFactoryResource(DataFactory.ResourceId);
+            DataFactoryResource resource = armClient.GetDataFactoryResource(resourceId);
 
             var isActive = false;
             await foreach (DataFlowDebugSessionInfo session in resource.GetDataFlowDebugSessionsAsync())


### PR DESCRIPTION
This PR applies several .NET and Roslyn recommendations in the Data Factory project:
* Use `.ConfigureAwait(false)` for asynchronous operations;
* Make multiple `.Dispose(Async)` calls redundant.

Relates #429 