### PR TITLE
fix(deps): correct package ranges for including .NET 10-supported dependencies

### DIFF
--- a/src/Arcus.Testing.Core/Arcus.Testing.Core.csproj
+++ b/src/Arcus.Testing.Core/Arcus.Testing.Core.csproj
@@ -30,8 +30,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="[8.*,10.0.0)" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="[8.*,10.0.0)" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="[8.*,11.0.0)" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="[8.*,11.0.0)" />
     <PackageReference Include="Polly" Version="[8.*,9.0.0)" />
   </ItemGroup>
 

--- a/src/Arcus.Testing.Integration.DataFactory/Arcus.Testing.Integration.DataFactory.csproj
+++ b/src/Arcus.Testing.Integration.DataFactory/Arcus.Testing.Integration.DataFactory.csproj
@@ -31,7 +31,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="[1.*,2.0.0)" />
     <PackageReference Include="Azure.ResourceManager.DataFactory" Version="[1.*,2.0.0)" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="[8.*,10.0.0)" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="[8.*,11.0.0)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Arcus.Testing.Logging.MSTest/Arcus.Testing.Logging.MSTest.csproj
+++ b/src/Arcus.Testing.Logging.MSTest/Arcus.Testing.Logging.MSTest.csproj
@@ -33,7 +33,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="[8.*,10.0.0)" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="[8.*,11.0.0)" />
     <PackageReference Include="MSTest.TestFramework" Version="[3.*,5.0.0)" />
   </ItemGroup>
 

--- a/src/Arcus.Testing.Logging.NUnit/Arcus.Testing.Logging.NUnit.csproj
+++ b/src/Arcus.Testing.Logging.NUnit/Arcus.Testing.Logging.NUnit.csproj
@@ -33,7 +33,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="[8.*,10.0.0)" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="[8.*,11.0.0)" />
   </ItemGroup>
 
 </Project>

--- a/src/Arcus.Testing.Logging.Xunit.v3/Arcus.Testing.Logging.Xunit.v3.csproj
+++ b/src/Arcus.Testing.Logging.Xunit.v3/Arcus.Testing.Logging.Xunit.v3.csproj
@@ -29,7 +29,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="[8.*,10.0.0)" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="[8.*,11.0.0)" />
     <PackageReference Include="xunit.v3.extensibility.core" Version="[2.*,4.0.0)" />
   </ItemGroup>
 

--- a/src/Arcus.Testing.Logging.Xunit/Arcus.Testing.Logging.Xunit.csproj
+++ b/src/Arcus.Testing.Logging.Xunit/Arcus.Testing.Logging.Xunit.csproj
@@ -33,7 +33,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="[8.*,10.0.0)" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="[8.*,11.0.0)" />
     <PackageReference Include="xunit.abstractions" Version="2.0.3" />
   </ItemGroup>
 


### PR DESCRIPTION
We should broaden our package range to include also the .NET 10-supported packages, otherwise the upgrade does not fully work.
Relates to #88 