### PR TITLE
test(integration): remove unnecessary test collections

### DIFF
--- a/src/Arcus.Testing.Tests.Integration/Storage/TemporaryBlobContainerTests.cs
+++ b/src/Arcus.Testing.Tests.Integration/Storage/TemporaryBlobContainerTests.cs
@@ -6,7 +6,6 @@ using Xunit;
 
 namespace Arcus.Testing.Tests.Integration.Storage
 {
-    [Collection(TestCollections.BlobStorage)]
     public class TemporaryBlobContainerTests : IntegrationTest
     {
         /// <summary>

--- a/src/Arcus.Testing.Tests.Integration/Storage/TemporaryBlobFileTests.cs
+++ b/src/Arcus.Testing.Tests.Integration/Storage/TemporaryBlobFileTests.cs
@@ -6,7 +6,6 @@ using Xunit;
 
 namespace Arcus.Testing.Tests.Integration.Storage
 {
-    [Collection(TestCollections.BlobStorage)]
     public class TemporaryBlobFileTests : IntegrationTest
     {
         /// <summary>

--- a/src/Arcus.Testing.Tests.Integration/Storage/TemporaryMongoDbCollectionTests.cs
+++ b/src/Arcus.Testing.Tests.Integration/Storage/TemporaryMongoDbCollectionTests.cs
@@ -8,7 +8,6 @@ using Xunit;
 
 namespace Arcus.Testing.Tests.Integration.Storage
 {
-    [Collection(TestCollections.MongoDb)]
     public class TemporaryMongoDbCollectionTests : IntegrationTest
     {
         /// <summary>

--- a/src/Arcus.Testing.Tests.Integration/Storage/TemporaryMongoDbDocumentTests.cs
+++ b/src/Arcus.Testing.Tests.Integration/Storage/TemporaryMongoDbDocumentTests.cs
@@ -9,7 +9,6 @@ using Xunit;
 
 namespace Arcus.Testing.Tests.Integration.Storage
 {
-    [Collection(TestCollections.MongoDb)]
     public class TemporaryMongoDbDocumentTests : IntegrationTest
     {
         /// <summary>

--- a/src/Arcus.Testing.Tests.Integration/Storage/TemporaryNoSqlContainerTests.cs
+++ b/src/Arcus.Testing.Tests.Integration/Storage/TemporaryNoSqlContainerTests.cs
@@ -9,7 +9,6 @@ using Xunit;
 
 namespace Arcus.Testing.Tests.Integration.Storage
 {
-    [Collection(TestCollections.NoSql)]
     public class TemporaryNoSqlContainerTests : IntegrationTest
     {
         private static string[] PartitionKeyPaths => new[]

--- a/src/Arcus.Testing.Tests.Integration/Storage/TemporaryNoSqlItemTests.cs
+++ b/src/Arcus.Testing.Tests.Integration/Storage/TemporaryNoSqlItemTests.cs
@@ -9,7 +9,6 @@ using Xunit;
 
 namespace Arcus.Testing.Tests.Integration.Storage
 {
-    [Collection(TestCollections.NoSql)]
     public class TemporaryNoSqlItemTests : IntegrationTest
     {
         /// <summary>

--- a/src/Arcus.Testing.Tests.Integration/TestCollections.cs
+++ b/src/Arcus.Testing.Tests.Integration/TestCollections.cs
@@ -1,9 +1,0 @@
-﻿namespace Arcus.Testing.Tests.Integration
-{
-    public static class TestCollections
-    {
-        public const string BlobStorage = nameof(BlobStorage);
-        public const string MongoDb = nameof(MongoDb);
-        public const string NoSql = nameof(NoSql);
-    }
-}


### PR DESCRIPTION
We placed certain storage-specific integration tests together, but the tests are written in such a way that they support parallism (case in point: the collection attribute was missing from some of them). This was added previously for a starting point, but with a mature test suite, we can remove them again.