### PR TITLE
feat(assert): add assert csv options to assert xslt

### DIFF
--- a/docs/versioned_docs/version-v2.1.0/03-Features/02-assertion.mdx
+++ b/docs/versioned_docs/version-v2.1.0/03-Features/02-assertion.mdx
@@ -327,9 +327,11 @@ using Arcus.Testing;
 // ----------------------------------------------------
 string input = "<data>...</data>";
 string xslt = "<xsl:stylesheet>...</xsl:stylesheet>";
+var arguments = new XsltArgumentList();
 
 string expected = "<other-data>...</other-data>"
 string actual = AssertXslt.TransformToXml(xslt, input);
+string actual = AssertXslt.TransformToXml(xslt, input, arguments);
 // Use `AssertXml.Equal` to do the equalization.
 
 // XML -> JSON
@@ -339,6 +341,7 @@ string xslt = "<xsl:stylesheet>...</xsl:stylesheet>";
 
 string expected = "{ \"data\": ... }";
 string actual = AssertXslt.TransformToJson(xslt, input);
+string actual = AssertXslt.TransformToJson(xslt, input, arguments);
 // Use `AssertJson.Equal` to do the equalization.
 
 // XML -> CSV
@@ -348,10 +351,23 @@ string xslt = "<xsl:stylesheet>...</xsl:stylesheet>";
 
 string expected = "data;cost\nsome-data;123,45";
 string actual = AssertXslt.TransformToCsv(xslt, input);
