### PR TITLE
chore(sonar.qube): ignore S1133 throughout as common in library development

### DIFF
--- a/src/Arcus.Testing.Core/Arcus.Testing.Core.csproj
+++ b/src/Arcus.Testing.Core/Arcus.Testing.Core.csproj
@@ -19,6 +19,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsNotAsErrors>$(WarningsNotAsErrors);NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>
+    <NoWarn>S1133</NoWarn>
     <AnalysisMode>All</AnalysisMode>
   </PropertyGroup>
 

--- a/src/Arcus.Testing.Core/ResourceDirectory.cs
+++ b/src/Arcus.Testing.Core/ResourceDirectory.cs
@@ -80,9 +80,7 @@ namespace Arcus.Testing
         /// <exception cref="FileNotFoundException">
         ///     Thrown when there exists no test resource file in the current test resource directory with the given <paramref name="fileName"/>.
         /// </exception>
-#pragma warning disable S1133 // Should wait until the next major version to remove obsolete code.
         [Obsolete("Will be removed in v3.0, please use " + nameof(ReadFileText) + " instead")]
-#pragma warning restore S1133
         public string ReadFileTextByName(string fileName)
         {
             return ReadFileText(fileName);
@@ -100,9 +98,7 @@ namespace Arcus.Testing
         /// <exception cref="FileNotFoundException">
         ///     Thrown when there exists no test resource file in the current test resource directory with the given <paramref name="searchPattern"/>.
         /// </exception>
-#pragma warning disable S1133 // Should wait until the next major version to remove obsolete code.
         [Obsolete("Will be removed in v3.0, please use " + nameof(ReadFileText) + " instead")]
-#pragma warning restore S1133
         public string ReadFileTextByPattern(string searchPattern)
         {
             return ReadFileText(searchPattern);
@@ -142,9 +138,7 @@ namespace Arcus.Testing
         /// <exception cref="FileNotFoundException">
         ///     Thrown when there exists no test resource file in the current test resource directory with the given <paramref name="fileName"/>.
         /// </exception>
-#pragma warning disable S1133 // Should wait until the next major version to remove obsolete code.
         [Obsolete("Will be removed in v3.0, please use " + nameof(ReadFileBytes) + " instead")]
-#pragma warning restore S1133
         public byte[] ReadFileBytesByName(string fileName)
         {
             return ReadFileBytes(fileName);
@@ -162,9 +156,7 @@ namespace Arcus.Testing
         /// <exception cref="FileNotFoundException">
         ///     Thrown when there exists no test resource file in the current test resource directory with the given <paramref name="searchPattern"/>.
         /// </exception>
-#pragma warning disable S1133 // Should wait until the next major version to remove obsolete code.
         [Obsolete("Will be removed in v3.0, please use " + nameof(ReadFileBytes) + " instead")]
-#pragma warning restore S1133
         public byte[] ReadFileBytesByPattern(string searchPattern)
         {
             return ReadFileBytes(searchPattern);

--- a/src/Arcus.Testing.Storage.Blob/Arcus.Testing.Storage.Blob.csproj
+++ b/src/Arcus.Testing.Storage.Blob/Arcus.Testing.Storage.Blob.csproj
@@ -19,6 +19,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsNotAsErrors>$(WarningsNotAsErrors);NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>
+    <NoWarn>S1133</NoWarn>
     <AnalysisMode>All</AnalysisMode>
   </PropertyGroup>
 

--- a/src/Arcus.Testing.Storage.Blob/TemporaryBlobContainer.cs
+++ b/src/Arcus.Testing.Storage.Blob/TemporaryBlobContainer.cs
@@ -117,9 +117,7 @@ namespace Arcus.Testing
         /// (default for cleaning blobs) Configures the <see cref="TemporaryBlobContainer"/> to only delete the Azure Blobs upon disposal
         /// if the blob was upserted by the test fixture (using <see cref="TemporaryBlobContainer.UpsertBlobFileAsync"/>).
         /// </summary>
-#pragma warning disable S1133 // Will be removed in v3.0.
         [Obsolete("Will be removed in v3, please use " + nameof(CleanUpsertedBlobs) + " instead that provides exactly the same on-teardown functionality")]
-#pragma warning restore S1133
         public OnTeardownBlobContainerOptions CleanCreatedBlobs()
         {
             return CleanUpsertedBlobs();
@@ -365,9 +363,7 @@ namespace Arcus.Testing
         /// <param name="blobContent">The content of the blob to upload.</param>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="blobName"/> is blank.</exception>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="blobContent"/> is <c>null</c>.</exception>
-#pragma warning disable S1133 // Will be removed in v3.0.
         [Obsolete("Will be removed in v3, please use the " + nameof(UpsertBlobFileAsync) + "instead that provides exactly the same functionality")]
-#pragma warning restore S1133
         public Task<BlobClient> UploadBlobAsync(string blobName, BinaryData blobContent)
         {
             return UpsertBlobFileAsync(blobName, blobContent);

--- a/src/Arcus.Testing.Storage.Blob/TemporaryBlobFile.cs
+++ b/src/Arcus.Testing.Storage.Blob/TemporaryBlobFile.cs
@@ -62,9 +62,7 @@ namespace Arcus.Testing
         /// <param name="logger">The logger to write diagnostic messages during the upload process.</param>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="blobContainerUri"/> or the <paramref name="blobName"/> is blank.</exception>
         /// <exception cref="ArgumentNullException">Thrown when <paramref name="blobContainerUri"/> or the <paramref name="blobContent"/> is <c>null</c>.</exception>
-#pragma warning disable S1133 // Will be removed in v3.0
         [Obsolete("Will be removed in v3.0, please use the " + nameof(UpsertFileAsync) + " instead which provides the exact same functionality")]
-#pragma warning restore S1133
         public static Task<TemporaryBlobFile> UploadIfNotExistsAsync(Uri blobContainerUri, string blobName, BinaryData blobContent, ILogger logger)
         {
             return UpsertFileAsync(blobContainerUri, blobName, blobContent, logger);
@@ -77,9 +75,7 @@ namespace Arcus.Testing
         /// <param name="blobContent">The content of the blob to upload.</param>
         /// <param name="logger">The logger to write diagnostic messages during the upload process.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="blobClient"/> or the <paramref name="blobContent"/> is <c>null</c>.</exception>
-#pragma warning disable S1133 // Will be removed in v3.0
         [Obsolete("Will be removed in v3.0, please use the " + nameof(UpsertFileAsync) + " instead which provides the exact same functionality")]
-#pragma warning restore S1133
         public static Task<TemporaryBlobFile> UploadIfNotExistsAsync(BlobClient blobClient, BinaryData blobContent, ILogger logger)
         {
             return UpsertFileAsync(blobClient, blobContent, logger);

--- a/src/Arcus.Testing.Storage.Cosmos/Arcus.Testing.Storage.Cosmos.csproj
+++ b/src/Arcus.Testing.Storage.Cosmos/Arcus.Testing.Storage.Cosmos.csproj
@@ -19,6 +19,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsNotAsErrors>$(WarningsNotAsErrors);NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>
+    <NoWarn>S1133</NoWarn>
     <AnalysisMode>All</AnalysisMode>
     <AzureCosmosDisableNewtonsoftJsonCheck>true</AzureCosmosDisableNewtonsoftJsonCheck>
   </PropertyGroup>

--- a/src/Arcus.Testing.Storage.Cosmos/TemporaryMongoDbCollection.cs
+++ b/src/Arcus.Testing.Storage.Cosmos/TemporaryMongoDbCollection.cs
@@ -120,9 +120,7 @@ namespace Arcus.Testing
         /// in an Azure Cosmos DB for MongoDB collection upon disposal if the document was inserted by the test fixture
         /// (using <see cref="TemporaryMongoDbCollection.UpsertDocumentAsync{TDocument}"/>).
         /// </summary>
-#pragma warning disable S1133 // Will be removed in v3.0.
         [Obsolete("Will be removed in v3, please use the " + nameof(CleanUpsertedDocuments) + "instead that provides exactly the same functionality")]
-#pragma warning restore S1133
         public OnTeardownMongoDbCollectionOptions CleanCreatedDocuments()
         {
             return CleanUpsertedDocuments();
@@ -440,9 +438,7 @@ namespace Arcus.Testing
         /// <typeparam name="TDocument">The type of the document in the MongoDB collection.</typeparam>
         /// <param name="document">The document to upload to the MongoDB collection.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="document"/> is <c>null</c>.</exception>
-#pragma warning disable S1133 // Will be removed in v3.0.
         [Obsolete("Will be removed in v3, please use the " + nameof(UpsertDocumentAsync) + "instead that provides exactly the same functionality")]
-#pragma warning restore S1133
         public Task AddDocumentAsync<TDocument>(TDocument document)
         {
             return UpsertDocumentAsync(document);

--- a/src/Arcus.Testing.Storage.Cosmos/TemporaryMongoDbDocument.cs
+++ b/src/Arcus.Testing.Storage.Cosmos/TemporaryMongoDbDocument.cs
@@ -75,9 +75,7 @@ namespace Arcus.Testing
         /// <param name="logger">The logger to write diagnostic information during the lifetime of the MongoDb document.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="cosmosDbResourceId"/> or <paramref name="document"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="databaseName"/> or the <paramref name="collectionName"/> is blank.</exception>
-#pragma warning disable S1133 // Will be removed in v3.0.
         [Obsolete("Will be removed in v3, please use the " + nameof(UpsertDocumentAsync) + "instead that provides exactly the same functionality")]
-#pragma warning restore S1133
         public static Task<TemporaryMongoDbDocument> InsertIfNotExistsAsync<TDocument>(
             ResourceIdentifier cosmosDbResourceId,
             string databaseName,
@@ -96,9 +94,7 @@ namespace Arcus.Testing
         /// <param name="document">The document that should be temporarily inserted into the MongoDB collection.</param>
         /// <param name="logger">The logger to write diagnostic information during the lifetime of the MongoDb document.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="collection"/> or the <paramref name="document"/> is <c>null</c>.</exception>
-#pragma warning disable S1133 // Will be removed in v3.0.
         [Obsolete("Will be removed in v3, please use the " + nameof(UpsertDocumentAsync) + "instead that provides exactly the same functionality")]
-#pragma warning restore S1133
         public static Task<TemporaryMongoDbDocument> InsertIfNotExistsAsync<TDocument>(IMongoCollection<TDocument> collection, TDocument document, ILogger logger)
         {
             return UpsertDocumentAsync(collection, document, logger);

--- a/src/Arcus.Testing.Storage.Cosmos/TemporaryNoSqlContainer.cs
+++ b/src/Arcus.Testing.Storage.Cosmos/TemporaryNoSqlContainer.cs
@@ -179,9 +179,7 @@ namespace Arcus.Testing
         /// (default for cleaning items) Configures the <see cref="TemporaryNoSqlContainer"/> to only delete the NoSQL items
         /// in an Azure Cosmos DB for NoSQL container upon disposal if the item was upserted by the test fixture (using <see cref="TemporaryNoSqlContainer.AddItemAsync{TItem}"/>).
         /// </summary>
-#pragma warning disable S1133 // Will be removed in v3.0.
         [Obsolete("Will be removed in v3, please use " + nameof(CleanUpsertedItems) + " instead that provides exactly the same on-teardown functionality")]
-#pragma warning restore S1133
         public OnTeardownNoSqlContainerOptions CleanCreatedItems()
         {
             return CleanUpsertedItems();
@@ -622,9 +620,7 @@ namespace Arcus.Testing
         /// <typeparam name="T">The custom NoSQL model.</typeparam>
         /// <param name="item">The item to create in the NoSQL container.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="item"/> is <c>null</c>.</exception>
-#pragma warning disable S1133 // Will be removed in v3.0.
         [Obsolete("Will be removed in v3, please use the " + nameof(UpsertItemAsync) + "instead that provides exactly the same functionality")]
-#pragma warning restore S1133
         public Task AddItemAsync<T>(T item)
         {
             return UpsertItemAsync(item);

--- a/src/Arcus.Testing.Storage.Cosmos/TemporaryNoSqlItem.cs
+++ b/src/Arcus.Testing.Storage.Cosmos/TemporaryNoSqlItem.cs
@@ -65,9 +65,7 @@ namespace Arcus.Testing
         /// <param name="item">The item to temporary create in the NoSQL container.</param>
         /// <param name="logger">The logger instance to write diagnostic information during the lifetime of the test fixture.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="container"/> is <c>null</c>.</exception>
-#pragma warning disable S1133 // Will be deleted in v3.0.
         [Obsolete("Will be removed in v3.0, please use the " + nameof(UpsertItemAsync) + " instead which provides the exact same functionality")]
-#pragma warning restore S1133
         public static Task<TemporaryNoSqlItem> InsertIfNotExistsAsync<TItem>(Container container, TItem item, ILogger logger)
         {
             return UpsertItemAsync(container, item, logger);

--- a/src/Arcus.Testing.Storage.Table/Arcus.Testing.Storage.Table.csproj
+++ b/src/Arcus.Testing.Storage.Table/Arcus.Testing.Storage.Table.csproj
@@ -19,6 +19,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsNotAsErrors>$(WarningsNotAsErrors);NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>
+     <NoWarn>S1133</NoWarn>
     <AnalysisMode>All</AnalysisMode>
   </PropertyGroup>
 

--- a/src/Arcus.Testing.Storage.Table/TemporaryTable.cs
+++ b/src/Arcus.Testing.Storage.Table/TemporaryTable.cs
@@ -103,9 +103,7 @@ namespace Arcus.Testing
         /// (default for cleaning documents) Configures the <see cref="TemporaryTable"/> to only delete the Azure Table entities upon disposal
         /// if the document was inserted by the test fixture (using <see cref="TemporaryTable.UpsertEntityAsync{TEntity}"/>).
         /// </summary>
-#pragma warning disable S1133 // Will be removed in v3.0.
         [Obsolete("Will be removed in v3.0, please use the " + nameof(CleanUpsertedEntities) + " instead that provides exactly the same functionality")]
-#pragma warning restore S1133
         public OnTeardownTemporaryTableOptions CleanCreatedEntities()
         {
             return CleanUpsertedEntities();
@@ -358,9 +356,7 @@ namespace Arcus.Testing
         /// <typeparam name="TEntity">A custom model type that implements <see cref="ITableEntity" /> or an instance of <see cref="TableEntity" />.</typeparam>
         /// <param name="entity">The entity to temporary add to the table.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="entity"/> is <c>null</c>.</exception>
-#pragma warning disable S1133 // Will be removed in v3.0.
         [Obsolete("Will be removed in v3.0, please use the " + nameof(UpsertEntityAsync) + " instead that provides exactly the same functionality")]
-#pragma warning restore S1133
         public Task AddEntityAsync<TEntity>(TEntity entity) where TEntity : class, ITableEntity
         {
             return UpsertEntityAsync(entity);


### PR DESCRIPTION
Ignores the SonarQube rule S1133 throughout source control as this rules notifies that 'obsolete functionality should eventually be deleted', but this is something being tracked outside source control and is common in library development to mark certain functionality obsolete.
