### PR TITLE
chore(logging): apply roslyn analysers to logging projects

### DIFF
--- a/src/Arcus.Testing.Logging.MSTest/Arcus.Testing.Logging.MSTest.csproj
+++ b/src/Arcus.Testing.Logging.MSTest/Arcus.Testing.Logging.MSTest.csproj
@@ -19,7 +19,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsNotAsErrors>$(WarningsNotAsErrors);NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>
-    <AnalysisMode>Recommended</AnalysisMode>
+    <AnalysisMode>All</AnalysisMode>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Arcus.Testing.Logging.MSTest/Extensions/ILoggerBuilderExtensions.cs
+++ b/src/Arcus.Testing.Logging.MSTest/Extensions/ILoggerBuilderExtensions.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Extensions.Logging
         /// <summary>
         /// Adds the logging messages from the given xUnit <paramref name="testContext"/> as a provider to the <paramref name="builder"/>.
         /// </summary>
-        /// <param name="builder">The logging builder to add the NUnit logging test messages to.</param>
+        /// <param name="builder">The logging builder to add the MSTest logging test messages to.</param>
         /// <param name="testContext">The MSTest writer to write custom test output.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="builder"/> or the <paramref name="testContext"/> is <c>null</c>.</exception>
         public static ILoggingBuilder AddMSTestLogging(this ILoggingBuilder builder, TestContext testContext)

--- a/src/Arcus.Testing.Logging.MSTest/Extensions/ILoggerBuilderExtensions.cs
+++ b/src/Arcus.Testing.Logging.MSTest/Extensions/ILoggerBuilderExtensions.cs
@@ -22,7 +22,9 @@ namespace Microsoft.Extensions.Logging
             ArgumentNullException.ThrowIfNull(builder);
             ArgumentNullException.ThrowIfNull(testContext);
 
+#pragma warning disable CA2000 // Responsibility of disposing the created object is transferred to the caller
             var provider = new MSTestLoggerProvider(testContext);
+#pragma warning restore CA2000
             return builder.AddProvider(provider);
         }
 

--- a/src/Arcus.Testing.Logging.MSTest/Extensions/ILoggerBuilderExtensions.cs
+++ b/src/Arcus.Testing.Logging.MSTest/Extensions/ILoggerBuilderExtensions.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Extensions.Logging
     public static class ILoggerBuilderExtensions
     {
         /// <summary>
-        /// Adds the logging messages from the given xUnit <paramref name="testContext"/> as a provider to the <paramref name="builder"/>.
+        /// Adds the logging messages from the given MSTest <paramref name="testContext"/> as a provider to the <paramref name="builder"/>.
         /// </summary>
         /// <param name="builder">The logging builder to add the MSTest logging test messages to.</param>
         /// <param name="testContext">The MSTest writer to write custom test output.</param>

--- a/src/Arcus.Testing.Logging.MSTest/MSTestLogger.cs
+++ b/src/Arcus.Testing.Logging.MSTest/MSTestLogger.cs
@@ -38,6 +38,8 @@ namespace Arcus.Testing
             Exception exception,
             Func<TState, Exception, string> formatter)
         {
+            ArgumentNullException.ThrowIfNull(formatter);
+
             string message = formatter(state, exception);
             if (exception is null)
             {

--- a/src/Arcus.Testing.Logging.NUnit/Arcus.Testing.Logging.NUnit.csproj
+++ b/src/Arcus.Testing.Logging.NUnit/Arcus.Testing.Logging.NUnit.csproj
@@ -19,7 +19,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsNotAsErrors>$(WarningsNotAsErrors);NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>
-    <AnalysisMode>Recommended</AnalysisMode>
+    <AnalysisMode>All</AnalysisMode>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Arcus.Testing.Logging.NUnit/Extensions/ILoggerBuilderExtensions.cs
+++ b/src/Arcus.Testing.Logging.NUnit/Extensions/ILoggerBuilderExtensions.cs
@@ -23,7 +23,9 @@ namespace Microsoft.Extensions.Logging
             ArgumentNullException.ThrowIfNull(outputWriter);
 
             var logger = new NUnitTestLogger(outputWriter);
+#pragma warning disable CA2000 // Responsibility of disposing the created object is transferred to the caller
             var provider = new NUnitLoggerProvider(logger);
+#pragma warning restore CA2000
 
             return builder.AddProvider(provider);
         }
@@ -41,7 +43,9 @@ namespace Microsoft.Extensions.Logging
             ArgumentNullException.ThrowIfNull(outputWriter);
 
             var logger = new NUnitTestLogger(outputWriter, errorWriter);
+#pragma warning disable CA2000 // Responsibility of disposing the created object is transferred to the caller
             var provider = new NUnitLoggerProvider(logger);
+#pragma warning restore CA2000
 
             return builder.AddProvider(provider);
         }

