### PR TITLE
chore(xunit.v3): remove empty namespace to finalize xunit v3 migration

### DIFF
--- a/src/Arcus.Testing.Tests.Integration/XunitV2Using.cs
+++ b/src/Arcus.Testing.Tests.Integration/XunitV2Using.cs
@@ -1,4 +1,0 @@
-﻿namespace Xunit.Abstractions
-{
-    // TODO: Remove this empty namespace once all tests have removed their using.
-}


### PR DESCRIPTION
We've added an empty namespace that was used in the old xUnit v2 to limit the PR changes during the migration. This namespace is now not used anymore throughout the tests, so we can remove it.

Relates to #269 