### PR TITLE
chore(az.fileshare): add cancellation token support for Azure Files test fixtures

### DIFF
--- a/docs/preview/03-Features/04-Azure/04-Storage/01-storage-account.mdx
+++ b/docs/preview/03-Features/04-Azure/04-Storage/01-storage-account.mdx
@@ -255,7 +255,7 @@ using Azure.Storage.Files.Shares;
 var shareClient = new ShareClient(...);
 
 await using var directory = await TemporaryShareDirectory.CreateIfNotExistsAsync(
-    shareClient, "<directory-name", logger);
+    shareClient, "<directory-name", logger, CancellationToken.None);
 
 // Interact with the directory during the lifetime of the fixture.
 ShareDirectoryClient client = directory.Client;
@@ -271,7 +271,7 @@ await using TemporaryShareDirectory directory = ...
 string fileName = "TestFile";
 await using Stream fileContents = File.OpenRead(...);
 
-await directory.UpsertFileAsync(fileName, fileContents);
+await directory.UpsertFileAsync(fileName, fileContents, CancellationToken.None);
 ```
 
 :::praise
@@ -335,13 +335,11 @@ The `TemporaryShareFile` provides a solution when the integration test requires 
 ```csharp
 using Arcus.Testing;
 
-ShareDirectoryClient client = ...
-
-string fileName = "TestFile";
+ShareFileClient client = ...
 await using Stream fileContents = File.OpenRead(...);
 
 await using var file = await TemporaryShareFile.UpsertFileAsync(
-    client, fileName, fileContents, logger);
+    client, fileContents, logger, CancellationToken.None);
 ```
 
 </TabItem>

--- a/docs/preview/03-Features/04-Azure/04-Storage/01-storage-account.mdx
+++ b/docs/preview/03-Features/04-Azure/04-Storage/01-storage-account.mdx
@@ -255,7 +255,7 @@ using Azure.Storage.Files.Shares;
 var shareClient = new ShareClient(...);
 
 await using var directory = await TemporaryShareDirectory.CreateIfNotExistsAsync(
-    shareClient, "<directory-name", logger, CancellationToken.None);
+    shareClient, "<directory-name", logger, cancellationToken);
 
 // Interact with the directory during the lifetime of the fixture.
 ShareDirectoryClient client = directory.Client;
@@ -271,7 +271,7 @@ await using TemporaryShareDirectory directory = ...
 string fileName = "TestFile";
 await using Stream fileContents = File.OpenRead(...);
 
-await directory.UpsertFileAsync(fileName, fileContents, CancellationToken.None);
+await directory.UpsertFileAsync(fileName, fileContents, cancellationToken);
 ```
 
 :::praise
