### PR TITLE
chore(deps): apply warning recommendations for most-recent deps versions

### DIFF
--- a/src/Arcus.Testing.Core/ResourceDirectory.cs
+++ b/src/Arcus.Testing.Core/ResourceDirectory.cs
@@ -80,7 +80,7 @@ namespace Arcus.Testing
         /// <exception cref="FileNotFoundException">
         ///     Thrown when there exists no test resource file in the current test resource directory with the given <paramref name="fileName"/>.
         /// </exception>
-        [Obsolete("Will be removed in v3.0, please use " + nameof(ReadFileText) + " instead")]
+        [Obsolete("Will be removed in v3.0, please use " + nameof(ReadFileText) + " instead", DiagnosticId = "ARCUS")]
         public string ReadFileTextByName(string fileName)
         {
             return ReadFileText(fileName);
@@ -98,7 +98,7 @@ namespace Arcus.Testing
         /// <exception cref="FileNotFoundException">
         ///     Thrown when there exists no test resource file in the current test resource directory with the given <paramref name="searchPattern"/>.
         /// </exception>
-        [Obsolete("Will be removed in v3.0, please use " + nameof(ReadFileText) + " instead")]
+        [Obsolete("Will be removed in v3.0, please use " + nameof(ReadFileText) + " instead", DiagnosticId = "ARCUS")]
         public string ReadFileTextByPattern(string searchPattern)
         {
             return ReadFileText(searchPattern);
@@ -138,7 +138,7 @@ namespace Arcus.Testing
         /// <exception cref="FileNotFoundException">
         ///     Thrown when there exists no test resource file in the current test resource directory with the given <paramref name="fileName"/>.
         /// </exception>
-        [Obsolete("Will be removed in v3.0, please use " + nameof(ReadFileBytes) + " instead")]
+        [Obsolete("Will be removed in v3.0, please use " + nameof(ReadFileBytes) + " instead", DiagnosticId = "ARCUS")]
         public byte[] ReadFileBytesByName(string fileName)
         {
             return ReadFileBytes(fileName);
@@ -156,7 +156,7 @@ namespace Arcus.Testing
         /// <exception cref="FileNotFoundException">
         ///     Thrown when there exists no test resource file in the current test resource directory with the given <paramref name="searchPattern"/>.
         /// </exception>
-        [Obsolete("Will be removed in v3.0, please use " + nameof(ReadFileBytes) + " instead")]
+        [Obsolete("Will be removed in v3.0, please use " + nameof(ReadFileBytes) + " instead", DiagnosticId = "ARCUS")]
         public byte[] ReadFileBytesByPattern(string searchPattern)
         {
             return ReadFileBytes(searchPattern);

--- a/src/Arcus.Testing.Storage.Blob/TemporaryBlobContainer.cs
+++ b/src/Arcus.Testing.Storage.Blob/TemporaryBlobContainer.cs
@@ -117,7 +117,7 @@ namespace Arcus.Testing
         /// (default for cleaning blobs) Configures the <see cref="TemporaryBlobContainer"/> to only delete the Azure Blobs upon disposal
         /// if the blob was upserted by the test fixture (using <see cref="TemporaryBlobContainer.UpsertBlobFileAsync"/>).
         /// </summary>
-        [Obsolete("Will be removed in v3, please use " + nameof(CleanUpsertedBlobs) + " instead that provides exactly the same on-teardown functionality")]
+        [Obsolete("Will be removed in v3, please use " + nameof(CleanUpsertedBlobs) + " instead that provides exactly the same on-teardown functionality", DiagnosticId = "ARCUS")]
         public OnTeardownBlobContainerOptions CleanCreatedBlobs()
         {
             return CleanUpsertedBlobs();
@@ -363,7 +363,7 @@ namespace Arcus.Testing
         /// <param name="blobContent">The content of the blob to upload.</param>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="blobName"/> is blank.</exception>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="blobContent"/> is <c>null</c>.</exception>
-        [Obsolete("Will be removed in v3, please use the " + nameof(UpsertBlobFileAsync) + "instead that provides exactly the same functionality")]
+        [Obsolete("Will be removed in v3, please use the " + nameof(UpsertBlobFileAsync) + "instead that provides exactly the same functionality", DiagnosticId = "ARCUS")]
         public Task<BlobClient> UploadBlobAsync(string blobName, BinaryData blobContent)
         {
             return UpsertBlobFileAsync(blobName, blobContent);

--- a/src/Arcus.Testing.Storage.Blob/TemporaryBlobFile.cs
+++ b/src/Arcus.Testing.Storage.Blob/TemporaryBlobFile.cs
@@ -62,7 +62,7 @@ namespace Arcus.Testing
         /// <param name="logger">The logger to write diagnostic messages during the upload process.</param>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="blobContainerUri"/> or the <paramref name="blobName"/> is blank.</exception>
         /// <exception cref="ArgumentNullException">Thrown when <paramref name="blobContainerUri"/> or the <paramref name="blobContent"/> is <c>null</c>.</exception>
-        [Obsolete("Will be removed in v3.0, please use the " + nameof(UpsertFileAsync) + " instead which provides the exact same functionality")]
+        [Obsolete("Will be removed in v3.0, please use the " + nameof(UpsertFileAsync) + " instead which provides the exact same functionality", DiagnosticId = "ARCUS")]
         public static Task<TemporaryBlobFile> UploadIfNotExistsAsync(Uri blobContainerUri, string blobName, BinaryData blobContent, ILogger logger)
         {
             return UpsertFileAsync(blobContainerUri, blobName, blobContent, logger);
@@ -75,7 +75,7 @@ namespace Arcus.Testing
         /// <param name="blobContent">The content of the blob to upload.</param>
         /// <param name="logger">The logger to write diagnostic messages during the upload process.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="blobClient"/> or the <paramref name="blobContent"/> is <c>null</c>.</exception>
-        [Obsolete("Will be removed in v3.0, please use the " + nameof(UpsertFileAsync) + " instead which provides the exact same functionality")]
+        [Obsolete("Will be removed in v3.0, please use the " + nameof(UpsertFileAsync) + " instead which provides the exact same functionality", DiagnosticId = "ARCUS")]
         public static Task<TemporaryBlobFile> UploadIfNotExistsAsync(BlobClient blobClient, BinaryData blobContent, ILogger logger)
         {
             return UpsertFileAsync(blobClient, blobContent, logger);

--- a/src/Arcus.Testing.Storage.Cosmos/TemporaryMongoDbCollection.cs
+++ b/src/Arcus.Testing.Storage.Cosmos/TemporaryMongoDbCollection.cs
@@ -120,7 +120,7 @@ namespace Arcus.Testing
         /// in an Azure Cosmos DB for MongoDB collection upon disposal if the document was inserted by the test fixture
         /// (using <see cref="TemporaryMongoDbCollection.UpsertDocumentAsync{TDocument}"/>).
         /// </summary>
-        [Obsolete("Will be removed in v3, please use the " + nameof(CleanUpsertedDocuments) + "instead that provides exactly the same functionality")]
+        [Obsolete("Will be removed in v3, please use the " + nameof(CleanUpsertedDocuments) + "instead that provides exactly the same functionality", DiagnosticId = "ARCUS")]
         public OnTeardownMongoDbCollectionOptions CleanCreatedDocuments()
         {
             return CleanUpsertedDocuments();
@@ -438,7 +438,7 @@ namespace Arcus.Testing
         /// <typeparam name="TDocument">The type of the document in the MongoDB collection.</typeparam>
         /// <param name="document">The document to upload to the MongoDB collection.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="document"/> is <c>null</c>.</exception>
-        [Obsolete("Will be removed in v3, please use the " + nameof(UpsertDocumentAsync) + "instead that provides exactly the same functionality")]
+        [Obsolete("Will be removed in v3, please use the " + nameof(UpsertDocumentAsync) + "instead that provides exactly the same functionality", DiagnosticId = "ARCUS")]
         public Task AddDocumentAsync<TDocument>(TDocument document)
         {
             return UpsertDocumentAsync(document);

--- a/src/Arcus.Testing.Storage.Cosmos/TemporaryNoSqlContainer.cs
+++ b/src/Arcus.Testing.Storage.Cosmos/TemporaryNoSqlContainer.cs
@@ -15,6 +15,7 @@ using Microsoft.Azure.Cosmos;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using static Arcus.Testing.NoSqlExtraction;
+using PartitionKey = Microsoft.Azure.Cosmos.PartitionKey;
 
 namespace Arcus.Testing
 {
@@ -179,7 +180,7 @@ namespace Arcus.Testing
         /// (default for cleaning items) Configures the <see cref="TemporaryNoSqlContainer"/> to only delete the NoSQL items
         /// in an Azure Cosmos DB for NoSQL container upon disposal if the item was upserted by the test fixture (using <see cref="TemporaryNoSqlContainer.AddItemAsync{TItem}"/>).
         /// </summary>
-        [Obsolete("Will be removed in v3, please use " + nameof(CleanUpsertedItems) + " instead that provides exactly the same on-teardown functionality")]
+        [Obsolete("Will be removed in v3, please use " + nameof(CleanUpsertedItems) + " instead that provides exactly the same on-teardown functionality", DiagnosticId = "ARCUS")]
         public OnTeardownNoSqlContainerOptions CleanCreatedItems()
         {
             return CleanUpsertedItems();
@@ -620,7 +621,7 @@ namespace Arcus.Testing
         /// <typeparam name="T">The custom NoSQL model.</typeparam>
         /// <param name="item">The item to create in the NoSQL container.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="item"/> is <c>null</c>.</exception>
-        [Obsolete("Will be removed in v3, please use the " + nameof(UpsertItemAsync) + "instead that provides exactly the same functionality")]
+        [Obsolete("Will be removed in v3, please use the " + nameof(UpsertItemAsync) + "instead that provides exactly the same functionality", DiagnosticId = "ARCUS")]
         public Task AddItemAsync<T>(T item)
         {
             return UpsertItemAsync(item);
@@ -684,50 +685,42 @@ namespace Arcus.Testing
                 return;
             }
 
-            if (_options.OnTeardown.Items is OnTeardownNoSqlContainer.CleanAll)
+            await ForEachItemAsync((id, partitionKey, doc) =>
             {
-                await ForEachItemAsync((id, partitionKey, _) =>
+                disposables.Add(AsyncDisposable.Create(async () =>
                 {
-                    disposables.Add(AsyncDisposable.Create(async () =>
+                    switch (_options.OnTeardown.Items)
                     {
-                        _logger.LogTeardownDeleteItem(id, partitionKey, Client.Database.Id, Client.Id);
-                        using ResponseMessage response = await Client.DeleteItemStreamAsync(id, partitionKey).ConfigureAwait(false);
+                        case OnTeardownNoSqlContainer.CleanAll:
+                            _logger.LogTeardownDeleteItem(id, partitionKey, Client.Database.Id, Client.Id);
+                            await DeleteItemAsync(id, partitionKey).ConfigureAwait(false);
+                            break;
 
-                        if (!response.IsSuccessStatusCode && response.StatusCode != HttpStatusCode.NotFound)
-                        {
-                            throw new RequestFailedException((int) response.StatusCode,
-                                $"[Test:Teardown] Failed to delete NoSQL item '{id}' {partitionKey} in Azure Cosmos DB for NoSQL container '{Client.Database.Id}/{Client.Id}' " +
-                                $"since the delete operation responded with a failure: {(int) response.StatusCode} {response.StatusCode}: {response.ErrorMessage}");
-                        }
-                    }));
-
-                    return Task.CompletedTask;
-
-                }).ConfigureAwait(false);
-            }
-            else if (_options.OnTeardown.Items is OnTeardownNoSqlContainer.CleanIfMatched)
-            {
-                await ForEachItemAsync((id, partitionKey, doc) =>
-                {
-                    disposables.Add(AsyncDisposable.Create(async () =>
-                    {
-                        if (_options.OnTeardown.IsMatched(id, partitionKey, doc, Client.Database.Client))
-                        {
+                        case OnTeardownNoSqlContainer.CleanIfMatched when _options.OnTeardown.IsMatched(id, partitionKey, doc, Client.Database.Client):
                             _logger.LogTeardownDeleteMatchedItem(id, partitionKey, Client.Database.Id, Client.Id);
-                            using ResponseMessage response = await Client.DeleteItemStreamAsync(id, partitionKey).ConfigureAwait(false);
+                            await DeleteItemAsync(id, partitionKey).ConfigureAwait(false);
+                            break;
 
-                            if (!response.IsSuccessStatusCode && response.StatusCode != HttpStatusCode.NotFound)
-                            {
-                                throw new RequestFailedException((int) response.StatusCode,
-                                    $"[Test:Teardown] Failed to delete matched NoSQL item '{id}' {partitionKey} in Azure Cosmos DB for NoSQL container '{Client.Database.Id}/{Client.Id}' " +
-                                    $"since the delete operation responded with a failure: {(int) response.StatusCode} {response.StatusCode}: {response.ErrorMessage}");
-                            }
-                        }
-                    }));
+                        case OnTeardownNoSqlContainer.CleanIfUpserted:
+                        default:
+                            break;
+                    }
+                }));
 
-                    return Task.CompletedTask;
+                return Task.CompletedTask;
 
-                }).ConfigureAwait(false);
+            }).ConfigureAwait(false);
+        }
+
+        private async Task DeleteItemAsync(string id, PartitionKey partitionKey)
+        {
+            using ResponseMessage response = await Client.DeleteItemStreamAsync(id, partitionKey).ConfigureAwait(false);
+
+            if (!response.IsSuccessStatusCode && response.StatusCode != HttpStatusCode.NotFound)
+            {
+                throw new RequestFailedException((int) response.StatusCode,
+                    $"[Test:Teardown] Failed to delete NoSQL item '{id}' {partitionKey} in Azure Cosmos DB for NoSQL container '{Client.Database.Id}/{Client.Id}' " +
+                    $"since the delete operation responded with a failure: {(int) response.StatusCode} {response.StatusCode}: {response.ErrorMessage}");
             }
         }
 

--- a/src/Arcus.Testing.Storage.Cosmos/TemporaryNoSqlItem.cs
+++ b/src/Arcus.Testing.Storage.Cosmos/TemporaryNoSqlItem.cs
@@ -65,7 +65,7 @@ namespace Arcus.Testing
         /// <param name="item">The item to temporary create in the NoSQL container.</param>
         /// <param name="logger">The logger instance to write diagnostic information during the lifetime of the test fixture.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="container"/> is <c>null</c>.</exception>
-        [Obsolete("Will be removed in v3.0, please use the " + nameof(UpsertItemAsync) + " instead which provides the exact same functionality")]
+        [Obsolete("Will be removed in v3.0, please use the " + nameof(UpsertItemAsync) + " instead which provides the exact same functionality", DiagnosticId = "ARCUS")]
         public static Task<TemporaryNoSqlItem> InsertIfNotExistsAsync<TItem>(Container container, TItem item, ILogger logger)
         {
             return UpsertItemAsync(container, item, logger);

--- a/src/Arcus.Testing.Storage.Table/TemporaryTable.cs
+++ b/src/Arcus.Testing.Storage.Table/TemporaryTable.cs
@@ -103,7 +103,7 @@ namespace Arcus.Testing
         /// (default for cleaning documents) Configures the <see cref="TemporaryTable"/> to only delete the Azure Table entities upon disposal
         /// if the document was inserted by the test fixture (using <see cref="TemporaryTable.UpsertEntityAsync{TEntity}"/>).
         /// </summary>
-        [Obsolete("Will be removed in v3.0, please use the " + nameof(CleanUpsertedEntities) + " instead that provides exactly the same functionality")]
+        [Obsolete("Will be removed in v3.0, please use the " + nameof(CleanUpsertedEntities) + " instead that provides exactly the same functionality", DiagnosticId = "ARCUS")]
         public OnTeardownTemporaryTableOptions CleanCreatedEntities()
         {
             return CleanUpsertedEntities();
@@ -356,7 +356,7 @@ namespace Arcus.Testing
         /// <typeparam name="TEntity">A custom model type that implements <see cref="ITableEntity" /> or an instance of <see cref="TableEntity" />.</typeparam>
         /// <param name="entity">The entity to temporary add to the table.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="entity"/> is <c>null</c>.</exception>
-        [Obsolete("Will be removed in v3.0, please use the " + nameof(UpsertEntityAsync) + " instead that provides exactly the same functionality")]
+        [Obsolete("Will be removed in v3.0, please use the " + nameof(UpsertEntityAsync) + " instead that provides exactly the same functionality", DiagnosticId = "ARCUS")]
         public Task AddEntityAsync<TEntity>(TEntity entity) where TEntity : class, ITableEntity
         {
             return UpsertEntityAsync(entity);

--- a/src/Arcus.Testing.Storage.Table/TemporaryTableEntity.cs
+++ b/src/Arcus.Testing.Storage.Table/TemporaryTableEntity.cs
@@ -51,7 +51,7 @@ namespace Arcus.Testing
         /// <exception cref="ArgumentException">Thrown when the <paramref name="accountName"/> or the <paramref name="tableName"/> is blank.</exception>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="entity"/> is <c>null</c>.</exception>
 #pragma warning disable S1133 // Will be removed in v3.0.
-        [Obsolete("Will be removed in v3.0, please use the " + nameof(UpsertEntityAsync) + " instead which provides exactly the same functionality")]
+        [Obsolete("Will be removed in v3.0, please use the " + nameof(UpsertEntityAsync) + " instead which provides exactly the same functionality", DiagnosticId = "ARCUS")]
 #pragma warning restore S1133
         public static Task<TemporaryTableEntity> AddIfNotExistsAsync<TEntity>(
             string accountName,
@@ -72,7 +72,7 @@ namespace Arcus.Testing
         /// <param name="logger">The logger instance to write diagnostic information during the lifetime of the test fixture.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="client"/> or the <paramref name="entity"/> is <c>null</c>.</exception>
 #pragma warning disable S1133 // Will be removed in v3.0.
-        [Obsolete("Will be removed in v3.0, please use the " + nameof(UpsertEntityAsync) + " instead which provides exactly the same functionality")]
+        [Obsolete("Will be removed in v3.0, please use the " + nameof(UpsertEntityAsync) + " instead which provides exactly the same functionality", DiagnosticId = "ARCUS")]
 #pragma warning restore S1133
         public static Task<TemporaryTableEntity> AddIfNotExistsAsync<TEntity>(TableClient client, TEntity entity, ILogger logger) where TEntity : class, ITableEntity
         {

--- a/src/Arcus.Testing.Tests.Integration/Arcus.Testing.Tests.Integration.csproj
+++ b/src/Arcus.Testing.Tests.Integration/Arcus.Testing.Tests.Integration.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <IsPackable>false</IsPackable>
+    <NoWarn>ARCUS</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
@@ -13,7 +14,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.*" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.*" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.*" />
     <PackageReference Include="xunit.v3" Version="3.*" Aliases="XunitV3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.*">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Arcus.Testing.Tests.Unit/Arcus.Testing.Tests.Unit.csproj
+++ b/src/Arcus.Testing.Tests.Unit/Arcus.Testing.Tests.Unit.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <IsPackable>false</IsPackable>
-      <NoWarn>CA2007<!-- unit tests do not have a synchronization context, only sync 'hidden' as async --></NoWarn>
+      <NoWarn>ARCUS;CA2007<!-- unit tests do not have a synchronization context, only sync 'hidden' as async --></NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
@@ -15,7 +15,7 @@
     </PackageReference>
     <PackageReference Include="FsCheck" Version="3.*" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.*" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.*" />
     <PackageReference Include="Moq" Version="4.*" />
     <PackageReference Include="MSTest.TestFramework" Version="3.*" />
     <PackageReference Include="xunit.v3" Version="3.*" />

--- a/src/Arcus.Testing.sln
+++ b/src/Arcus.Testing.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 17
-VisualStudioVersion = 17.3.32825.248
+# Visual Studio Version 18
+VisualStudioVersion = 18.0.11217.181 d18.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Arcus.Testing.Tests.Integration", "Arcus.Testing.Tests.Integration\Arcus.Testing.Tests.Integration.csproj", "{4DCD1626-66B4-4396-9CD6-951E9CE7BDE8}"
 EndProject
@@ -12,10 +12,6 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Arcus.Testing.Core", "Arcus.Testing.Core\Arcus.Testing.Core.csproj", "{AD55A0DA-693C-4336-99D8-A0386574A522}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Arcus.Testing.Assert", "Arcus.Testing.Assert\Arcus.Testing.Assert.csproj", "{014C45A4-1899-4486-88B0-7503AFE694EB}"
-EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Samples", "Samples", "{057BBCFA-D72F-473E-AB38-5A628A47D56D}"
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Arcus.Testing.Sample.TestingFrameworkMigration", "..\samples\Arcus.Testing.Sample.TestingFrameworkMigration\Arcus.Testing.Sample.TestingFrameworkMigration.csproj", "{19A63ECA-029D-46B3-A252-445570AD7D82}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Arcus.Testing.Logging.MSTest", "Arcus.Testing.Logging.MSTest\Arcus.Testing.Logging.MSTest.csproj", "{50163460-A494-4C02-B6BC-30A0DE46BABE}"
 EndProject
@@ -74,8 +70,6 @@ Global
 		{014C45A4-1899-4486-88B0-7503AFE694EB}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{014C45A4-1899-4486-88B0-7503AFE694EB}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{014C45A4-1899-4486-88B0-7503AFE694EB}.Release|Any CPU.Build.0 = Release|Any CPU
-		{19A63ECA-029D-46B3-A252-445570AD7D82}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{19A63ECA-029D-46B3-A252-445570AD7D82}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{50163460-A494-4C02-B6BC-30A0DE46BABE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{50163460-A494-4C02-B6BC-30A0DE46BABE}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{50163460-A494-4C02-B6BC-30A0DE46BABE}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -127,7 +121,6 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{4DCD1626-66B4-4396-9CD6-951E9CE7BDE8} = {64013B91-7B1E-4F88-8FD7-CCF583D4A4CA}
 		{3D66B14F-2CC7-44E6-A53F-1E45F9A6BCF6} = {64013B91-7B1E-4F88-8FD7-CCF583D4A4CA}
-		{19A63ECA-029D-46B3-A252-445570AD7D82} = {057BBCFA-D72F-473E-AB38-5A628A47D56D}
 		{50163460-A494-4C02-B6BC-30A0DE46BABE} = {45B1870D-C19A-4680-BDD8-2F670C793BC2}
 		{122F9379-5FAD-4759-BFAB-5A437826682C} = {45B1870D-C19A-4680-BDD8-2F670C793BC2}
 		{56AF4FFB-6D1D-4C11-834B-70920BA046BD} = {45B1870D-C19A-4680-BDD8-2F670C793BC2}


### PR DESCRIPTION
Uses and apply Roslyn recommendations for the most recent versions of the Microsoft testing SDK and xUnit v3, plus make sure that we don't fall over deprecated functionality of our own in testing contexts.