### PR TITLE
fix(test.auth): move managed identity as an assembly test fixture

### DIFF
--- a/src/Arcus.Testing.Tests.Integration/Fixture/TemporaryManagedIdentityConnection.cs
+++ b/src/Arcus.Testing.Tests.Integration/Fixture/TemporaryManagedIdentityConnection.cs
@@ -1,45 +1,37 @@
 ﻿using System;
 using Arcus.Testing.Tests.Integration.Configuration;
-using Microsoft.Extensions.Logging;
+using Arcus.Testing.Tests.Integration.Fixture;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
+
+[assembly: AssemblyFixture(typeof(TemporaryManagedIdentityConnection))]
 
 namespace Arcus.Testing.Tests.Integration.Fixture
 {
     /// <summary>
     /// Represents a temporary managed identity authentication that is set for the duration of the test.
     /// </summary>
-    internal sealed class TemporaryManagedIdentityConnection : IDisposable
+    public sealed class TemporaryManagedIdentityConnection : IDisposable
     {
         private readonly TemporaryEnvironmentVariable[] _environmentVariables;
 
-        private TemporaryManagedIdentityConnection(TemporaryEnvironmentVariable[] environmentVariables)
-        {
-            _environmentVariables = environmentVariables;
-        }
-
         /// <summary>
-        /// Creates a new <see cref="TemporaryManagedIdentityConnection"/> instance for a specific <paramref name="configuration"/>
-        /// using the current registration of the service principal.
+        /// Initializes a new instance of the <see cref="TemporaryManagedIdentityConnection"/> class.
         /// </summary>
-        public static TemporaryManagedIdentityConnection Create(TestConfig configuration, ILogger logger)
+        public TemporaryManagedIdentityConnection()
         {
-            ArgumentNullException.ThrowIfNull(configuration);
-            logger ??= NullLogger.Instance;
+            var configuration = TestConfig.Create();
+            var logger = NullLogger.Instance;
 
             ServicePrincipal servicePrincipal = configuration.GetServicePrincipal();
-            if (servicePrincipal.IsDefault)
-            {
-                logger.LogTrace("[Test:Setup] no local service principal was registered in the test configuration 'appsettings.*.json', which means managed identity relies on local authenticated sessions (ex. VisualStudio account, Azure CLI...)");
-                return new TemporaryManagedIdentityConnection([]);
-            }
-
-            return new TemporaryManagedIdentityConnection(
-            [
-                TemporaryEnvironmentVariable.SetSecretIfNotExists("AZURE_TENANT_ID", servicePrincipal.TenantId, logger),
-                TemporaryEnvironmentVariable.SetSecretIfNotExists("AZURE_CLIENT_ID", servicePrincipal.ClientId, logger),
-                TemporaryEnvironmentVariable.SetSecretIfNotExists("AZURE_CLIENT_SECRET", servicePrincipal.ClientSecret, logger)
-            ]);
+            _environmentVariables = servicePrincipal.IsDefault
+                ? []
+                :
+                [
+                    TemporaryEnvironmentVariable.SetSecretIfNotExists("AZURE_TENANT_ID", servicePrincipal.TenantId, logger),
+                    TemporaryEnvironmentVariable.SetSecretIfNotExists("AZURE_CLIENT_ID", servicePrincipal.ClientId, logger),
+                    TemporaryEnvironmentVariable.SetSecretIfNotExists("AZURE_CLIENT_SECRET", servicePrincipal.ClientSecret, logger)
+                ];
         }
 
         /// <summary>

--- a/src/Arcus.Testing.Tests.Integration/Integration/DataFactory/RunDataFlowTests.cs
+++ b/src/Arcus.Testing.Tests.Integration/Integration/DataFactory/RunDataFlowTests.cs
@@ -6,7 +6,6 @@ using System.Text.Json.Nodes;
 using System.Threading.Tasks;
 using Arcus.Testing.Tests.Core.Assert_.Fixture;
 using Arcus.Testing.Tests.Core.Integration.DataFactory;
-using Arcus.Testing.Tests.Integration.Fixture;
 using Arcus.Testing.Tests.Integration.Integration.DataFactory.Fixture;
 using Azure.Core;
 using Azure.Identity;
@@ -274,7 +273,6 @@ namespace Arcus.Testing.Tests.Integration.Integration.DataFactory
     public class DataFactoryDebugSession : IAsyncLifetime
     {
         private readonly TestConfig _config;
-        private TemporaryManagedIdentityConnection _connection;
         private static readonly Faker Bogus = new();
 
         /// <summary>
@@ -298,8 +296,6 @@ namespace Arcus.Testing.Tests.Integration.Integration.DataFactory
         /// </summary>
         public async ValueTask InitializeAsync()
         {
-            _connection = TemporaryManagedIdentityConnection.Create(_config, NullLogger.Instance);
-
             DataFactoryConfig dataFactory = _config.GetDataFactory();
             Guid unknownSessionId = Guid.NewGuid();
 
@@ -360,8 +356,6 @@ namespace Arcus.Testing.Tests.Integration.Integration.DataFactory
                     await ShouldNotFindActiveSessionAsync(SessionId);
                 }));
             }