@@ -339,7 +339,7 @@ ShareFileClient client = ...
 await using Stream fileContents = File.OpenRead(...);
 
 await using var file = await TemporaryShareFile.UpsertFileAsync(
-    client, fileContents, logger, CancellationToken.None);
+    client, fileContents, logger, cancellationToken);
 ```
 
 </TabItem>

--- a/src/Arcus.Testing.Storage.File.Share/Arcus.Testing.Storage.File.Share.csproj
+++ b/src/Arcus.Testing.Storage.File.Share/Arcus.Testing.Storage.File.Share.csproj
@@ -23,6 +23,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+      <Compile Include="..\ObsoleteDefaults.cs" Link="ObsoleteDefaults.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <None Include="..\..\README.md" Pack="true" PackagePath="\" />
     <None Include="..\..\LICENSE" Pack="true" PackagePath="\" />
     <None Include="..\..\docs\static\img\icon.png" Pack="true" PackagePath="\" />

--- a/src/Arcus.Testing.Storage.File.Share/TemporaryShareFile.cs
+++ b/src/Arcus.Testing.Storage.File.Share/TemporaryShareFile.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using Azure;
 using Azure.Storage.Files.Shares;
@@ -59,13 +60,13 @@ namespace Arcus.Testing
         /// <param name="logger">The instance to log diagnostic traces during the lifetime of the fixture.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="directoryClient"/> or the <paramref name="fileContents"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="fileName"/> is blank.</exception>
+        [Obsolete("Will be removed in v3, please use the " + nameof(UpsertFileAsync) + " overload instead that provides cancellation token support", DiagnosticId = ObsoleteDefaults.DiagnosticId)]
         public static Task<TemporaryShareFile> UpsertFileAsync(ShareDirectoryClient directoryClient, string fileName, Stream fileContents, ILogger logger)
         {
             ArgumentNullException.ThrowIfNull(directoryClient);
-            ArgumentException.ThrowIfNullOrWhiteSpace(fileName);
-
             ShareFileClient fileClient = directoryClient.GetFileClient(fileName);
-            return UpsertFileAsync(fileClient, fileContents, logger);
+
+            return UpsertFileAsync(fileClient, fileContents, logger, CancellationToken.None);
         }
 
         /// <summary>
@@ -79,19 +80,45 @@ namespace Arcus.Testing
         /// <param name="fileStream">The contents of the file to upload to the share directory.</param>
         /// <param name="logger">The instance to log diagnostic traces during the lifetime of the fixture.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="fileClient"/> or the <paramref name="fileStream"/> is <c>null</c>.</exception>
-        public static async Task<TemporaryShareFile> UpsertFileAsync(ShareFileClient fileClient, Stream fileStream, ILogger logger)
+        [Obsolete("Will be removed in v3, please use the " + nameof(UpsertFileAsync) + " overload instead that provides cancellation token support", DiagnosticId = ObsoleteDefaults.DiagnosticId)]
+        public static Task<TemporaryShareFile> UpsertFileAsync(ShareFileClient fileClient, Stream fileStream, ILogger logger)
+        {
+            return UpsertFileAsync(fileClient, fileStream, logger, CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Creates a new or replaces an existing file on an Azure Files share directory.
+        /// </summary>
+        /// <remarks>
+        ///     Make sure that the <paramref name="fileStream"/>'s <see cref="Stream.Length"/> is accessible,
+        ///     so the appropriate size can be set on the file share.
+        /// </remarks>
+        /// <param name="fileClient">The client to interact with the share file to upload to file to.</param>
+        /// <param name="fileStream">The contents of the file to upload to the share directory.</param>
+        /// <param name="logger">The instance to log diagnostic traces during the lifetime of the fixture.</param>
+        /// <param name="cancellationToken">The optional token to propagate notifications that the operation should be cancelled.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="fileClient"/> or the <paramref name="fileStream"/> is <c>null</c>.</exception>
+        /// <exception cref="RequestFailedException">Thrown when the interaction with Azure failed.</exception>
+        /// <exception cref="DirectoryNotFoundException">Thrown when the <paramref name="fileClient"/> refers to a non-existing Azure Files share directory.</exception>
+        /// <exception cref="DriveNotFoundException">Thrown when the <paramref name="fileClient"/> refers to a non-existing Azure Files share.</exception>
+        public static async Task<TemporaryShareFile> UpsertFileAsync(
+            ShareFileClient fileClient,
+            Stream fileStream,
+            ILogger logger,
+            CancellationToken cancellationToken)
         {
             ArgumentNullException.ThrowIfNull(fileClient);
             ArgumentNullException.ThrowIfNull(fileStream);
+            cancellationToken.ThrowIfCancellationRequested();
             logger ??= NullLogger.Instance;
 
-            if (await fileClient.ExistsAsync().ConfigureAwait(false))
+            if (await fileClient.ExistsAsync(cancellationToken).ConfigureAwait(false))
             {
                 logger.LogSetupReplaceExistingFile(fileClient.Name, fileClient.AccountName, fileClient.Path);
 
-                ShareFileDownloadInfo result = await fileClient.DownloadAsync().ConfigureAwait(false);
-                await fileClient.CreateAsync(fileStream.Length).ConfigureAwait(false);
-                await fileClient.UploadAsync(fileStream).ConfigureAwait(false);
+                ShareFileDownloadInfo result = await fileClient.DownloadAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
+                await fileClient.CreateAsync(fileStream.Length, cancellationToken: cancellationToken).ConfigureAwait(false);
+                await fileClient.UploadAsync(fileStream, cancellationToken: cancellationToken).ConfigureAwait(false);
 
                 return new TemporaryShareFile(fileClient, (result.Content, result.ContentLength), logger);
             }
@@ -100,8 +127,8 @@ namespace Arcus.Testing
             {
                 logger.LogSetupUploadNewFile(fileClient.Name, fileClient.AccountName, fileClient.Path);
 
-                await fileClient.CreateAsync(fileStream.Length).ConfigureAwait(false);
-                await fileClient.UploadAsync(fileStream).ConfigureAwait(false);
+                await fileClient.CreateAsync(fileStream.Length, cancellationToken: cancellationToken).ConfigureAwait(false);
+                await fileClient.UploadAsync(fileStream, cancellationToken: cancellationToken).ConfigureAwait(false);
             }
             catch (RequestFailedException exception) when (exception.ErrorCode == ShareErrorCode.ShareNotFound)
             {

--- a/src/Arcus.Testing.Tests.Integration/Storage/TemporaryShareDirectoryTests.cs
+++ b/src/Arcus.Testing.Tests.Integration/Storage/TemporaryShareDirectoryTests.cs
@@ -321,7 +321,7 @@ namespace Arcus.Testing.Tests.Integration.Storage
             _logger.LogTrace("[Test] Upload new Azure File share item '{FileName}' in directory '{AccountName}/{DirectoryPath}'", fileName, directoryClient.AccountName, directoryClient.Path);
 
             await using var contents = BinaryData.FromString(fileContents).ToStream();
-            FileClient fileClient = await directoryClient.CreateFileAsync(fileName, contents.Length, cancellationToken: _cancellationToken)
+            FileClient fileClient = await directoryClient.CreateFileAsync(fileName, contents.Length, cancellationToken: _cancellationToken);
             await fileClient.UploadAsync(contents, cancellationToken: _cancellationToken);
 
             return fileClient;

--- a/src/Arcus.Testing.Tests.Integration/Storage/TemporaryShareFileTests.cs
+++ b/src/Arcus.Testing.Tests.Integration/Storage/TemporaryShareFileTests.cs
@@ -125,7 +125,7 @@ namespace Arcus.Testing.Tests.Integration.Storage
 
         private async Task<TemporaryShareFile> WhenFileCreatedAsync(FileClient client, Stream fileStream)
         {
-            var temp = await TemporaryShareFile.UpsertFileAsync(client, fileStream, Logger);
+            var temp = await TemporaryShareFile.UpsertFileAsync(client, fileStream, Logger, TestContext.Current.CancellationToken);
 
             Assert.Equal(client.Name, temp.Client.Name);
             return temp;
@@ -133,7 +133,7 @@ namespace Arcus.Testing.Tests.Integration.Storage
 
         private async Task<FileShareTestContext> GivenFileShareAsync()
         {
-            return await FileShareTestContext.GivenAvailableAsync(Configuration, Logger);
+            return await FileShareTestContext.GivenAvailableAsync(Configuration, Logger, TestContext.Current.CancellationToken);
         }
     }
 }


### PR DESCRIPTION
Adds cancellation support for the Azure Files test fixtures so that canceling a test is faster and less overhead, while keeping teardown in place.

