### PR TITLE
fix(mongodb): remove incorrect client arg-null check in mongo db collection ctor

### DIFF
--- a/src/Arcus.Testing.Storage.Cosmos/TemporaryMongoDbCollection.cs
+++ b/src/Arcus.Testing.Storage.Cosmos/TemporaryMongoDbCollection.cs
@@ -238,7 +238,6 @@ namespace Arcus.Testing
             ILogger logger,
             TemporaryMongoDbCollectionOptions options)
         {
-            ArgumentNullException.ThrowIfNull(client);
             ArgumentNullException.ThrowIfNull(database);
             ArgumentNullException.ThrowIfNull(collectionName);
             ArgumentNullException.ThrowIfNull(options);


### PR DESCRIPTION
We should not check for `null` in the constructor of the `TemporaryMongoDbCollection`, as the client is only there in case we created the client and have to dispose it afterwards, not to be used in the collection itself.
Since the integration tests only randomized on the resource ID overloads, it didn't took these overloads into account. This PR fixes that.

Closes #492 