### PR TITLE
chore(fileshare): apply roslyn code analyzer suggestions

### DIFF
--- a/src/Arcus.Testing.Core/DisposableCollection.cs
+++ b/src/Arcus.Testing.Core/DisposableCollection.cs
@@ -54,6 +54,7 @@ namespace Arcus.Testing
     public sealed class DisposableCollection : IAsyncDisposable, IReadOnlyCollection<IAsyncDisposable>
     {
         private readonly Collection<IAsyncDisposable> _disposables = [];
+        private readonly DisposeOptions _options = new();
         private readonly ILogger _logger;
 
         /// <summary>
@@ -66,23 +67,47 @@ namespace Arcus.Testing
         }
 
         /// <summary>
+        /// Gets the boolean flag to indicate whether the collection was already teared down.
+        /// Useful to determine in a test fixture as a condition for throwing <see cref="ObjectDisposedException"/> exceptions.
+        /// </summary>
+        public bool IsDisposed { get; private set; }
+
+        /// <summary>
         /// Gets the available options to manipulate the dispose behavior of the collection.
         /// </summary>
-        public DisposeOptions Options { get; } = new();
+        /// <exception cref="ObjectDisposedException">Thrown when the test fixture was already teared down.</exception>
+        public DisposeOptions Options
+        {
+            get
+            {
+                ObjectDisposedException.ThrowIf(IsDisposed, this);
+                return _options;
+            }
+        }
 
         /// <summary>
         /// Gets the number of disposable elements in the collection.
         /// </summary>
         /// <returns>The number of disposable elements in the collection.</returns>
-        public int Count => _disposables.Count;
+        /// <exception cref="ObjectDisposedException">Thrown when the test fixture was already teared down.</exception>
+        public int Count
+        {
+            get
+            {
+                ObjectDisposedException.ThrowIf(IsDisposed, this);
+                return _disposables.Count;
+            }
+        }
 
         /// <summary>
         /// Adds a <paramref name="disposable"/> to this collection which will get disposed when this collection gets disposed.
         /// </summary>
         /// <param name="disposable">The disposable instance to add to the collection.</param>
+        /// <exception cref="ObjectDisposedException">Thrown when the test fixture was already teared down.</exception>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="disposable"/> is <c>null</c>.</exception>
         public void Add(IAsyncDisposable disposable)
         {
+            ObjectDisposedException.ThrowIf(IsDisposed, this);
             ArgumentNullException.ThrowIfNull(disposable);
             _disposables.Add(disposable);
         }
@@ -91,9 +116,11 @@ namespace Arcus.Testing
         /// Adds a <paramref name="disposable"/> to this collection which will get disposed when this collection gets disposed.
         /// </summary>
         /// <param name="disposable">The disposable instance to add to the collection.</param>
+        /// <exception cref="ObjectDisposedException">Thrown when the test fixture was already teared down.</exception>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="disposable"/> is <c>null</c>.</exception>
         public void Add(IDisposable disposable)
         {
+            ObjectDisposedException.ThrowIf(IsDisposed, this);
             ArgumentNullException.ThrowIfNull(disposable);
             Add(AsyncDisposable.Create(disposable));
         }
@@ -102,9 +129,11 @@ namespace Arcus.Testing
         /// Adds a range of <paramref name="disposables"/> to this collection which will get disposed when this collection gets disposed.
         /// </summary>
         /// <param name="disposables">The disposable instances to add to the collection.</param>
