### PR TITLE
chore(net10.0): add support for .net 10.0 throughout

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -40,6 +40,11 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
 
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: 10.0.x
+
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v3

--- a/.github/workflows/dotnet-format.yml
+++ b/.github/workflows/dotnet-format.yml
@@ -16,6 +16,6 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 8.0.x
+        dotnet-version: 10.0.x
     - name: Format
       run: dotnet format src/Arcus.Testing.sln --verify-no-changes --verbosity diagnostic

--- a/build/variables/build.yml
+++ b/build/variables/build.yml
@@ -1,5 +1,5 @@
 variables:
-  DotNet.Sdk.Version: '10.0.100-preview.6'
+  DotNet.Sdk.Version: '10.0.x'
   # Backwards compatible .NET SDK version
   DotNet.Sdk.VersionBC: '8.0.x'
   DotNet.Sdk.IncludePreviewVersions: true

--- a/build/variables/build.yml
+++ b/build/variables/build.yml
@@ -1,7 +1,7 @@
 variables:
-  DotNet.Sdk.Version: '8.0.x'
+  DotNet.Sdk.Version: '10.0.100-preview.6'
   # Backwards compatible .NET SDK version
-  DotNet.Sdk.VersionBC: '6.0.100'
-  DotNet.Sdk.IncludePreviewVersions: false
+  DotNet.Sdk.VersionBC: '8.0.x'
+  DotNet.Sdk.IncludePreviewVersions: true
   Project: 'Arcus.Testing'
   Vm.Image: 'ubuntu-latest'

--- a/samples/Arcus.Testing.Sample.TestingFrameworkMigration/Arcus.Testing.Sample.TestingFrameworkMigration.csproj
+++ b/samples/Arcus.Testing.Sample.TestingFrameworkMigration/Arcus.Testing.Sample.TestingFrameworkMigration.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net10.0;net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/src/Arcus.Testing.Assert/Arcus.Testing.Assert.csproj
+++ b/src/Arcus.Testing.Assert/Arcus.Testing.Assert.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net10.0;net8.0</TargetFrameworks>
     <RootNamespace>Arcus.Testing</RootNamespace>
     <Authors>Arcus</Authors>
     <Company>Arcus</Company>

--- a/src/Arcus.Testing.Core/Arcus.Testing.Core.csproj
+++ b/src/Arcus.Testing.Core/Arcus.Testing.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net10.0;net8.0</TargetFrameworks>
     <RootNamespace>Arcus.Testing</RootNamespace>
     <Authors>Arcus</Authors>
     <Company>Arcus</Company>

--- a/src/Arcus.Testing.Integration.DataFactory/Arcus.Testing.Integration.DataFactory.csproj
+++ b/src/Arcus.Testing.Integration.DataFactory/Arcus.Testing.Integration.DataFactory.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net10.0;net8.0</TargetFrameworks>
     <RootNamespace>Arcus.Testing</RootNamespace>
     <Authors>Arcus</Authors>
     <Company>Arcus</Company>

--- a/src/Arcus.Testing.Logging.MSTest/Arcus.Testing.Logging.MSTest.csproj
+++ b/src/Arcus.Testing.Logging.MSTest/Arcus.Testing.Logging.MSTest.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net10.0;net8.0</TargetFrameworks>
     <RootNamespace>Arcus.Testing</RootNamespace>
     <Authors>Arcus</Authors>
     <Company>Arcus</Company>

--- a/src/Arcus.Testing.Logging.NUnit/Arcus.Testing.Logging.NUnit.csproj
+++ b/src/Arcus.Testing.Logging.NUnit/Arcus.Testing.Logging.NUnit.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net10.0;net8.0</TargetFrameworks>
     <RootNamespace>Arcus.Testing</RootNamespace>
     <Authors>Arcus</Authors>
     <Company>Arcus</Company>

--- a/src/Arcus.Testing.Logging.Xunit.v3/Arcus.Testing.Logging.Xunit.v3.csproj
+++ b/src/Arcus.Testing.Logging.Xunit.v3/Arcus.Testing.Logging.Xunit.v3.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net10.0;net8.0</TargetFrameworks>
     <RootNamespace>Arcus.Testing</RootNamespace>
     <Authors>Arcus</Authors>
     <Company>Arcus</Company>

--- a/src/Arcus.Testing.Logging.Xunit/Arcus.Testing.Logging.Xunit.csproj
+++ b/src/Arcus.Testing.Logging.Xunit/Arcus.Testing.Logging.Xunit.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net10.0;net8.0</TargetFrameworks>
     <RootNamespace>Arcus.Testing</RootNamespace>
     <Authors>Arcus</Authors>
     <Company>Arcus</Company>

--- a/src/Arcus.Testing.Messaging.ServiceBus/Arcus.Testing.Messaging.ServiceBus.csproj
+++ b/src/Arcus.Testing.Messaging.ServiceBus/Arcus.Testing.Messaging.ServiceBus.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net10.0;net8.0</TargetFrameworks>
     <RootNamespace>Arcus.Testing</RootNamespace>
     <Authors>Arcus</Authors>
     <Company>Arcus</Company>

--- a/src/Arcus.Testing.Storage.Blob/Arcus.Testing.Storage.Blob.csproj
+++ b/src/Arcus.Testing.Storage.Blob/Arcus.Testing.Storage.Blob.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net10.0;net8.0</TargetFrameworks>
     <RootNamespace>Arcus.Testing</RootNamespace>
     <Authors>Arcus</Authors>
     <Company>Arcus</Company>

--- a/src/Arcus.Testing.Storage.Cosmos/Arcus.Testing.Storage.Cosmos.csproj
+++ b/src/Arcus.Testing.Storage.Cosmos/Arcus.Testing.Storage.Cosmos.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net10.0;net8.0</TargetFrameworks>
     <RootNamespace>Arcus.Testing</RootNamespace>
     <Authors>Arcus</Authors>
     <Company>Arcus</Company>

--- a/src/Arcus.Testing.Storage.File.Share/Arcus.Testing.Storage.File.Share.csproj
+++ b/src/Arcus.Testing.Storage.File.Share/Arcus.Testing.Storage.File.Share.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net10.0;net8.0</TargetFrameworks>
     <RootNamespace>Arcus.Testing</RootNamespace>
     <Authors>Arcus</Authors>
     <Company>Arcus</Company>

--- a/src/Arcus.Testing.Storage.Table/Arcus.Testing.Storage.Table.csproj
+++ b/src/Arcus.Testing.Storage.Table/Arcus.Testing.Storage.Table.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net10.0;net8.0</TargetFrameworks>
     <RootNamespace>Arcus.Testing</RootNamespace>
     <Authors>Arcus</Authors>
     <Company>Arcus</Company>

--- a/src/Arcus.Testing.Tests.Core/Arcus.Testing.Tests.Core.csproj
+++ b/src/Arcus.Testing.Tests.Core/Arcus.Testing.Tests.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/Arcus.Testing.Tests.Integration/Arcus.Testing.Tests.Integration.csproj
+++ b/src/Arcus.Testing.Tests.Integration/Arcus.Testing.Tests.Integration.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/Arcus.Testing.Tests.Unit/Arcus.Testing.Tests.Unit.csproj
+++ b/src/Arcus.Testing.Tests.Unit/Arcus.Testing.Tests.Unit.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <IsPackable>false</IsPackable>
       <NoWarn>CA2007<!-- unit tests do not have a synchronization context, only sync 'hidden' as async --></NoWarn>


### PR DESCRIPTION
Move the .NET support window towards .NET 10 (currently preview). No breaking changes are there, we can simply add the number to the .csproj files.

Closes #452 