### PR TITLE
chore(logging): upgrade xunit v3 package dependency

### DIFF
--- a/src/Arcus.Testing.Logging.Xunit.v3/Arcus.Testing.Logging.Xunit.v3.csproj
+++ b/src/Arcus.Testing.Logging.Xunit.v3/Arcus.Testing.Logging.Xunit.v3.csproj
@@ -30,7 +30,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="[8.*,10.0.0)" />
-    <PackageReference Include="xunit.v3.extensibility.core" Version="[2.*,3.0.0)" />
+    <PackageReference Include="xunit.v3.extensibility.core" Version="[3.*,4.0.0)" />
   </ItemGroup>
 
 </Project>

--- a/src/Arcus.Testing.Logging.Xunit.v3/Arcus.Testing.Logging.Xunit.v3.csproj
+++ b/src/Arcus.Testing.Logging.Xunit.v3/Arcus.Testing.Logging.Xunit.v3.csproj
@@ -30,7 +30,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="[8.*,10.0.0)" />
-    <PackageReference Include="xunit.v3.extensibility.core" Version="[3.*,4.0.0)" />
+    <PackageReference Include="xunit.v3.extensibility.core" Version="[2.*,4.0.0)" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Xunit has already moved on to a next release version, we better expand our window for it. This PR uses v4 as next threshold, since there were no issues with v3.