### PR TITLE
chore(core): make multiple dispose calls in test core redundant

### DIFF
--- a/src/Arcus.Testing.Core/AsyncDisposable.cs
+++ b/src/Arcus.Testing.Core/AsyncDisposable.cs
@@ -9,6 +9,7 @@ namespace Arcus.Testing
     public class AsyncDisposable : IAsyncDisposable
     {
         private readonly Func<Task> _disposeAsync;
+        private bool _isDisposed;
 
         private AsyncDisposable(Func<Task> disposeAsync)
         {
@@ -60,6 +61,13 @@ namespace Arcus.Testing
         /// <returns>A task that represents the asynchronous dispose operation.</returns>
         public async ValueTask DisposeAsync()
         {
+            if (_isDisposed)
+            {
+                return;
+            }
+
+            _isDisposed = true;
+
             await _disposeAsync().ConfigureAwait(false);
             GC.SuppressFinalize(this);
         }

--- a/src/Arcus.Testing.Core/TemporaryEnvironmentVariable.cs
+++ b/src/Arcus.Testing.Core/TemporaryEnvironmentVariable.cs
@@ -13,6 +13,8 @@ namespace Arcus.Testing
         private readonly bool _isSecret;
         private readonly ILogger _logger;
 
+        private bool _isDisposed;
+
         private TemporaryEnvironmentVariable(string variableName, string currentValue, string originalValue, bool isSecret, ILogger logger)
         {
             ArgumentNullException.ThrowIfNull(variableName);
@@ -97,6 +99,13 @@ namespace Arcus.Testing
         /// </summary>
         public void Dispose()
         {
+            if (_isDisposed)
+            {
+                return;
+            }
+
+            _isDisposed = true;
+
             switch (_originalValue, _isSecret)
             {
                 case (null, false):

--- a/src/Arcus.Testing.Tests.Unit/Core/AsyncDisposableTests.cs
+++ b/src/Arcus.Testing.Tests.Unit/Core/AsyncDisposableTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Arcus.Testing.Tests.Unit.Core
@@ -21,6 +22,24 @@ namespace Arcus.Testing.Tests.Unit.Core
         public void Create_WithoutDisposeAsync_Fails()
         {
             Assert.ThrowsAny<ArgumentException>(() => AsyncDisposable.Create(disposeAsync: null));
+        }
+
+        [Fact]
+        public async Task Dispose_MultipleTimes_SucceedsByBeingRedundant()
+        {
+            // Arrange
+            int disposeCount = 0;
+            var disposable = AsyncDisposable.Create(() => ++disposeCount);
+
+            // Act
+            await disposable.DisposeAsync();
+
+            // Assert
+            await disposable.DisposeAsync();
+            await disposable.DisposeAsync();
+            await disposable.DisposeAsync();
+
+            Assert.Equal(1, disposeCount);
         }
     }
 }


### PR DESCRIPTION
Multiple calls to a dispose operation should be redundant, if we follow the best practices for .NET.
This PR does this for the Core functionality.

Relates to #450 