### PR TITLE
chore(tests.integration): improve the performance of the integration-tests

### DIFF
--- a/src/Arcus.Testing.Tests.Integration/Integration/DataFactory/RunDataFlowTests.cs
+++ b/src/Arcus.Testing.Tests.Integration/Integration/DataFactory/RunDataFlowTests.cs
@@ -351,14 +351,14 @@ namespace Arcus.Testing.Tests.Integration.Integration.DataFactory
         {
             await using (var disposables = new DisposableCollection(NullLogger.Instance))
             {
-                if (Value != null)
+                disposables.Add(AsyncDisposable.Create(async () =>
                 {
-                    disposables.Add(AsyncDisposable.Create(async () =>
-                    {
-                        await Value.DisposeAsync();
-                        await ShouldNotFindActiveSessionAsync(SessionId);
-                    }));
-                }
+                    // Expected to dispose the debug session multiple times to verify redundancy.
+                    await Value.DisposeAsync();
+                    await Value.DisposeAsync();
+
+                    await ShouldNotFindActiveSessionAsync(SessionId);
+                }));
 
                 disposables.Add(_connection);
             }

--- a/src/Arcus.Testing.Tests.Integration/Integration/DataFactory/TemporaryDataFlowDebugSessionTests.cs
+++ b/src/Arcus.Testing.Tests.Integration/Integration/DataFactory/TemporaryDataFlowDebugSessionTests.cs
@@ -1,12 +1,8 @@
-﻿using System;
-using System.Threading.Tasks;
-using Arcus.Testing.Tests.Integration.Fixture;
-using Azure.Core;
+﻿using System.Threading.Tasks;
 using Xunit;
 
 namespace Arcus.Testing.Tests.Integration.Integration.DataFactory
 {
-    [Collection(DataFactoryDebugSessionCollection.CollectionName)]
     public class TemporaryDataFlowDebugSessionTests : IntegrationTest
     {
         private readonly DataFactoryDebugSession _fixture;
@@ -32,40 +28,6 @@ namespace Arcus.Testing.Tests.Integration.Integration.DataFactory
             }
 
             await _fixture.ShouldFindActiveSessionAsync(_fixture.Value.SessionId);
-        }
-    }
-
-    public class DataFactoryDataFlowDebugSessionDisposeTest : IntegrationTest
-    {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="DataFactoryDataFlowDebugSessionDisposeTest"/> class.
-        /// </summary>
-        public DataFactoryDataFlowDebugSessionDisposeTest(ITestOutputHelper outputWriter) : base(outputWriter)
-        {
-        }
-
-        [Fact]
-        public async Task StartDebugSession_DisposeTwice_SucceedsByBeingRedundant()
-        {
-            // Arrange
-            using var connection = TemporaryManagedIdentityConnection.Create(Configuration, Logger);
-
-            DataFactoryConfig dataFactory = Configuration.GetDataFactory();
-            ResourceIdentifier resourceId = dataFactory.ResourceId;
-            var session = await TemporaryDataFlowDebugSession.StartDebugSessionAsync(resourceId, Logger);
-            Guid sessionId = session.SessionId;
-
-            await session.DisposeAsync();
-
-            // Act
-            await session.DisposeAsync();
-
-            // Assert
-            bool isActive = await DataFactoryDebugSession.IsDebugSessionActiveAsync(resourceId, sessionId);
-            Assert.False(isActive, $"expected to remove active debug session '{sessionId}' in DataFactory '{dataFactory.Name}', but it's still active");
-
-            Assert.Throws<ObjectDisposedException>(() => session.SessionId);
-            await Assert.ThrowsAsync<ObjectDisposedException>(() => session.RunDataFlowAsync(Bogus.Lorem.Word(), Bogus.Lorem.Word()));
         }
     }
 }

--- a/src/Arcus.Testing.Tests.Integration/Storage/TemporaryBlobContainerTests.cs
+++ b/src/Arcus.Testing.Tests.Integration/Storage/TemporaryBlobContainerTests.cs
@@ -6,7 +6,6 @@ using Xunit;
 
 namespace Arcus.Testing.Tests.Integration.Storage
 {
-    [Collection(TestCollections.BlobStorage)]
     public class TemporaryBlobContainerTests : IntegrationTest
     {
         /// <summary>

--- a/src/Arcus.Testing.Tests.Integration/Storage/TemporaryBlobFileTests.cs
+++ b/src/Arcus.Testing.Tests.Integration/Storage/TemporaryBlobFileTests.cs
@@ -6,7 +6,6 @@ using Xunit;
 
 namespace Arcus.Testing.Tests.Integration.Storage
 {
-    [Collection(TestCollections.BlobStorage)]
     public class TemporaryBlobFileTests : IntegrationTest
     {
         /// <summary>

--- a/src/Arcus.Testing.Tests.Integration/Storage/TemporaryMongoDbCollectionTests.cs
+++ b/src/Arcus.Testing.Tests.Integration/Storage/TemporaryMongoDbCollectionTests.cs
@@ -8,7 +8,6 @@ using Xunit;
 
 namespace Arcus.Testing.Tests.Integration.Storage
 {
-    [Collection(TestCollections.MongoDb)]
     public class TemporaryMongoDbCollectionTests : IntegrationTest
     {
         /// <summary>

--- a/src/Arcus.Testing.Tests.Integration/Storage/TemporaryMongoDbDocumentTests.cs
+++ b/src/Arcus.Testing.Tests.Integration/Storage/TemporaryMongoDbDocumentTests.cs
@@ -9,7 +9,6 @@ using Xunit;
 
 namespace Arcus.Testing.Tests.Integration.Storage
 {
-    [Collection(TestCollections.MongoDb)]
     public class TemporaryMongoDbDocumentTests : IntegrationTest
     {
         /// <summary>

--- a/src/Arcus.Testing.Tests.Integration/Storage/TemporaryNoSqlContainerTests.cs
+++ b/src/Arcus.Testing.Tests.Integration/Storage/TemporaryNoSqlContainerTests.cs
@@ -9,7 +9,6 @@ using Xunit;
 
 namespace Arcus.Testing.Tests.Integration.Storage
 {
-    [Collection(TestCollections.NoSql)]
     public class TemporaryNoSqlContainerTests : IntegrationTest
     {
         private static string[] PartitionKeyPaths => new[]

--- a/src/Arcus.Testing.Tests.Integration/Storage/TemporaryNoSqlItemTests.cs
+++ b/src/Arcus.Testing.Tests.Integration/Storage/TemporaryNoSqlItemTests.cs
@@ -9,7 +9,6 @@ using Xunit;
 
 namespace Arcus.Testing.Tests.Integration.Storage
 {
-    [Collection(TestCollections.NoSql)]
     public class TemporaryNoSqlItemTests : IntegrationTest
     {
         /// <summary>


### PR DESCRIPTION
* Removes the test collections as these are actually unnecessary since the tests are very isolated written, this means we can run several of them in parallel (storage <> messaging, for example).
* Removes the long-running (3min+) tests to verify if the temporary data flow debug session can be disposed twice in favor of adding additional test assertions upon the xUnit-injected test fixture.