+string actual = AssertXslt.TransformToCsv(xslt, input, arguments);
+string actual = AssertXslt.TransformToCsv(xslt, input, options =>
+{
+    options.Arguments = arguments;
+    options.WithResult((AssertCsvOptions csv) =>
+    {
+        // Additional options to control how the output CSV should look like.
+        // 👀 Note that when using equalization after transformation, 
+        // it is best to use the `TransformToCsv` overload that returns a `CsvTable`.
+        // That way, the load options defined here will be embedded in the 'actual' value. 
+
+        csv.Separator = ',';
+    })
+});
+
 // Use `AssertCsv.Equal` to do the equalization.
 ```
-
-> ⚡ Both types of transformations can be adapted by passing any runtime XSLT arguments.
 
 <details>
   <summary><strong>Why use the `AssertXslt` to load something that is already available with `XsltCompiledTransform.Load`?</strong></summary>

--- a/src/Arcus.Testing.Tests.Unit/Assert_/AssertXsltTests.cs
+++ b/src/Arcus.Testing.Tests.Unit/Assert_/AssertXsltTests.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.IO;
 using System.Text.Json;
 using System.Xml;
 using System.Xml.Xsl;
@@ -12,22 +11,31 @@ namespace Arcus.Testing.Tests.Unit.Assert_
 {
     public class AssertXsltTests
     {
+        private readonly ResourceDirectory _resources;
         private static readonly Faker Bogus = new();
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AssertXsltTests"/> class.
+        /// </summary>
+        public AssertXsltTests()
+        {
+            _resources = ResourceDirectory.CurrentDirectory / nameof(Assert_) / "Resources";
+        }
 
         [Fact]
         public void TransformToXml_ToXml_Succeeds()
         {
             // Arrange
             string sampleName = "xslt-transform.xml-xml.sample";
-            string xslt = ReadResourceFileByName($"{sampleName}.transformer.xslt");
+            string xslt = _resources.ReadFileText($"{sampleName}.transformer.xslt");
 
-            string input = ReadResourceFileByName($"{sampleName}.input.xml");
+            string input = _resources.ReadFileText($"{sampleName}.input.xml");
 
             // Act
             string actual = TransformToXml(xslt, input);
 
             // Assert
-            string expected = ReadResourceFileByName($"{sampleName}.output.xml");
+            string expected = _resources.ReadFileText($"{sampleName}.output.xml");
             AssertXml.Equal(expected, actual);
         }
 
@@ -36,9 +44,9 @@ namespace Arcus.Testing.Tests.Unit.Assert_
         {
             // Arrange
             string sampleName = "xslt-transform.xml-json.sample";
-            string xslt = ReadResourceFileByName($"{sampleName}.transformer.xslt");
-            string input = ReadResourceFileByName($"{sampleName}.input.xml");
-            string expected = ReadResourceFileByName($"{sampleName}.output.json");
+            string xslt = _resources.ReadFileText($"{sampleName}.transformer.xslt");
+            string input = _resources.ReadFileText($"{sampleName}.input.xml");
+            string expected = _resources.ReadFileText($"{sampleName}.output.json");
 
             // Act
             string actual = TransformToJson(xslt, input);
@@ -52,12 +60,12 @@ namespace Arcus.Testing.Tests.Unit.Assert_
         {
             // Arrange
             string sampleName = "xslt-transform.xml-csv.sample";
-            string xslt = ReadResourceFileByName($"{sampleName}.transformer.xslt");
-            string input = ReadResourceFileByName($"{sampleName}.input.xml");
-            string expected = ReadResourceFileByName($"{sampleName}.output.csv");
+            var xslt = AssertXslt.Load(_resources.ReadFileText($"{sampleName}.transformer.xslt"));
+            var input = AssertXml.Load(_resources.ReadFileText($"{sampleName}.input.xml"));
+            var expected = AssertCsv.Load(_resources.ReadFileText($"{sampleName}.output.csv"));
 
             // Act
-            string actual = TransformToCsv(xslt, input);
+            CsvTable actual = TransformToCsv(xslt, input);
 
             // Assert
             AssertCsv.Equal(expected, actual);
@@ -132,14 +140,6 @@ namespace Arcus.Testing.Tests.Unit.Assert_
             });
         }
 
-        private static string ReadResourceFileByName(string fileName)
-        {
-            string directoryPath = Path.Combine(Directory.GetCurrentDirectory(), nameof(Assert_), "Resources");
-            string filePath = Path.Combine(directoryPath, fileName);
-
-            return File.ReadAllText(filePath);
-        }
-
         private static string TransformToXml(string xslt, string xml)
         {
             if (Bogus.Random.Bool())
@@ -168,6 +168,21 @@ namespace Arcus.Testing.Tests.Unit.Assert_
             }
 
             return AssertXslt.TransformToCsv(AssertXslt.Load(xslt), AssertXml.Load(xml)).ToString();
+        }
+
+        private static CsvTable TransformToCsv(XslCompiledTransform xslt, XmlDocument xml)
+        {
+            return AssertXslt.TransformToCsv(xslt, xml, options =>
+            {
+                if (Bogus.Random.Bool())
+                {
+                    var args = new XsltArgumentList();
+                    args.AddParam("separator", namespaceUri: "", ",");
+
+                    options.Arguments = args;
+                    options.WithResult(csv => csv.Separator = ',');
+                }
+            });
         }
 
         [Fact]

--- a/src/Arcus.Testing.Tests.Unit/Assert_/Resources/xslt-transform.xml-csv.sample.transformer.xslt
+++ b/src/Arcus.Testing.Tests.Unit/Assert_/Resources/xslt-transform.xml-csv.sample.transformer.xslt
@@ -6,7 +6,7 @@
 	exclude-result-prefixes="xs math" version="3.0">
 	<xsl:output method="text" indent="yes" omit-xml-declaration="yes" />
 
-	<xsl:variable name="separator" select="';'"/>
+	<xsl:param name="separator" select="';'"/>
 
 	<xsl:template match="/">
 		<xsl:apply-templates select="Data"/>


### PR DESCRIPTION
Because the `AssertXslt.TransformToCsv` uses the `AssertCsv.Load` functionality to make sure that the transformation output is indeed a correct CSV, we should also make sure that we provide the necessary load options to it, to customize the CSV output.

Closes #462  