### PR TITLE
chore(deps): remove unnecessary system http package

### DIFF
--- a/src/Arcus.Testing.Tests.Core/Arcus.Testing.Tests.Core.csproj
+++ b/src/Arcus.Testing.Tests.Core/Arcus.Testing.Tests.Core.csproj
@@ -7,7 +7,6 @@
 
   <ItemGroup>
     <PackageReference Include="Bogus" Version="35.*" />
-    <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="xunit.v3.assert" Version="2.*" />
   </ItemGroup>
 


### PR DESCRIPTION
The old .NET 6, we were forced to add a dedicated System HTTP package in our test infrastructure. This is now unnecessary, so we can remove the package.