### PR TITLE
chore(core): apply roslyn analysers to core project

### DIFF
--- a/src/Arcus.Testing.Core/Arcus.Testing.Core.csproj
+++ b/src/Arcus.Testing.Core/Arcus.Testing.Core.csproj
@@ -19,7 +19,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsNotAsErrors>$(WarningsNotAsErrors);NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>
-    <AnalysisMode>Default</AnalysisMode>
+    <AnalysisMode>All</AnalysisMode>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Arcus.Testing.Core/DisposableCollection.cs
+++ b/src/Arcus.Testing.Core/DisposableCollection.cs
@@ -171,7 +171,9 @@ namespace Arcus.Testing
 
                     }).ConfigureAwait(false);
                 }
+#pragma warning disable CA1031 // Should catch all exceptions to determine if the fixture teardown failed.
                 catch (Exception exception)
+#pragma warning restore CA1031
                 {
                     exceptions.Add(exception);
                 }

--- a/src/Arcus.Testing.Core/ResourceDirectory.cs
+++ b/src/Arcus.Testing.Core/ResourceDirectory.cs
@@ -292,7 +292,9 @@ namespace Arcus.Testing
         /// <exception cref="DirectoryNotFoundException">
         ///     Thrown when no test resource subdirectory is found within the current test resource directory with the given <paramref name="subDirectoryName"/>.
         /// </exception>
+#pragma warning disable CA2225 // Does not require public 'Divide' alternative, as this is the .WithSubDirectory(...) method.
         public static ResourceDirectory operator /(ResourceDirectory current, string subDirectoryName)
+#pragma warning restore CA2225
         {
             ArgumentNullException.ThrowIfNull(current);
             return current.WithSubDirectory(subDirectoryName);


### PR DESCRIPTION
Applies `All` Roslyn analyzers on `.Core` project.
Relates to #454 