-
-            disposables.Add(_connection);
         }
     }
 }

--- a/src/Arcus.Testing.Tests.Integration/Integration/DataFactory/TemporaryDataFlowDebugSessionTests.cs
+++ b/src/Arcus.Testing.Tests.Integration/Integration/DataFactory/TemporaryDataFlowDebugSessionTests.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Threading.Tasks;
-using Arcus.Testing.Tests.Integration.Fixture;
 using Azure.Core;
 using Xunit;
 
@@ -48,8 +47,6 @@ namespace Arcus.Testing.Tests.Integration.Integration.DataFactory
         public async Task StartDebugSession_DisposeTwice_SucceedsByBeingRedundant()
         {
             // Arrange
-            using var connection = TemporaryManagedIdentityConnection.Create(Configuration, Logger);
-
             DataFactoryConfig dataFactory = Configuration.GetDataFactory();
             ResourceIdentifier resourceId = dataFactory.ResourceId;
             var session = await TemporaryDataFlowDebugSession.StartDebugSessionAsync(resourceId, Logger);

--- a/src/Arcus.Testing.Tests.Integration/Messaging/Fixture/ServiceBusTestContext.cs
+++ b/src/Arcus.Testing.Tests.Integration/Messaging/Fixture/ServiceBusTestContext.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Threading.Tasks;
-using Arcus.Testing.Tests.Integration.Fixture;
 using Arcus.Testing.Tests.Integration.Messaging.Configuration;
 using Azure.Identity;
 using Azure.Messaging.ServiceBus;
@@ -20,7 +19,6 @@ namespace Arcus.Testing.Tests.Integration.Messaging.Fixture
     /// </summary>
     internal class ServiceBusTestContext : IAsyncDisposable
     {
-        private readonly TemporaryManagedIdentityConnection _connection;
         private readonly ServiceBusAdministrationClient _adminClient;
         private readonly ServiceBusClient _messagingClient;
         private readonly Collection<string> _topicNames = new(), _queueNames = new();
@@ -31,12 +29,10 @@ namespace Arcus.Testing.Tests.Integration.Messaging.Fixture
         private static readonly Faker Bogus = new();
 
         private ServiceBusTestContext(
-            TemporaryManagedIdentityConnection connection,
             ServiceBusAdministrationClient adminClient,
             ServiceBusClient messagingClient,
             ILogger logger)
         {
-            _connection = connection;
             _adminClient = adminClient;
             _messagingClient = messagingClient;
             _logger = logger;
@@ -49,12 +45,11 @@ namespace Arcus.Testing.Tests.Integration.Messaging.Fixture
         {
             ServiceBusNamespace serviceBus = config.GetServiceBus();
 
-            var connection = TemporaryManagedIdentityConnection.Create(config, logger);
             var credential = new DefaultAzureCredential();
             var adminClient = new ServiceBusAdministrationClient(serviceBus.HostName, credential);
             var messagingClient = new ServiceBusClient(serviceBus.HostName, credential);
 
-            return new ServiceBusTestContext(connection, adminClient, messagingClient, logger);
+            return new ServiceBusTestContext(adminClient, messagingClient, logger);
         }
 
         /// <summary>
@@ -387,7 +382,6 @@ namespace Arcus.Testing.Tests.Integration.Messaging.Fixture
             })));
 
             disposables.Add(_messagingClient);
-            disposables.Add(_connection);
         }
     }
 }

--- a/src/Arcus.Testing.Tests.Integration/Storage/Fixture/NoSqlTestContext.cs
+++ b/src/Arcus.Testing.Tests.Integration/Storage/Fixture/NoSqlTestContext.cs
@@ -2,7 +2,6 @@
 using System.Collections.ObjectModel;
 using System.Net;
 using System.Threading.Tasks;
