### PR TITLE
chore(core): disable sonar-qube false positive unreachable code

### DIFF
--- a/src/Arcus.Testing.Core/DisposableCollection.cs
+++ b/src/Arcus.Testing.Core/DisposableCollection.cs
@@ -226,7 +226,9 @@ namespace Arcus.Testing
                 throw exceptions[0];
             }
 
+#pragma warning disable S2583 // False positive (due to configure-await): Change this condition so that it does not always evaluate to 'False'. Some code paths are unreachable.
             if (exceptions.Count > 1)
+#pragma warning restore S2583
             {
                 throw new AggregateException(
                     "[Test:Teardown] Some test fixtures failed to tear down correctly, please check the collected exceptions for more information",


### PR DESCRIPTION
SonarQube incorrectly reports false positive on `if` condition after adding `.ConfigureAwait(false)` in the `DisposableCollection`. This PR disables that warning on that line.