--- a/src/Arcus.Testing.Logging.NUnit/Extensions/ILoggerBuilderExtensions.cs
+++ b/src/Arcus.Testing.Logging.NUnit/Extensions/ILoggerBuilderExtensions.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Extensions.Logging
     public static class ILoggerBuilderExtensions
     {
         /// <summary>
-        /// Adds the logging messages from the given xUnit <paramref name="outputWriter"/> as a provider to the <paramref name="builder"/>.
+        /// Adds the logging messages from the given NUnit <paramref name="outputWriter"/> as a provider to the <paramref name="builder"/>.
         /// </summary>
         /// <param name="builder">The logging builder to add the NUnit logging test messages to.</param>
         /// <param name="outputWriter">The NUnit test writer to write custom test output.</param>

--- a/src/Arcus.Testing.Logging.NUnit/NUnitTestLogger.cs
+++ b/src/Arcus.Testing.Logging.NUnit/NUnitTestLogger.cs
@@ -53,6 +53,8 @@ namespace Arcus.Testing
             Exception exception,
             Func<TState, Exception, string> formatter)
         {
+            ArgumentNullException.ThrowIfNull(formatter);
+
             string message = formatter(state, exception);
             void WriteToContext(TextWriter writer)
             {

--- a/src/Arcus.Testing.Logging.Xunit.v3/Arcus.Testing.Logging.Xunit.v3.csproj
+++ b/src/Arcus.Testing.Logging.Xunit.v3/Arcus.Testing.Logging.Xunit.v3.csproj
@@ -19,7 +19,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsNotAsErrors>$(WarningsNotAsErrors);NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>
-    <AnalysisMode>Recommended</AnalysisMode>
+    <AnalysisMode>All</AnalysisMode>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Arcus.Testing.Logging.Xunit.v3/Extensions/ILoggerBuilderExtensions.cs
+++ b/src/Arcus.Testing.Logging.Xunit.v3/Extensions/ILoggerBuilderExtensions.cs
@@ -22,7 +22,9 @@ namespace Microsoft.Extensions.Logging
             ArgumentNullException.ThrowIfNull(builder);
             ArgumentNullException.ThrowIfNull(outputWriter);
 
+#pragma warning disable CA2000 // Responsibility of disposing the created object is transferred to the caller
             return builder.AddProvider(new XunitLoggerProvider(outputWriter));
+#pragma warning restore CA2000
         }
 
         [ProviderAlias("Xunit")]

--- a/src/Arcus.Testing.Logging.Xunit/Arcus.Testing.Logging.Xunit.csproj
+++ b/src/Arcus.Testing.Logging.Xunit/Arcus.Testing.Logging.Xunit.csproj
@@ -19,7 +19,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsNotAsErrors>$(WarningsNotAsErrors);NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>
-    <AnalysisMode>Recommended</AnalysisMode>
+    <AnalysisMode>All</AnalysisMode>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Arcus.Testing.Logging.Xunit/Extensions/ILoggerBuilderExtensions.cs
+++ b/src/Arcus.Testing.Logging.Xunit/Extensions/ILoggerBuilderExtensions.cs
@@ -22,7 +22,9 @@ namespace Microsoft.Extensions.Logging
             ArgumentNullException.ThrowIfNull(builder);
             ArgumentNullException.ThrowIfNull(outputWriter);
 
+#pragma warning disable CA2000 // Responsibility of disposing the created object is transferred to the caller
             var provider = new XunitLoggerProvider(outputWriter);
+#pragma warning restore CA2000
             return builder.AddProvider(provider);
         }
 

--- a/src/Arcus.Testing.Logging.Xunit/XunitTestLogger.cs
+++ b/src/Arcus.Testing.Logging.Xunit/XunitTestLogger.cs
@@ -30,6 +30,8 @@ namespace Arcus.Testing
         /// <param name="formatter">Function to create a <c>string</c> message of the <paramref name="state" /> and <paramref name="exception" />.</param>
         public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
         {
+            ArgumentNullException.ThrowIfNull(formatter);
+
             string message = formatter(state, exception);
             if (exception is null)
             {


### PR DESCRIPTION
Apply `All` the Roslyn analyzer rules to the logging projects.
Relates to #449 