+        /// <exception cref="ObjectDisposedException">Thrown when the test fixture was already teared down.</exception>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="disposables"/> or any of its elements are <c>null</c>.</exception>
         public void AddRange(IEnumerable<IAsyncDisposable> disposables)
         {
+            ObjectDisposedException.ThrowIf(IsDisposed, this);
             ArgumentNullException.ThrowIfNull(disposables);
 
             foreach (IAsyncDisposable disposable in disposables)
@@ -117,9 +146,11 @@ namespace Arcus.Testing
         /// Adds a range of <paramref name="disposables"/> to this collection which will get disposed when this collection gets disposed.
         /// </summary>
         /// <param name="disposables">The disposable instances to add to the collection.</param>
+        /// <exception cref="ObjectDisposedException">Thrown when the test fixture was already teared down.</exception>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="disposables"/> or any of its elements are <c>null</c>.</exception>
         public void AddRange(IEnumerable<IDisposable> disposables)
         {
+            ObjectDisposedException.ThrowIf(IsDisposed, this);
             ArgumentNullException.ThrowIfNull(disposables);
 
             foreach (IDisposable disposable in disposables)
@@ -132,8 +163,10 @@ namespace Arcus.Testing
         /// Returns an enumerator that iterates through the collection.
         /// </summary>
         /// <returns>An enumerator that can be used to iterate through the collection.</returns>
+        /// <exception cref="ObjectDisposedException">Thrown when the test fixture was already teared down.</exception>
         public IEnumerator<IAsyncDisposable> GetEnumerator()
         {
+            ObjectDisposedException.ThrowIf(IsDisposed, this);
             return _disposables.GetEnumerator();
         }
 
@@ -141,8 +174,10 @@ namespace Arcus.Testing
         /// Returns an enumerator that iterates through a collection.
         /// </summary>
         /// <returns>An <see cref="IEnumerator" /> object that can be used to iterate through the collection.</returns>
+        /// <exception cref="ObjectDisposedException">Thrown when the test fixture was already teared down.</exception>
         IEnumerator IEnumerable.GetEnumerator()
         {
+            ObjectDisposedException.ThrowIf(IsDisposed, this);
             return GetEnumerator();
         }
 
@@ -152,13 +187,20 @@ namespace Arcus.Testing
         /// <returns>A task that represents the asynchronous dispose operation.</returns>
         public async ValueTask DisposeAsync()
         {
+            if (IsDisposed)
+            {
+                return;
+            }
+
+            IsDisposed = true;
+
             AsyncRetryPolicy policy =
                 Policy.Handle<Exception>(ex =>
                       {
-                          _logger.LogTearDownError(ex, ex.Message, Options.RetryInterval);
+                          _logger.LogTearDownError(ex, ex.Message, _options.RetryInterval);
                           return true;
                       })
-                      .WaitAndRetryAsync(Options.RetryCount, _ => Options.RetryInterval);
+                      .WaitAndRetryAsync(_options.RetryCount, _ => _options.RetryInterval);
 
             var exceptions = new Collection<Exception>();
             foreach (IAsyncDisposable fixture in _disposables)

--- a/src/Arcus.Testing.Core/DisposableCollection.cs
+++ b/src/Arcus.Testing.Core/DisposableCollection.cs
@@ -192,8 +192,6 @@ namespace Arcus.Testing
                 return;
             }
 
-            IsDisposed = true;
-
             AsyncRetryPolicy policy =
                 Policy.Handle<Exception>(ex =>
                       {
@@ -230,6 +228,8 @@ namespace Arcus.Testing
                     "[Test:Teardown] Some test fixtures failed to tear down correctly, please check the collected exceptions for more information",
                     exceptions);
             }
+
+            IsDisposed = true;
         }
     }
 