-using Arcus.Testing.Tests.Integration.Fixture;
 using Azure;
 using Azure.Identity;
 using Azure.ResourceManager;
@@ -32,20 +31,17 @@ namespace Arcus.Testing.Tests.Integration.Storage.Fixture
     /// </summary>
     public class NoSqlTestContext : IAsyncDisposable
     {
-        private readonly TemporaryManagedIdentityConnection _connection;
         private readonly CosmosDbConfig _config;
         private readonly CosmosClient _client;
         private readonly Collection<string> _containerNames = new();
         private readonly ILogger _logger;
 
         private NoSqlTestContext(
-            TemporaryManagedIdentityConnection connection,
             CosmosClient client,
             Database database,
             CosmosDbConfig config,
             ILogger logger)
         {
-            _connection = connection;
             _config = config;
             _client = client;
             Database = database;
@@ -62,13 +58,12 @@ namespace Arcus.Testing.Tests.Integration.Storage.Fixture
         /// </summary>
         public static NoSqlTestContext Given(TestConfig config, ILogger logger)
         {
-            var connection = TemporaryManagedIdentityConnection.Create(config, logger);
             CosmosDbConfig noSql = config.GetNoSql();
 
             var client = new CosmosClient(noSql.AccountEndpoint.ToString(), new DefaultAzureCredential());
             Database database = client.GetDatabase(noSql.DatabaseName);
 
-            return new NoSqlTestContext(connection, client, database, noSql, logger);
+            return new NoSqlTestContext(client, database, noSql, logger);
         }
 
         /// <summary>
@@ -236,7 +231,6 @@ namespace Arcus.Testing.Tests.Integration.Storage.Fixture
                     // Ignore when the client is not active anymore.
                 }
             }));
-            disposables.Add(_connection);
         }
     }
 }

--- a/src/Arcus.Testing.Tests.Integration/Storage/Fixture/TableStorageTestContext.cs
+++ b/src/Arcus.Testing.Tests.Integration/Storage/Fixture/TableStorageTestContext.cs
@@ -2,7 +2,6 @@
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Threading.Tasks;
-using Arcus.Testing.Tests.Integration.Fixture;
 using Arcus.Testing.Tests.Integration.Storage.Configuration;
 using Azure;
 using Azure.Data.Tables;
@@ -19,7 +18,6 @@ namespace Arcus.Testing.Tests.Integration.Storage.Fixture
     /// </summary>
     public class TableStorageTestContext : IAsyncDisposable
     {
-        private readonly TemporaryManagedIdentityConnection _connection;
         private readonly Collection<string> _tableNames = new();
         private readonly TableServiceClient _serviceClient;
         private readonly ILogger _logger;
@@ -27,11 +25,9 @@ namespace Arcus.Testing.Tests.Integration.Storage.Fixture
         private static readonly Faker Bogus = new();
 
         private TableStorageTestContext(
-            TemporaryManagedIdentityConnection connection,
             TableServiceClient serviceClient,
             ILogger logger)
         {
-            _connection = connection;
             _serviceClient = serviceClient;
             _logger = logger;
         }
@@ -41,14 +37,12 @@ namespace Arcus.Testing.Tests.Integration.Storage.Fixture
         /// </summary>
         public static Task<TableStorageTestContext> GivenAsync(TestConfig configuration, ILogger logger)
         {
-            var connection = TemporaryManagedIdentityConnection.Create(configuration, logger);
-
             StorageAccount storageAccount = configuration.GetStorageAccount();
             var serviceClient = new TableServiceClient(
                 new Uri($"https://{storageAccount.Name}.table.core.windows.net"),
                 new DefaultAzureCredential());
 
-            return Task.FromResult(new TableStorageTestContext(connection, serviceClient, logger));
+            return Task.FromResult(new TableStorageTestContext(serviceClient, logger));
         }
 
         /// <summary>
@@ -186,8 +180,6 @@ namespace Arcus.Testing.Tests.Integration.Storage.Fixture
                     await _serviceClient.DeleteTableAsync(tableName);
                 });
             }));
-
-            disposables.Add(_connection);
         }
     }
 }


### PR DESCRIPTION
Due to the full parallelization of the integration tests (see #476), we need to make sure that there are no shared test fixtures across the tests. It turns out that we have configured a managed identity connection for each test context, and since this is pointing to the same service principal, it could happen that it gets teared down while another test still needs it.

This PR moves the managed identity test fixture to an assembly test fixture, so that authentication is configured once and shared across the tests.