### PR TITLE
docs(v2.2): use 'main' io 'master' in v2.2 index page

### DIFF
--- a/docs/versioned_docs/version-v2.2.0/01-index.md
+++ b/docs/versioned_docs/version-v2.2.0/01-index.md
@@ -29,4 +29,4 @@ See our dedicated [getting started](02-getting-started.md) page to take your fir
 # License
 This is licensed under The MIT License (MIT). Which means that you can use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the web application. But you always need to state that Codit is the original author of this web application.
 
-_[Full license here](https://github.com/arcus-azure/arcus.testing/blob/master/LICENSE)_
+_[Full license here](https://github.com/arcus-azure/arcus.testing/blob/main/LICENSE)_


### PR DESCRIPTION
Use the more inclusive 'main' on the v2.2 index page.
Relates to #481 