--- a/src/Arcus.Testing.Storage.File.Share/Arcus.Testing.Storage.File.Share.csproj
+++ b/src/Arcus.Testing.Storage.File.Share/Arcus.Testing.Storage.File.Share.csproj
@@ -19,7 +19,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsNotAsErrors>$(WarningsNotAsErrors);NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>
-    <AnalysisMode>Recommended</AnalysisMode>
+    <AnalysisMode>All</AnalysisMode>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Arcus.Testing.Storage.File.Share/TemporaryShareDirectory.cs
+++ b/src/Arcus.Testing.Storage.File.Share/TemporaryShareDirectory.cs
@@ -151,8 +151,10 @@ namespace Arcus.Testing
     public class TemporaryShareDirectory : IAsyncDisposable
     {
         private readonly bool _createdByUs;
+        private readonly ShareDirectoryClient _client;
         private readonly Collection<TemporaryShareFile> _files = [];
         private readonly TemporaryShareDirectoryOptions _options;
+        private readonly DisposableCollection _disposables;
         private readonly ILogger _logger;
 
         private TemporaryShareDirectory(
@@ -166,19 +168,36 @@ namespace Arcus.Testing
             _createdByUs = createdByUs;
             _options = options;
             _logger = logger ?? NullLogger.Instance;
+            _disposables = new DisposableCollection(_logger);
 
-            Client = client;
+            _client = client;
         }
 
         /// <summary>
         /// Represents the client to interact with the temporary stored Azure Files share currently in storage.
         /// </summary>
-        public ShareDirectoryClient Client { get; }
+        /// <exception cref="ObjectDisposedException">Thrown when the test fixture was already teared down.</exception>
+        public ShareDirectoryClient Client
+        {
+            get
+            {
+                ObjectDisposedException.ThrowIf(_disposables.IsDisposed, this);
+                return _client;
+            }
+        }
 
         /// <summary>
         /// Gets the options to manipulate the deletion of the <see cref="TemporaryShareDirectory"/>.
         /// </summary>
-        public OnTeardownTemporaryShareDirectoryOptions OnTeardown => _options.OnTeardown;
+        /// <exception cref="ObjectDisposedException">Thrown when the test fixture was already teared down.</exception>
+        public OnTeardownTemporaryShareDirectoryOptions OnTeardown
+        {
+            get
+            {
+                ObjectDisposedException.ThrowIf(_disposables.IsDisposed, this);
+                return _options.OnTeardown;
+            }
+        }
 
         /// <summary>
         /// Creates a temporary directory share on an Azure Files share resource.
@@ -244,10 +263,10 @@ namespace Arcus.Testing
             var options = new TemporaryShareDirectoryOptions();
             configureOptions?.Invoke(options);
 
-            if (await directoryClient.ExistsAsync())
+            if (await directoryClient.ExistsAsync().ConfigureAwait(false))
             {
                 logger.LogSetupUseExistingDirectory(directoryClient.Name, directoryClient.AccountName, directoryClient.Path);
-                await CleanDirectoryOnSetupAsync(directoryClient, options, logger);
+                await CleanDirectoryOnSetupAsync(directoryClient, options, logger).ConfigureAwait(false);
 
                 return new TemporaryShareDirectory(directoryClient, createdByUs: false, options, logger);
             }
@@ -255,7 +274,7 @@ namespace Arcus.Testing
             try
             {
                 logger.LogSetupCreateNewDirectory(directoryClient.Name, directoryClient.AccountName, directoryClient.Path);
-                await directoryClient.CreateAsync();
+                await directoryClient.CreateAsync().ConfigureAwait(false);
             }
             catch (RequestFailedException exception) when (exception.ErrorCode == ShareErrorCode.ShareNotFound)
             {
@@ -278,11 +297,11 @@ namespace Arcus.Testing
 
             if (options.OnSetup.Items is OnSetupDirectoryShare.CleanIfExisted)
             {
-                await DeleteAllDirectoryContentsAsync(directoryClient, TestFixture.Setup, logger);
+                await DeleteAllDirectoryContentsAsync(directoryClient, TestFixture.Setup, logger).ConfigureAwait(false);
             }
             else if (options.OnSetup.Items is OnSetupDirectoryShare.CleanIfMatched)
             {
-                await DeleteDirectoryContentsAsync(directoryClient, options.OnSetup.IsMatch, TestFixture.Setup, logger);
+                await DeleteDirectoryContentsAsync(directoryClient, options.OnSetup.IsMatch, TestFixture.Setup, logger).ConfigureAwait(false);
             }
         }
 
@@ -294,11 +313,13 @@ namespace Arcus.Testing
         /// </remarks>
         /// <param name="fileName">The name of the file to upload to the share directory.</param>
         /// <param name="fileContents">The contents of the file to upload to the share directory.</param>
+        /// <exception cref="ObjectDisposedException">Thrown when the test fixture was already teared down.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="fileName"/> is blank.</exception>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="fileContents"/> is <c>null</c>.</exception>
         public async Task UpsertFileAsync(string fileName, Stream fileContents)
         {
-            _files.Add(await TemporaryShareFile.UpsertFileAsync(Client, fileName, fileContents, _logger));
+            ObjectDisposedException.ThrowIf(_disposables.IsDisposed, this);
+            _files.Add(await TemporaryShareFile.UpsertFileAsync(Client, fileName, fileContents, _logger).ConfigureAwait(false));
         }
 
         /// <summary>
@@ -307,22 +328,29 @@ namespace Arcus.Testing
         /// <returns>A task that represents the asynchronous dispose operation.</returns>
         public async ValueTask DisposeAsync()
         {
-            await using var disposables = new DisposableCollection(_logger);
-            disposables.AddRange(_files);
-
-            if (_createdByUs)
+            if (_disposables.IsDisposed)
             {
-                await DeleteAllDirectoryContentsAsync(Client, TestFixture.Teardown, _logger);
-
-                disposables.Add(AsyncDisposable.Create(async () =>
-                {
-                    _logger.LogTeardownDeleteDirectory(Client.Name, Client.AccountName, Client.Path);
-                    await Client.DeleteAsync();
-                }));
+                return;
             }
-            else
+
+            await using (_disposables.ConfigureAwait(false))
             {
-                await CleanDirectoryOnTeardownAsync();
+                _disposables.AddRange(_files);
+
+                if (_createdByUs)
+                {
+                    await DeleteAllDirectoryContentsAsync(_client, TestFixture.Teardown, _logger).ConfigureAwait(false);
+
+                    _disposables.Add(AsyncDisposable.Create(async () =>
+                    {
+                        _logger.LogTeardownDeleteDirectory(_client.Name, _client.AccountName, _client.Path);
+                        await _client.DeleteAsync().ConfigureAwait(false);
+                    }));
+                }
+                else
+                {
+                    _disposables.Add(AsyncDisposable.Create(CleanDirectoryOnTeardownAsync));
+                }
             }
 
             GC.SuppressFinalize(this);
@@ -337,11 +365,11 @@ namespace Arcus.Testing
 
             if (_options.OnTeardown.Items is OnTeardownDirectoryShare.CleanAll)
             {
-                await DeleteAllDirectoryContentsAsync(Client, TestFixture.Teardown, _logger);
+                await DeleteAllDirectoryContentsAsync(_client, TestFixture.Teardown, _logger).ConfigureAwait(false);
             }
             else if (_options.OnTeardown.Items is OnTeardownDirectoryShare.CleanIfMatched)
             {
-                await DeleteDirectoryContentsAsync(Client, _options.OnTeardown.IsMatch, TestFixture.Teardown, _logger);
+                await DeleteDirectoryContentsAsync(_client, _options.OnTeardown.IsMatch, TestFixture.Teardown, _logger).ConfigureAwait(false);
             }
         }
 
@@ -353,38 +381,33 @@ namespace Arcus.Testing
             TestFixture state,
             ILogger logger)
         {
-            await using var disposables = new DisposableCollection(logger);
+            await current.ForceCloseAllHandlesAsync(recursive: true).ConfigureAwait(false);
 
-            disposables.Add(AsyncDisposable.Create(async () =>
+            await foreach (ShareFileItem item in current.GetFilesAndDirectoriesAsync().ConfigureAwait(false))
             {
-                await current.ForceCloseAllHandlesAsync(recursive: true);
-
-                await foreach (ShareFileItem item in current.GetFilesAndDirectoriesAsync())
+                if (item.IsDirectory)
                 {
-                    if (item.IsDirectory)
+                    ShareDirectoryClient sub = current.GetSubdirectoryClient(item.Name);
+                    if (shouldDeleteItem(item))
                     {
-                        ShareDirectoryClient sub = current.GetSubdirectoryClient(item.Name);
-                        if (shouldDeleteItem(item))
-                        {
-                            await DeleteAllDirectoryContentsAsync(sub, state, logger);
+                        await DeleteAllDirectoryContentsAsync(sub, state, logger).ConfigureAwait(false);
 
-                            LogDeleteDirectory(logger, state, sub.Name, sub.AccountName, sub.Path);
-                            await sub.DeleteIfExistsAsync();
-                        }
-                        else
-                        {
-                            await DeleteDirectoryContentsAsync(sub, shouldDeleteItem, state, logger);
-                        }
+                        LogDeleteDirectory(logger, state, sub.Name, sub.AccountName, sub.Path);
+                        await sub.DeleteIfExistsAsync().ConfigureAwait(false);
                     }
-                    else if (shouldDeleteItem(item))
+                    else
                     {
-                        ShareFileClient file = current.GetFileClient(item.Name);
-
-                        LogDeleteFile(logger, state, file.Name, file.AccountName, file.Path);
-                        await file.DeleteIfExistsAsync();
+                        await DeleteDirectoryContentsAsync(sub, shouldDeleteItem, state, logger).ConfigureAwait(false);
                     }
                 }
-            }));
+                else if (shouldDeleteItem(item))
+                {
+                    ShareFileClient file = current.GetFileClient(item.Name);
+
+                    LogDeleteFile(logger, state, file.Name, file.AccountName, file.Path);
+                    await file.DeleteIfExistsAsync().ConfigureAwait(false);
+                }
+            }
         }
 
         private static void LogDeleteDirectory(ILogger logger, TestFixture state, string directoryName, string accountName, string directoryPath)
