### PR TITLE
chore(core): disable sonar-qube false positive unreachable code

### DIFF
--- a/src/Arcus.Testing.Core/DisposableCollection.cs
+++ b/src/Arcus.Testing.Core/DisposableCollection.cs
@@ -221,7 +221,7 @@ namespace Arcus.Testing
 
 #pragma warning disable S2583 // False positive (due to configure-await): Change this condition so that it does not always evaluate to 'False'. Some code paths are unreachable.
             if (exceptions.Count == 1)
-#pragma warning enable
+#pragma warning restore S2583
             {
                 throw exceptions[0];
             }

--- a/src/Arcus.Testing.Core/DisposableCollection.cs
+++ b/src/Arcus.Testing.Core/DisposableCollection.cs
@@ -219,7 +219,9 @@ namespace Arcus.Testing
                 }
             }
 
+#pragma warning disable S2583 // False positive (due to configure-await): Change this condition so that it does not always evaluate to 'False'. Some code paths are unreachable.
             if (exceptions.Count == 1)
+#pragma warning enable
             {
                 throw exceptions[0];
             }


### PR DESCRIPTION
Since we changed the disposable retry in the `DisposableCollection` to use the `.ConfigureAwait(false)` construct, SonarQube incorrectly notes that some code is unreachable. This PR ignores this false positive on this line.