@@ -417,7 +440,7 @@ namespace Arcus.Testing
 
         private static async Task DeleteAllDirectoryContentsAsync(ShareDirectoryClient current, TestFixture state, ILogger logger)
         {
-            await DeleteDirectoryContentsAsync(current, shouldDeleteItem: _ => true, state, logger);
+            await DeleteDirectoryContentsAsync(current, shouldDeleteItem: _ => true, state, logger).ConfigureAwait(false);
         }
     }
 

--- a/src/Arcus.Testing.Tests.Integration/Storage/TemporaryShareDirectoryTests.cs
+++ b/src/Arcus.Testing.Tests.Integration/Storage/TemporaryShareDirectoryTests.cs
@@ -168,10 +168,17 @@ namespace Arcus.Testing.Tests.Integration.Storage
             await temp.WhenFileFileUploadAsync(file);
             await share.WhenFileAvailableAsync(await share.WhenDirectoryAvailableAsync(temp.Client));
 
-            await temp.DisposeAsync();
+            await WhenTestFixtureTeardownAsync(temp);
 
             await share.ShouldNotHaveFilesAsync(file);
             await share.ShouldNotHaveDirectoriesAsync(dir);
+        }
+
+        private static async Task WhenTestFixtureTeardownAsync(TemporaryShareDirectory temp)
+        {
+            // Calling dispose multiple times should be redundant.
+            await temp.DisposeAsync();
+            await temp.DisposeAsync();
         }
 
         [Fact]

--- a/src/Arcus.Testing.Tests.Integration/Storage/TemporaryShareFileTests.cs
+++ b/src/Arcus.Testing.Tests.Integration/Storage/TemporaryShareFileTests.cs
@@ -58,10 +58,17 @@ namespace Arcus.Testing.Tests.Integration.Storage
             BinaryData actualBefore = await share.ShouldHaveFileAsync(file);
             AssertEqualContents(newContents, actualBefore);
 
-            await temp.DisposeAsync();
+            await WhenTestFixtureTeardownAsync(temp);
 
             BinaryData actualAfter = await share.ShouldHaveFileAsync(file);
             AssertEqualContents(originalContents, actualAfter);
+        }
+
+        private static async Task WhenTestFixtureTeardownAsync(TemporaryShareFile temp)
+        {
+            // Calling dispose multiple times should be redundant.
+            await temp.DisposeAsync();
+            await temp.DisposeAsync();
         }
 
         private static void AssertEqualContents(Stream expectedStream, BinaryData actual)


### PR DESCRIPTION
Applies the Roslyn and .NET recommendations regarding asynchronous operations and disposable objects:
* Use `.ConfigureAwait(false)` in asynchronous operations;

Relates to #429 