### PR TITLE
chore(cosmos): add cancellation token support to cosmos test fixtures

### DIFF
--- a/docs/preview/03-Features/04-Azure/04-Storage/02-cosmos.mdx
+++ b/docs/preview/03-Features/04-Azure/04-Storage/02-cosmos.mdx
@@ -34,7 +34,7 @@ await using var collection = await TemporaryMongoDbCollection.CreateIfNotExistsA
     "<database-name>",
     "<collection-name>",
     logger,
-    CancellationToken.None);
+    cancellationToken);
 
 // Interact with the collection during the lifetime of the fixture.
 IMongoCollection<Shipment> client = collection.GetCollectionClient<Shipment>();
@@ -49,7 +49,7 @@ using Arcus.Testing;
 
 await using TemporaryMongoDbCollection collection = ...
 
-await collection.UpsertDocumentAsync(new Shipment { BoatName = "The Alice"  }, CancellationToken.None);
+await collection.UpsertDocumentAsync(new Shipment { BoatName = "The Alice"  }, cancellationToken);
 ```
 
 :::praise
@@ -126,7 +126,7 @@ await using var document = await TemporaryMongoDbDocument.UpsertDocumentAsync(
     "<collection-name>",
     shipment,
     logger,
-    CancellationToken.None);
+    cancellationToken);
 
 BsonValue documentId = document.Id;
 ```
@@ -165,7 +165,7 @@ await using var container = await TemporaryNoSqlContainer.CreateIfNotExistsAsync
     "<container-name>",
     "/partition-key-path",
     logger,
-    CancellationToken.None);
+    cancellationToken);
 
 // Interact with the container during the lifetime of the fixture.
 Container client = container.Client;
@@ -180,7 +180,7 @@ using Arcus.Testing;
 
 await using TemporaryNoSqlContainer container = ...
 
-await container.UpsertItemAsync(new Shipment { Id = "123", BoatName = "The Alice" }, CancellationToken.None);
+await container.UpsertItemAsync(new Shipment { Id = "123", BoatName = "The Alice" }, cancellationToken);
 ```
 
 :::praise
@@ -245,7 +245,7 @@ Container containerClient = ...
 var shipment = new Shipment { Id = "123", BoatName = "The Alice" };
 
 await using var item = await TemporaryNoSqlItem.UpsertItemAsync(
-    containerClient, shipment, logger, CancellationToken.None);
+    containerClient, shipment, logger, cancellationToken);
 
 string itemId = item.Id;
 PartitionKey partitionKey = item.PartitionKey;

--- a/docs/preview/03-Features/04-Azure/04-Storage/02-cosmos.mdx
+++ b/docs/preview/03-Features/04-Azure/04-Storage/02-cosmos.mdx
@@ -33,7 +33,8 @@ await using var collection = await TemporaryMongoDbCollection.CreateIfNotExistsA
     cosmosDbAccountResourceId,
     "<database-name>",
     "<collection-name>",
-    logger);
+    logger,
+    CancellationToken.None);
 
 // Interact with the collection during the lifetime of the fixture.
 IMongoCollection<Shipment> client = collection.GetCollectionClient<Shipment>();
@@ -48,7 +49,7 @@ using Arcus.Testing;
 
 await using TemporaryMongoDbCollection collection = ...
 
-await collection.UpsertDocumentAsync(new Shipment { BoatName = "The Alice"  });
+await collection.UpsertDocumentAsync(new Shipment { BoatName = "The Alice"  }, CancellationToken.None);
 ```
 
 :::praise
@@ -124,7 +125,8 @@ await using var document = await TemporaryMongoDbDocument.UpsertDocumentAsync(
     "<database-name>",
     "<collection-name>",
     shipment,
-    logger);
+    logger,
+    CancellationToken.None);
 
 BsonValue documentId = document.Id;
 ```
@@ -162,7 +164,8 @@ await using var container = await TemporaryNoSqlContainer.CreateIfNotExistsAsync
     "<database-name>",
     "<container-name>",
     "/partition-key-path",
-    logger);
+    logger,
+    CancellationToken.None);
 
 // Interact with the container during the lifetime of the fixture.
 Container client = container.Client;
@@ -177,7 +180,7 @@ using Arcus.Testing;
 
 await using TemporaryNoSqlContainer container = ...
 
-await container.UpsertItemAsync(new Shipment { Id = "123", BoatName = "The Alice" });
+await container.UpsertItemAsync(new Shipment { Id = "123", BoatName = "The Alice" }, CancellationToken.None);
 ```
 
 :::praise
@@ -242,7 +245,7 @@ Container containerClient = ...
 var shipment = new Shipment { Id = "123", BoatName = "The Alice" };
 
 await using var item = await TemporaryNoSqlItem.UpsertItemAsync(
-    containerClient, shipment, logger);
+    containerClient, shipment, logger, CancellationToken.None);
 
 string itemId = item.Id;
 PartitionKey partitionKey = item.PartitionKey;

--- a/src/Arcus.Testing.Storage.Cosmos/MongoDbConnection.cs
+++ b/src/Arcus.Testing.Storage.Cosmos/MongoDbConnection.cs
@@ -2,6 +2,7 @@
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text.Json;
+using System.Threading;
 using System.Threading.Tasks;
 using Azure;
 using Azure.Core;
@@ -21,22 +22,31 @@ namespace Arcus.Testing
         /// <summary>
         /// Authenticates a <see cref="MongoClient"/> with <see cref="DefaultAzureCredential"/>.
         /// </summary>
-        internal static async Task<MongoClient> AuthenticateMongoClientAsync(ResourceIdentifier cosmosDbResourceId, string databaseName, string collectionName, ILogger logger)
+        internal static async Task<MongoClient> AuthenticateMongoClientAsync(
+            ResourceIdentifier cosmosDbResourceId,
+            string databaseName,
+            string collectionName,
+            ILogger logger,
+            CancellationToken cancellationToken)
         {
-            AccessToken accessToken = await RequestAccessTokenAsync(logger).ConfigureAwait(false);
-            string responseBody = await RequestConnectionStringsAsync(cosmosDbResourceId, databaseName, collectionName, accessToken, logger).ConfigureAwait(false);
+            cancellationToken.ThrowIfCancellationRequested();
+
+            AccessToken accessToken = await RequestAccessTokenAsync(logger, cancellationToken).ConfigureAwait(false);
+            string responseBody = await RequestConnectionStringsAsync(cosmosDbResourceId, databaseName, collectionName, accessToken, logger, cancellationToken).ConfigureAwait(false);
 
             string connectionString = ParseConnectionString(responseBody);
             return new MongoClient(connectionString);
         }
 
-        private static async Task<AccessToken> RequestAccessTokenAsync(ILogger logger)
+        private static async Task<AccessToken> RequestAccessTokenAsync(ILogger logger, CancellationToken cancellationToken)
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             const string scope = "https://management.azure.com/.default";
             var tokenProvider = new DefaultAzureCredential();
 
             logger.LogRequestAccessToken(scope);
-            return await tokenProvider.GetTokenAsync(new TokenRequestContext(scopes: [scope])).ConfigureAwait(false);
+            return await tokenProvider.GetTokenAsync(new TokenRequestContext(scopes: [scope]), cancellationToken).ConfigureAwait(false);
         }
 
         private static async Task<string> RequestConnectionStringsAsync(
@@ -44,16 +54,19 @@ namespace Arcus.Testing
             string databaseName,
             string collectionName,
             AccessToken accessToken,
-            ILogger logger)
+            ILogger logger,
+            CancellationToken cancellationToken)
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             var listConnectionStringUrl = $"https://management.azure.com/{cosmosDbResourceId}/listConnectionStrings?api-version=2021-04-15";
             logger.LogRequestConnectionString(listConnectionStringUrl);
 
             using var request = new HttpRequestMessage(HttpMethod.Post, listConnectionStringUrl);
             request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken.Token);
 
-            using HttpResponseMessage response = await HttpClient.SendAsync(request).ConfigureAwait(false);
-            string responseBody = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+            using HttpResponseMessage response = await HttpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            string responseBody = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
 
             if (!response.IsSuccessStatusCode)
             {

--- a/src/Arcus.Testing.Storage.Cosmos/TemporaryMongoDbCollection.cs
+++ b/src/Arcus.Testing.Storage.Cosmos/TemporaryMongoDbCollection.cs
@@ -119,7 +119,7 @@ namespace Arcus.Testing
         /// <summary>
         /// (default for cleaning documents) Configures the <see cref="TemporaryMongoDbCollection"/> to only delete the MongoBb documents
         /// in an Azure Cosmos DB for MongoDB collection upon disposal if the document was inserted by the test fixture
-        /// (using <see cref="TemporaryMongoDbCollection.UpsertDocumentAsync{TDocument}"/>).
+        /// (using <see cref="TemporaryMongoDbCollection.UpsertDocumentAsync{TDocument}(TDocument,CancellationToken)"/>).
         /// </summary>
         [Obsolete("Will be removed in v3, please use the " + nameof(CleanUpsertedDocuments) + "instead that provides exactly the same functionality", DiagnosticId = ObsoleteDefaults.DiagnosticId)]
         public OnTeardownMongoDbCollectionOptions CleanCreatedDocuments()
@@ -130,7 +130,7 @@ namespace Arcus.Testing
         /// <summary>
         /// (default for cleaning documents) Configures the <see cref="TemporaryMongoDbCollection"/> to only delete or revert the MongoDB documents
         /// in an Azure Cosmos DB for MongoDB collection upon disposal if the document was upserted by the test fixture
-        /// (using <see cref="TemporaryMongoDbCollection.UpsertDocumentAsync{TDocument}"/>).
+        /// (using <see cref="TemporaryMongoDbCollection.UpsertDocumentAsync{TDocument}(TDocument,CancellationToken)"/>).
         /// </summary>
         public OnTeardownMongoDbCollectionOptions CleanUpsertedDocuments()
         {

--- a/src/Arcus.Testing.Storage.Cosmos/TemporaryMongoDbCollection.cs
+++ b/src/Arcus.Testing.Storage.Cosmos/TemporaryMongoDbCollection.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.ObjectModel;
 using System.Linq.Expressions;
+using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core;
 using Azure.ResourceManager.CosmosDB;
@@ -289,6 +290,7 @@ namespace Arcus.Testing
         /// <param name="logger">The logger to write diagnostic information during the lifetime of the MongoDB collection.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="cosmosDbResourceId"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="databaseName"/> or <paramref name="collectionName"/> is blank.</exception>
+        [Obsolete("Will be removed in v3, please use the " + nameof(CreateIfNotExistsAsync) + "instead that provides cancellation token support", DiagnosticId = ObsoleteDefaults.DiagnosticId)]
         public static Task<TemporaryMongoDbCollection> CreateIfNotExistsAsync(
             ResourceIdentifier cosmosDbResourceId,
             string databaseName,
@@ -314,9 +316,39 @@ namespace Arcus.Testing
         /// <param name="databaseName">The name of the MongoDB database in which the collection should be created.</param>
         /// <param name="collectionName">The unique name of the MongoDB collection.</param>
         /// <param name="logger">The logger to write diagnostic information during the lifetime of the MongoDB collection.</param>
+        /// <param name="cancellationToken">The optional token to propagate notifications that the operation should be cancelled.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="cosmosDbResourceId"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="databaseName"/> or <paramref name="collectionName"/> is blank.</exception>
+        public static Task<TemporaryMongoDbCollection> CreateIfNotExistsAsync(
+            ResourceIdentifier cosmosDbResourceId,
+            string databaseName,
+            string collectionName,
+            ILogger logger,
+            CancellationToken cancellationToken)
+        {
+            return CreateIfNotExistsAsync(cosmosDbResourceId, databaseName, collectionName, logger, configureOptions: null, cancellationToken);
+        }
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="TemporaryMongoDbCollection"/> which creates a new Azure Cosmos DB for MongoDB collection if it doesn't exist yet.
+        /// </summary>
+        /// <param name="cosmosDbResourceId">
+        ///   <para>The resource ID pointing towards the Azure Cosmos DB account.</para>
+        ///   <para>The resource ID can be constructed with the <see cref="CosmosDBAccountResource.CreateResourceIdentifier"/>:</para>
+        ///   <example>
+        ///     <code>
+        ///       ResourceIdentifier cosmosDbAccountResourceId =
+        ///           CosmosDBAccountResource.CreateResourceIdentifier("&lt;subscription-id&gt;", "&lt;resource-group&gt;", "&lt;account-name&gt;");
+        ///     </code>
+        ///   </example>
+        /// </param>
+        /// <param name="databaseName">The name of the MongoDB database in which the collection should be created.</param>
+        /// <param name="collectionName">The unique name of the MongoDB collection.</param>
+        /// <param name="logger">The logger to write diagnostic information during the lifetime of the MongoDB collection.</param>
         /// <param name="configureOptions">The additional options to manipulate the behavior of the test fixture during its lifetime.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="cosmosDbResourceId"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="databaseName"/> or <paramref name="collectionName"/> is blank.</exception>
+        [Obsolete("Will be removed in v3, please use the " + nameof(CreateIfNotExistsAsync) + "instead that provides cancellation token support", DiagnosticId = ObsoleteDefaults.DiagnosticId)]
         public static async Task<TemporaryMongoDbCollection> CreateIfNotExistsAsync(
             ResourceIdentifier cosmosDbResourceId,
             string databaseName,
@@ -329,10 +361,50 @@ namespace Arcus.Testing
             ArgumentException.ThrowIfNullOrWhiteSpace(collectionName);
             logger ??= NullLogger.Instance;
 
-            MongoClient client = await MongoDbConnection.AuthenticateMongoClientAsync(cosmosDbResourceId, databaseName, collectionName, logger).ConfigureAwait(false);
+            MongoClient client = await MongoDbConnection.AuthenticateMongoClientAsync(cosmosDbResourceId, databaseName, collectionName, logger, CancellationToken.None).ConfigureAwait(false);
             IMongoDatabase database = client.GetDatabase(databaseName);
 
-            return await CreateIfNotExistsAsync(client, clientCreatedByUs: true, database, collectionName, logger, configureOptions).ConfigureAwait(false);
+            return await CreateIfNotExistsAsync(client, clientCreatedByUs: true, database, collectionName, logger, configureOptions, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="TemporaryMongoDbCollection"/> which creates a new Azure Cosmos DB for MongoDB collection if it doesn't exist yet.
+        /// </summary>
+        /// <param name="cosmosDbResourceId">
+        ///   <para>The resource ID pointing towards the Azure Cosmos DB account.</para>
+        ///   <para>The resource ID can be constructed with the <see cref="CosmosDBAccountResource.CreateResourceIdentifier"/>:</para>
+        ///   <example>
+        ///     <code>
+        ///       ResourceIdentifier cosmosDbAccountResourceId =
+        ///           CosmosDBAccountResource.CreateResourceIdentifier("&lt;subscription-id&gt;", "&lt;resource-group&gt;", "&lt;account-name&gt;");
+        ///     </code>
+        ///   </example>
+        /// </param>
+        /// <param name="databaseName">The name of the MongoDB database in which the collection should be created.</param>
+        /// <param name="collectionName">The unique name of the MongoDB collection.</param>
+        /// <param name="logger">The logger to write diagnostic information during the lifetime of the MongoDB collection.</param>
+        /// <param name="configureOptions">The additional options to manipulate the behavior of the test fixture during its lifetime.</param>
+        /// <param name="cancellationToken">The optional token to propagate notifications that the operation should be cancelled.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="cosmosDbResourceId"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="databaseName"/> or <paramref name="collectionName"/> is blank.</exception>
+        public static async Task<TemporaryMongoDbCollection> CreateIfNotExistsAsync(
+            ResourceIdentifier cosmosDbResourceId,
+            string databaseName,
+            string collectionName,
+            ILogger logger,
+            Action<TemporaryMongoDbCollectionOptions> configureOptions,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            ArgumentNullException.ThrowIfNull(cosmosDbResourceId);
+            ArgumentException.ThrowIfNullOrWhiteSpace(databaseName);
+            ArgumentException.ThrowIfNullOrWhiteSpace(collectionName);
+            logger ??= NullLogger.Instance;
+
+            MongoClient client = await MongoDbConnection.AuthenticateMongoClientAsync(cosmosDbResourceId, databaseName, collectionName, logger, cancellationToken).ConfigureAwait(false);
+            IMongoDatabase database = client.GetDatabase(databaseName);
+
+            return await CreateIfNotExistsAsync(client, clientCreatedByUs: true, database, collectionName, logger, configureOptions, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -343,6 +415,7 @@ namespace Arcus.Testing
         /// <param name="logger">The logger to write diagnostic information during the lifetime of the MongoDB collection.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="database"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="collectionName"/> is blank.</exception>
+        [Obsolete("Will be removed in v3, please use the " + nameof(CreateIfNotExistsAsync) + "instead that provides cancellation token support", DiagnosticId = ObsoleteDefaults.DiagnosticId)]
         public static Task<TemporaryMongoDbCollection> CreateIfNotExistsAsync(IMongoDatabase database, string collectionName, ILogger logger)
         {
             return CreateIfNotExistsAsync(database, collectionName, logger, configureOptions: null);
@@ -354,16 +427,51 @@ namespace Arcus.Testing
         /// <param name="database">The client to the MongoDB database in which the collection should be created.</param>
         /// <param name="collectionName">The unique name of the MongoDB collection.</param>
         /// <param name="logger">The logger to write diagnostic information during the lifetime of the MongoDB collection.</param>
+        /// <param name="cancellationToken">The optional token to propagate notifications that the operation should be cancelled.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="database"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="collectionName"/> is blank.</exception>
+        public static Task<TemporaryMongoDbCollection> CreateIfNotExistsAsync(IMongoDatabase database, string collectionName, ILogger logger, CancellationToken cancellationToken)
+        {
+            return CreateIfNotExistsAsync(database, collectionName, logger, configureOptions: null, cancellationToken);
+        }
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="TemporaryMongoDbCollection"/> which creates a new Azure Cosmos DB for MongoDB collection if it doesn't exist yet.
+        /// </summary>
+        /// <param name="database">The client to the MongoDB database in which the collection should be created.</param>
+        /// <param name="collectionName">The unique name of the MongoDB collection.</param>
+        /// <param name="logger">The logger to write diagnostic information during the lifetime of the MongoDB collection.</param>
         /// <param name="configureOptions">The additional options to manipulate the behavior of the test fixture during its lifetime.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="database"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="collectionName"/> is blank.</exception>
+        [Obsolete("Will be removed in v3, please use the " + nameof(CreateIfNotExistsAsync) + "instead that provides cancellation token support", DiagnosticId = ObsoleteDefaults.DiagnosticId)]
         public static Task<TemporaryMongoDbCollection> CreateIfNotExistsAsync(
             IMongoDatabase database,
             string collectionName,
             ILogger logger,
             Action<TemporaryMongoDbCollectionOptions> configureOptions)
         {
-            return CreateIfNotExistsAsync(client: null, clientCreatedByUs: false, database, collectionName, logger, configureOptions);
+            return CreateIfNotExistsAsync(client: null, clientCreatedByUs: false, database, collectionName, logger, configureOptions, CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="TemporaryMongoDbCollection"/> which creates a new Azure Cosmos DB for MongoDB collection if it doesn't exist yet.
+        /// </summary>
+        /// <param name="database">The client to the MongoDB database in which the collection should be created.</param>
+        /// <param name="collectionName">The unique name of the MongoDB collection.</param>
+        /// <param name="logger">The logger to write diagnostic information during the lifetime of the MongoDB collection.</param>
+        /// <param name="configureOptions">The additional options to manipulate the behavior of the test fixture during its lifetime.</param>
+        /// <param name="cancellationToken">The optional token to propagate notifications that the operation should be cancelled.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="database"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="collectionName"/> is blank.</exception>
+        public static Task<TemporaryMongoDbCollection> CreateIfNotExistsAsync(
+            IMongoDatabase database,
+            string collectionName,
+            ILogger logger,
+            Action<TemporaryMongoDbCollectionOptions> configureOptions,
+            CancellationToken cancellationToken)
+        {
+            return CreateIfNotExistsAsync(client: null, clientCreatedByUs: false, database, collectionName, logger, configureOptions, cancellationToken);
         }
 
         private static async Task<TemporaryMongoDbCollection> CreateIfNotExistsAsync(
@@ -372,8 +480,10 @@ namespace Arcus.Testing
             IMongoDatabase database,
             string collectionName,
             ILogger logger,
-            Action<TemporaryMongoDbCollectionOptions> configureOptions)
+            Action<TemporaryMongoDbCollectionOptions> configureOptions,
+            CancellationToken cancellationToken)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             ArgumentNullException.ThrowIfNull(database);
             ArgumentException.ThrowIfNullOrWhiteSpace(collectionName);
             logger ??= NullLogger.Instance;
@@ -385,23 +495,29 @@ namespace Arcus.Testing
             {
                 Filter = Builders<BsonDocument>.Filter.Eq("name", collectionName)
             };
-            using IAsyncCursor<string> collectionNames = await database.ListCollectionNamesAsync(listOptions).ConfigureAwait(false);
-            if (await collectionNames.AnyAsync().ConfigureAwait(false))
+            using IAsyncCursor<string> collectionNames = await database.ListCollectionNamesAsync(listOptions, cancellationToken).ConfigureAwait(false);
+            if (await collectionNames.AnyAsync(cancellationToken).ConfigureAwait(false))
             {
                 logger.LogSetupUseExistingCollection(collectionName, database.DatabaseNamespace.DatabaseName);
 
-                await CleanCollectionOnSetupAsync(database, collectionName, options, logger).ConfigureAwait(false);
+                await CleanCollectionOnSetupAsync(database, collectionName, options, logger, cancellationToken).ConfigureAwait(false);
                 return new TemporaryMongoDbCollection(createdByUs: false, collectionName, client, clientCreatedByUs, database, logger, options);
             }
 
             logger.LogSetupCreateNewCollection(collectionName, database.DatabaseNamespace.DatabaseName);
-            await database.CreateCollectionAsync(collectionName).ConfigureAwait(false);
+            await database.CreateCollectionAsync(collectionName, cancellationToken: cancellationToken).ConfigureAwait(false);
 
             return new TemporaryMongoDbCollection(createdByUs: true, collectionName, client, clientCreatedByUs, database, logger, options);
         }
 
-        private static Task CleanCollectionOnSetupAsync(IMongoDatabase database, string collectionName, TemporaryMongoDbCollectionOptions options, ILogger logger)
+        private static Task CleanCollectionOnSetupAsync(
+            IMongoDatabase database,
+            string collectionName,
+            TemporaryMongoDbCollectionOptions options,
+            ILogger logger,
+            CancellationToken cancellationToken)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             if (options.OnSetup.Documents is OnSetupMongoDbCollection.LeaveExisted)
             {
                 return Task.CompletedTask;
@@ -412,13 +528,13 @@ namespace Arcus.Testing
             if (options.OnSetup.Documents is OnSetupMongoDbCollection.CleanIfExisted)
             {
                 logger.LogSetupCleanAllDocuments(database.DatabaseNamespace.DatabaseName, collectionName);
-                return collection.DeleteManyAsync(Builders<BsonDocument>.Filter.Empty);
+                return collection.DeleteManyAsync(Builders<BsonDocument>.Filter.Empty, cancellationToken);
             }
 
             if (options.OnSetup.Documents is OnSetupMongoDbCollection.CleanIfMatched)
             {
                 logger.LogSetupCleanAllMatchingDocuments(database.DatabaseNamespace.DatabaseName, collectionName);
-                return collection.DeleteManyAsync(options.OnSetup.IsMatched);
+                return collection.DeleteManyAsync(options.OnSetup.IsMatched, cancellationToken);
             }
 
             return Task.CompletedTask;
@@ -462,13 +578,32 @@ namespace Arcus.Testing
         /// <param name="document">The document to upload to the MongoDB collection.</param>
         /// <exception cref="ObjectDisposedException">Thrown when the test fixture was already teared down.</exception>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="document"/> is <c>null</c>.</exception>
-        public async Task UpsertDocumentAsync<TDocument>(TDocument document)
+        [Obsolete("Will be removed in v3, please use the " + nameof(UpsertDocumentAsync) + " overload instead with cancellation token support", DiagnosticId = ObsoleteDefaults.DiagnosticId)]
+        public Task UpsertDocumentAsync<TDocument>(TDocument document)
         {
+            return UpsertDocumentAsync(document, CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Adds a new or replaces an existing document in the Azure Cosmos DB for MongoDB collection (a.k.a. UPSERT).
+        /// </summary>
+        /// <remarks>
+        ///     ⚡ Any items upserted via this call will always be deleted (if new) or reverted (if existing)
+        ///     when the <see cref="TemporaryMongoDbCollection"/> is disposed.
+        /// </remarks>
+        /// <typeparam name="TDocument">The type of the document in the MongoDB collection.</typeparam>
+        /// <param name="document">The document to upload to the MongoDB collection.</param>
+        /// <param name="cancellationToken">The optional token to propagate notifications that the operation should be cancelled.</param>
+        /// <exception cref="ObjectDisposedException">Thrown when the test fixture was already teared down.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="document"/> is <c>null</c>.</exception>
+        public async Task UpsertDocumentAsync<TDocument>(TDocument document, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
             ObjectDisposedException.ThrowIf(_disposables.IsDisposed, this);
             ArgumentNullException.ThrowIfNull(document);
 
             IMongoCollection<TDocument> collection = GetCollectionClient<TDocument>();
-            _documents.Add(await TemporaryMongoDbDocument.UpsertDocumentAsync(collection, document, _logger).ConfigureAwait(false));
+            _documents.Add(await TemporaryMongoDbDocument.UpsertDocumentAsync(collection, document, _logger, cancellationToken).ConfigureAwait(false));
         }
 
         /// <summary>

--- a/src/Arcus.Testing.Storage.Cosmos/TemporaryMongoDbDocument.cs
+++ b/src/Arcus.Testing.Storage.Cosmos/TemporaryMongoDbDocument.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core;
 using Azure.ResourceManager.CosmosDB;
@@ -74,7 +75,7 @@ namespace Arcus.Testing
         /// <param name="logger">The logger to write diagnostic information during the lifetime of the MongoDb document.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="cosmosDbResourceId"/> or <paramref name="document"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="databaseName"/> or the <paramref name="collectionName"/> is blank.</exception>
-        [Obsolete("Will be removed in v3, please use the " + nameof(UpsertDocumentAsync) + "instead that provides exactly the same functionality", DiagnosticId = ObsoleteDefaults.DiagnosticId)]
+        [Obsolete("Will be removed in v3.0, please use the " + nameof(UpsertDocumentAsync) + "instead that provides exactly the same functionality", DiagnosticId = ObsoleteDefaults.DiagnosticId)]
         public static Task<TemporaryMongoDbDocument> InsertIfNotExistsAsync<TDocument>(
             ResourceIdentifier cosmosDbResourceId,
             string databaseName,
@@ -93,7 +94,7 @@ namespace Arcus.Testing
         /// <param name="document">The document that should be temporarily inserted into the MongoDB collection.</param>
         /// <param name="logger">The logger to write diagnostic information during the lifetime of the MongoDb document.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="collection"/> or the <paramref name="document"/> is <c>null</c>.</exception>
-        [Obsolete("Will be removed in v3, please use the " + nameof(UpsertDocumentAsync) + "instead that provides exactly the same functionality", DiagnosticId = ObsoleteDefaults.DiagnosticId)]
+        [Obsolete("Will be removed in v3.0, please use the " + nameof(UpsertDocumentAsync) + "instead that provides exactly the same functionality", DiagnosticId = ObsoleteDefaults.DiagnosticId)]
         public static Task<TemporaryMongoDbDocument> InsertIfNotExistsAsync<TDocument>(IMongoCollection<TDocument> collection, TDocument document, ILogger logger)
         {
             return UpsertDocumentAsync(collection, document, logger);
@@ -121,7 +122,8 @@ namespace Arcus.Testing
         /// <param name="logger">The logger to write diagnostic information during the lifetime of the MongoDB document.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="cosmosDbResourceId"/> or <paramref name="document"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="databaseName"/> or the <paramref name="collectionName"/> is blank.</exception>
-        public static async Task<TemporaryMongoDbDocument> UpsertDocumentAsync<TDocument>(
+        [Obsolete("Will be removed in v3.0, please use the " + nameof(UpsertDocumentAsync) + "overload with cancellation token support", DiagnosticId = ObsoleteDefaults.DiagnosticId)]
+        public static Task<TemporaryMongoDbDocument> UpsertDocumentAsync<TDocument>(
             ResourceIdentifier cosmosDbResourceId,
             string databaseName,
             string collectionName,
@@ -129,6 +131,42 @@ namespace Arcus.Testing
             ILogger logger)
             where TDocument : class
         {
+            return UpsertDocumentAsync(cosmosDbResourceId, databaseName, collectionName, document, logger, CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Creates a new or replaces an existing document in an Azure Cosmos DB for MongoDB collection.
+        /// </summary>
+        /// <remarks>
+        ///     ⚡ Document will be deleted (if new) or reverted (if existing) when the <see cref="TemporaryMongoDbDocument"/> is disposed.
+        /// </remarks>
+        /// <param name="cosmosDbResourceId">
+        ///   <para>The resource ID pointing towards the Azure Cosmos DB account.</para>
+        ///   <para>The resource ID can be constructed with the <see cref="CosmosDBAccountResource.CreateResourceIdentifier"/>:</para>
+        ///   <example>
+        ///     <code>
+        ///       ResourceIdentifier cosmosDbAccountResourceId =
+        ///           CosmosDBAccountResource.CreateResourceIdentifier("&lt;subscription-id&gt;", "&lt;resource-group&gt;", "&lt;account-name&gt;");
+        ///     </code>
+        ///   </example>
+        /// </param>
+        /// <param name="databaseName">The name of the MongoDB database in which the collection resides where the document should be created.</param>
+        /// <param name="collectionName">The name of the MongoDB collection in which the document should be created.</param>
+        /// <param name="document">The document that should be temporarily inserted into the MongoDB collection.</param>
+        /// <param name="logger">The logger to write diagnostic information during the lifetime of the MongoDB document.</param>
+        /// <param name="cancellationToken">The optional token to propagate notifications that the operation should be cancelled.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="cosmosDbResourceId"/> or <paramref name="document"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="databaseName"/> or the <paramref name="collectionName"/> is blank.</exception>
+        public static async Task<TemporaryMongoDbDocument> UpsertDocumentAsync<TDocument>(
+            ResourceIdentifier cosmosDbResourceId,
+            string databaseName,
+            string collectionName,
+            TDocument document,
+            ILogger logger,
+            CancellationToken cancellationToken)
+            where TDocument : class
+        {
+            cancellationToken.ThrowIfCancellationRequested();
             ArgumentNullException.ThrowIfNull(cosmosDbResourceId);
             ArgumentNullException.ThrowIfNull(document);
             ArgumentException.ThrowIfNullOrWhiteSpace(databaseName);
@@ -136,16 +174,16 @@ namespace Arcus.Testing
             logger ??= NullLogger.Instance;
 
 #pragma warning disable CA2000 // Responsibility of disposing the client in case of non-failure is passed to the returned temporary document test fixture.
-            MongoClient client = await MongoDbConnection.AuthenticateMongoClientAsync(cosmosDbResourceId, databaseName, collectionName, logger).ConfigureAwait(false);
+            MongoClient client = await MongoDbConnection.AuthenticateMongoClientAsync(cosmosDbResourceId, databaseName, collectionName, logger, cancellationToken).ConfigureAwait(false);
 #pragma warning restore CA2000
             try
             {
                 IMongoDatabase database = client.GetDatabase(databaseName);
                 IMongoCollection<TDocument> collection = database.GetCollection<TDocument>(collectionName);
 
-                return await UpsertDocumentAsync(client, clientCreatedByUs: true, collection, document, logger).ConfigureAwait(false);
+                return await UpsertDocumentAsync(client, clientCreatedByUs: true, collection, document, logger, cancellationToken).ConfigureAwait(false);
             }
-            catch (MongoException)
+            catch
             {
                 client.Dispose();
                 throw;
@@ -162,17 +200,40 @@ namespace Arcus.Testing
         /// <param name="document">The document that should be temporarily inserted into the MongoDB collection.</param>
         /// <param name="logger">The logger to write diagnostic information during the lifetime of the MongoDB document.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="collection"/> or the <paramref name="document"/> is <c>null</c>.</exception>
+        [Obsolete("Will be removed in v3.0, please use the " + nameof(UpsertDocumentAsync) + " overload with cancellation token support", DiagnosticId = ObsoleteDefaults.DiagnosticId)]
         public static Task<TemporaryMongoDbDocument> UpsertDocumentAsync<TDocument>(IMongoCollection<TDocument> collection, TDocument document, ILogger logger)
         {
-            return UpsertDocumentAsync(client: null, clientCreatedByUs: false, collection, document, logger);
+            return UpsertDocumentAsync(client: null, clientCreatedByUs: false, collection, document, logger, CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Creates a new or replaces an existing document in an Azure Cosmos DB for MongoDB collection.
+        /// </summary>
+        /// <remarks>
+        ///     ⚡ Document will be deleted (if new) or reverted (if existing) when the <see cref="TemporaryMongoDbDocument"/> is disposed.
+        /// </remarks>
+        /// <param name="collection">The collection client to interact with the MongoDB collection.</param>
+        /// <param name="document">The document that should be temporarily inserted into the MongoDB collection.</param>
+        /// <param name="logger">The logger to write diagnostic information during the lifetime of the MongoDB document.</param>
+        /// <param name="cancellationToken">The optional token to propagate notifications that the operation should be cancelled.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="collection"/> or the <paramref name="document"/> is <c>null</c>.</exception>
+        public static Task<TemporaryMongoDbDocument> UpsertDocumentAsync<TDocument>(
+            IMongoCollection<TDocument> collection,
+            TDocument document,
+            ILogger logger,
+            CancellationToken cancellationToken)
+        {
+            return UpsertDocumentAsync(client: null, clientCreatedByUs: false, collection, document, logger, cancellationToken);
         }
 
         private static async Task<TemporaryMongoDbDocument> UpsertDocumentAsync<TDocument>(
             MongoClient client, bool clientCreatedByUs,
             IMongoCollection<TDocument> collection,
             TDocument document,
-            ILogger logger)
+            ILogger logger,
+            CancellationToken cancellationToken)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             ArgumentNullException.ThrowIfNull(collection);
             ArgumentNullException.ThrowIfNull(document);
             logger ??= NullLogger.Instance;
@@ -188,17 +249,17 @@ namespace Arcus.Testing
             string collectionName = collection.CollectionNamespace.CollectionName;
             IMongoCollection<BsonDocument> collectionBson = collection.Database.GetCollection<BsonDocument>(collectionName);
 
-            BsonDocument originalDoc = await FindOriginalDocumentAsync(collectionBson, findOneDocument, documentType).ConfigureAwait(false);
+            BsonDocument originalDoc = await FindOriginalDocumentAsync(collectionBson, findOneDocument, documentType, cancellationToken).ConfigureAwait(false);
             if (originalDoc is null)
             {
                 logger.LogSetupInsertNewDocument(documentType.Name, documentId, collection.Database.DatabaseNamespace.DatabaseName, collectionName);
 
-                await collectionBson.InsertOneAsync(bson).ConfigureAwait(false);
+                await collectionBson.InsertOneAsync(bson, cancellationToken: cancellationToken).ConfigureAwait(false);
                 return new(id, documentType, findOneDocument, originalDoc: null, (client, clientCreatedByUs), collectionBson, logger);
             }
 
             logger.LogSetupReplaceDocument(documentType.Name, documentId, collection.Database.DatabaseNamespace.DatabaseName, collectionName);
-            await collectionBson.FindOneAndReplaceAsync(findOneDocument, bson).ConfigureAwait(false);
+            await collectionBson.FindOneAndReplaceAsync(findOneDocument, bson, cancellationToken: cancellationToken).ConfigureAwait(false);
 
             return new TemporaryMongoDbDocument(id, documentType, findOneDocument, originalDoc, (client, clientCreatedByUs), collectionBson, logger);
         }
@@ -206,10 +267,13 @@ namespace Arcus.Testing
         private static async Task<BsonDocument> FindOriginalDocumentAsync(
             IMongoCollection<BsonDocument> collectionBson,
             FilterDefinition<BsonDocument> findOneDocument,
-            Type documentType)
+            Type documentType,
+            CancellationToken cancellationToken)
         {
-            using IAsyncCursor<BsonDocument> existingDocs = await collectionBson.FindAsync(findOneDocument).ConfigureAwait(false);
-            List<BsonDocument> matchingDocs = await existingDocs.ToListAsync().ConfigureAwait(false);
+            cancellationToken.ThrowIfCancellationRequested();
+
+            using IAsyncCursor<BsonDocument> existingDocs = await collectionBson.FindAsync(findOneDocument, cancellationToken: cancellationToken).ConfigureAwait(false);
+            List<BsonDocument> matchingDocs = await existingDocs.ToListAsync(cancellationToken).ConfigureAwait(false);
 
             if (matchingDocs.Count > 1)
             {

--- a/src/Arcus.Testing.Storage.Cosmos/TemporaryNoSqlContainer.cs
+++ b/src/Arcus.Testing.Storage.Cosmos/TemporaryNoSqlContainer.cs
@@ -4,6 +4,7 @@ using System.Collections.ObjectModel;
 using System.Linq;
 using System.Net;
 using System.Text.Json.Nodes;
+using System.Threading;
 using System.Threading.Tasks;
 using Azure;
 using Azure.Core;
@@ -396,6 +397,7 @@ namespace Arcus.Testing
         /// <exception cref="ArgumentException">
         ///     Thrown when the <paramref name="databaseName"/>, <paramref name="containerName"/>, or the <paramref name="partitionKeyPath"/> is blank.
         /// </exception>
+        [Obsolete("Will be removed in v3.0, please use the " + nameof(CreateIfNotExistsAsync) + " overload with cancellation token support", DiagnosticId = ObsoleteDefaults.DiagnosticId)]
         public static Task<TemporaryNoSqlContainer> CreateIfNotExistsAsync(
             ResourceIdentifier cosmosDbAccountResourceId,
             string databaseName,
@@ -410,6 +412,46 @@ namespace Arcus.Testing
                 partitionKeyPath,
                 logger,
                 configureOptions: null);
+        }
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="TemporaryNoSqlContainer"/> which creates a new Azure Cosmos DB NoSQL container if it doesn't exist yet.
+        /// </summary>
+        /// <param name="cosmosDbAccountResourceId">
+        ///   <para>The resource ID of the Azure Cosmos DB resource where the temporary NoSQL container should be created.</para>
+        ///   <para>The resource ID can be constructed with the <see cref="CosmosDBAccountResource.CreateResourceIdentifier"/>:</para>
+        ///   <example>
+        ///     <code>
+        ///       ResourceIdentifier cosmosDbAccountResourceId =
+        ///           CosmosDBAccountResource.CreateResourceIdentifier("&lt;subscription-id&gt;", "&lt;resource-group&gt;", "&lt;account-name&gt;");
+        ///     </code>
+        ///   </example>
+        /// </param>
+        /// <param name="databaseName">The name of the existing NoSQL database in the Azure Cosmos DB resource.</param>
+        /// <param name="containerName">The name of the NoSQL container to be created within the Azure Cosmos DB resource.</param>
+        /// <param name="partitionKeyPath">The path to the partition key of the NoSQL item which describes how the items should be partitioned.</param>
+        /// <param name="logger">The logger instance to write diagnostic information during the lifetime of the NoSQL container.</param>
+        /// <param name="cancellationToken">The optional token to propagate notifications that the operation should be cancelled.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="cosmosDbAccountResourceId"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">
+        ///     Thrown when the <paramref name="databaseName"/>, <paramref name="containerName"/>, or the <paramref name="partitionKeyPath"/> is blank.
+        /// </exception>
+        public static Task<TemporaryNoSqlContainer> CreateIfNotExistsAsync(
+            ResourceIdentifier cosmosDbAccountResourceId,
+            string databaseName,
+            string containerName,
+            string partitionKeyPath,
+            ILogger logger,
+            CancellationToken cancellationToken)
+        {
+            return CreateIfNotExistsAsync(
+                cosmosDbAccountResourceId,
+                databaseName,
+                containerName,
+                partitionKeyPath,
+                logger,
+                configureOptions: null,
+                cancellationToken);
         }
 
         /// <summary>
@@ -434,6 +476,7 @@ namespace Arcus.Testing
         /// <exception cref="ArgumentException">
         ///     Thrown when the <paramref name="databaseName"/>, <paramref name="containerName"/>, or the <paramref name="partitionKeyPath"/> is blank.
         /// </exception>
+        [Obsolete("Will be removed in v3.0, please use the " + nameof(CreateIfNotExistsAsync) + " overload with cancellation token support", DiagnosticId = ObsoleteDefaults.DiagnosticId)]
         public static Task<TemporaryNoSqlContainer> CreateIfNotExistsAsync(
             ResourceIdentifier cosmosDbAccountResourceId,
             string databaseName,
@@ -450,6 +493,49 @@ namespace Arcus.Testing
                 partitionKeyPath,
                 logger,
                 configureOptions);
+        }
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="TemporaryNoSqlContainer"/> which creates a new Azure Cosmos DB for NoSql container if it doesn't exist yet.
+        /// </summary>
+        /// <param name="cosmosDbAccountResourceId">
+        ///   <para>The resource ID of the Azure Cosmos DB resource where the temporary NoSQL container should be created.</para>
+        ///   <para>The resource ID can be constructed with the <see cref="CosmosDBAccountResource.CreateResourceIdentifier"/>:</para>
+        ///   <example>
+        ///     <code>
+        ///       ResourceIdentifier cosmosDbAccountResourceId =
+        ///           CosmosDBAccountResource.CreateResourceIdentifier("&lt;subscription-id&gt;", "&lt;resource-group&gt;", "&lt;account-name&gt;");
+        ///     </code>
+        ///   </example>
+        /// </param>
+        /// <param name="databaseName">The name of the existing NoSQL database in the Azure Cosmos resource.</param>
+        /// <param name="containerName">The name of the NoSQL container to be created within the Azure Cosmos DB resource.</param>
+        /// <param name="partitionKeyPath">The path to the partition key of the NoSQL item which describes how the items should be partitioned.</param>
+        /// <param name="logger">The logger instance to write diagnostic information during the lifetime of the NoSQL container.</param>
+        /// <param name="configureOptions">The additional options to manipulate the behavior of the test fixture.</param>
+        /// <param name="cancellationToken">The optional token to propagate notifications that the operation should be cancelled.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="cosmosDbAccountResourceId"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">
+        ///     Thrown when the <paramref name="databaseName"/>, <paramref name="containerName"/>, or the <paramref name="partitionKeyPath"/> is blank.
+        /// </exception>
+        public static Task<TemporaryNoSqlContainer> CreateIfNotExistsAsync(
+            ResourceIdentifier cosmosDbAccountResourceId,
+            string databaseName,
+            string containerName,
+            string partitionKeyPath,
+            ILogger logger,
+            Action<TemporaryNoSqlContainerOptions> configureOptions,
+            CancellationToken cancellationToken)
+        {
+            return CreateIfNotExistsAsync(
+                cosmosDbAccountResourceId,
+                new DefaultAzureCredential(),
+                databaseName,
+                containerName,
+                partitionKeyPath,
+                logger,
+                configureOptions,
+                cancellationToken);
         }
 
         /// <summary>
@@ -476,6 +562,7 @@ namespace Arcus.Testing
         /// <exception cref="ArgumentException">
         ///     Thrown when the <paramref name="databaseName"/>, <paramref name="containerName"/>, or the <paramref name="partitionKeyPath"/> is blank.
         /// </exception>
+        [Obsolete("Will be removed in v3.0, please use the " + nameof(CreateIfNotExistsAsync) + " overload with cancellation token support", DiagnosticId = ObsoleteDefaults.DiagnosticId)]
         public static Task<TemporaryNoSqlContainer> CreateIfNotExistsAsync(
             ResourceIdentifier cosmosDbAccountResourceId,
             TokenCredential credential,
@@ -510,9 +597,93 @@ namespace Arcus.Testing
         /// <param name="credential">The credential implementation to authenticate with the Azure Cosmos DB resource.</param>
         /// <param name="databaseName">The name of the existing NoSQL database in the Azure Cosmos DB resource.</param>
         /// <param name="containerName">The name of the NoSQL container to be created within the Azure Cosmos DB resource.</param>
+        /// <param name="partitionKeyPath">The path to the partition key of the NoSql item which describes how the items should be partitioned.</param>
+        /// <param name="logger">The logger instance to write diagnostic information during the lifetime of the NoSQL container.</param>
+        /// <param name="cancellationToken">The optional token to propagate notifications that the operation should be cancelled.</param>
+        /// <exception cref="ArgumentNullException">
+        ///     Thrown when the <paramref name="cosmosDbAccountResourceId"/> or the <paramref name="credential"/> is <c>null</c>.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///     Thrown when the <paramref name="databaseName"/>, <paramref name="containerName"/>, or the <paramref name="partitionKeyPath"/> is blank.
+        /// </exception>
+        public static Task<TemporaryNoSqlContainer> CreateIfNotExistsAsync(
+            ResourceIdentifier cosmosDbAccountResourceId,
+            TokenCredential credential,
+            string databaseName,
+            string containerName,
+            string partitionKeyPath,
+            ILogger logger,
+            CancellationToken cancellationToken)
+        {
+            return CreateIfNotExistsAsync(
+                cosmosDbAccountResourceId,
+                credential,
+                databaseName,
+                containerName,
+                partitionKeyPath,
+                logger,
+                configureOptions: null,
+                cancellationToken);
+        }
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="TemporaryNoSqlContainer"/> which creates a new Azure Cosmos DB for NoSQL container if it doesn't exist yet.
+        /// </summary>
+        /// <param name="cosmosDbAccountResourceId">
+        ///   <para>The resource ID of the Azure Cosmos DB resource where the temporary NoSQL container should be created.</para>
+        ///   <para>The resource ID can be constructed with the <see cref="CosmosDBAccountResource.CreateResourceIdentifier"/>:</para>
+        ///   <example>
+        ///     <code>
+        ///       ResourceIdentifier cosmosDbAccountResourceId =
+        ///           CosmosDBAccountResource.CreateResourceIdentifier("&lt;subscription-id&gt;", "&lt;resource-group&gt;", "&lt;account-name&gt;");
+        ///     </code>
+        ///   </example>
+        /// </param>
+        /// <param name="credential">The credential implementation to authenticate with the Azure Cosmos DB resource.</param>
+        /// <param name="databaseName">The name of the existing NoSQL database in the Azure Cosmos DB resource.</param>
+        /// <param name="containerName">The name of the NoSQL container to be created within the Azure Cosmos DB resource.</param>
         /// <param name="partitionKeyPath">The path to the partition key of the NoSQL item which describes how the items should be partitioned.</param>
         /// <param name="logger">The logger instance to write diagnostic information during the lifetime of the NoSQL container.</param>
         /// <param name="configureOptions">The additional options to manipulate the behavior of the test fixture.</param>
+        /// <exception cref="ArgumentNullException">
+        ///     Thrown when the <paramref name="cosmosDbAccountResourceId"/> or the <paramref name="credential"/> is <c>null</c>.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///     Thrown when the <paramref name="databaseName"/>, <paramref name="containerName"/>, or the <paramref name="partitionKeyPath"/> is blank.
+        /// </exception>
+        [Obsolete("Will be removed in v3.0, please use the " + nameof(CreateIfNotExistsAsync) + " overload with cancellation token support", DiagnosticId = ObsoleteDefaults.DiagnosticId)]
+        public static Task<TemporaryNoSqlContainer> CreateIfNotExistsAsync(
+            ResourceIdentifier cosmosDbAccountResourceId,
+            TokenCredential credential,
+            string databaseName,
+            string containerName,
+            string partitionKeyPath,
+            ILogger logger,
+            Action<TemporaryNoSqlContainerOptions> configureOptions)
+        {
+            return CreateIfNotExistsAsync(cosmosDbAccountResourceId, credential, databaseName, containerName, partitionKeyPath, logger, configureOptions, CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="TemporaryNoSqlContainer"/> which creates a new Azure Cosmos DB for NoSQL container if it doesn't exist yet.
+        /// </summary>
+        /// <param name="cosmosDbAccountResourceId">
+        ///   <para>The resource ID of the Azure Cosmos DB resource where the temporary NoSQL container should be created.</para>
+        ///   <para>The resource ID can be constructed with the <see cref="CosmosDBAccountResource.CreateResourceIdentifier"/>:</para>
+        ///   <example>
+        ///     <code>
+        ///       ResourceIdentifier cosmosDbAccountResourceId =
+        ///           CosmosDBAccountResource.CreateResourceIdentifier("&lt;subscription-id&gt;", "&lt;resource-group&gt;", "&lt;account-name&gt;");
+        ///     </code>
+        ///   </example>
+        /// </param>
+        /// <param name="credential">The credential implementation to authenticate with the Azure Cosmos DB resource.</param>
+        /// <param name="databaseName">The name of the existing NoSQL database in the Azure Cosmos DB resource.</param>
+        /// <param name="containerName">The name of the NoSQL container to be created within the Azure Cosmos DB resource.</param>
+        /// <param name="partitionKeyPath">The path to the partition key of the NoSQL item which describes how the items should be partitioned.</param>
+        /// <param name="logger">The logger instance to write diagnostic information during the lifetime of the NoSQL container.</param>
+        /// <param name="configureOptions">The additional options to manipulate the behavior of the test fixture.</param>
+        /// <param name="cancellationToken">The optional token to propagate notifications that the operation should be cancelled.</param>
         /// <exception cref="ArgumentNullException">
         ///     Thrown when the <paramref name="cosmosDbAccountResourceId"/> or the <paramref name="credential"/> is <c>null</c>.
         /// </exception>
@@ -526,8 +697,10 @@ namespace Arcus.Testing
             string containerName,
             string partitionKeyPath,
             ILogger logger,
-            Action<TemporaryNoSqlContainerOptions> configureOptions)
+            Action<TemporaryNoSqlContainerOptions> configureOptions,
+            CancellationToken cancellationToken)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             ArgumentNullException.ThrowIfNull(cosmosDbAccountResourceId);
             ArgumentNullException.ThrowIfNull(credential);
             ArgumentException.ThrowIfNullOrWhiteSpace(databaseName);
@@ -538,18 +711,18 @@ namespace Arcus.Testing
             var options = new TemporaryNoSqlContainerOptions();
             configureOptions?.Invoke(options);
 
-            CosmosDBAccountResource cosmosDb = await GetCosmosDbResourceAsync(cosmosDbAccountResourceId, credential).ConfigureAwait(false);
-            CosmosDBSqlDatabaseResource database = await cosmosDb.GetCosmosDBSqlDatabaseAsync(databaseName).ConfigureAwait(false);
+            CosmosDBAccountResource cosmosDb = await GetCosmosDbResourceAsync(cosmosDbAccountResourceId, credential, cancellationToken).ConfigureAwait(false);
+            CosmosDBSqlDatabaseResource database = await cosmosDb.GetCosmosDBSqlDatabaseAsync(databaseName, cancellationToken).ConfigureAwait(false);
 
             var cosmosClient = new CosmosClient(cosmosDb.Data.DocumentEndpoint, credential);
             Container containerClient = cosmosClient.GetContainer(databaseName, containerName);
 
-            if (await database.GetCosmosDBSqlContainers().ExistsAsync(containerName).ConfigureAwait(false))
+            if (await database.GetCosmosDBSqlContainers().ExistsAsync(containerName, cancellationToken).ConfigureAwait(false))
             {
                 logger.LogSetupUseExistingContainer(containerName, databaseName);
-                await CleanContainerOnSetupAsync(containerClient, options, logger).ConfigureAwait(false);
+                await CleanContainerOnSetupAsync(containerClient, options, logger, cancellationToken).ConfigureAwait(false);
 
-                CosmosDBSqlContainerResource container = await database.GetCosmosDBSqlContainerAsync(containerName).ConfigureAwait(false);
+                CosmosDBSqlContainerResource container = await database.GetCosmosDBSqlContainerAsync(containerName, cancellationToken).ConfigureAwait(false);
                 return new TemporaryNoSqlContainer(cosmosClient, containerClient, container, createdByUs: false, options, logger);
             }
             else
@@ -557,7 +730,7 @@ namespace Arcus.Testing
                 logger.LogSetupCreateNewContainer(containerName, databaseName);
 
                 var properties = new ContainerProperties(containerName, partitionKeyPath);
-                CosmosDBSqlContainerResource container = await CreateNewNoSqlContainerAsync(cosmosDb, database, properties).ConfigureAwait(false);
+                CosmosDBSqlContainerResource container = await CreateNewNoSqlContainerAsync(cosmosDb, database, properties, cancellationToken).ConfigureAwait(false);
 
                 return new TemporaryNoSqlContainer(cosmosClient, containerClient, container, createdByUs: true, options, logger);
             }
@@ -566,8 +739,11 @@ namespace Arcus.Testing
         private static async Task<CosmosDBSqlContainerResource> CreateNewNoSqlContainerAsync(
             CosmosDBAccountResource cosmosDb,
             CosmosDBSqlDatabaseResource database,
-            ContainerProperties properties)
+            ContainerProperties properties,
+            CancellationToken cancellationToken)
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             var partitionKey = new CosmosDBContainerPartitionKey();
             foreach (string path in properties.PartitionKeyPaths)
             {
@@ -580,22 +756,28 @@ namespace Arcus.Testing
             };
             var request = new CosmosDBSqlContainerCreateOrUpdateContent(cosmosDb.Data.Location, newContainer);
             await database.GetCosmosDBSqlContainers()
-                          .CreateOrUpdateAsync(WaitUntil.Completed, properties.Id, request)
+                          .CreateOrUpdateAsync(WaitUntil.Completed, properties.Id, request, cancellationToken)
                           .ConfigureAwait(false);
 
-            return await database.GetCosmosDBSqlContainerAsync(properties.Id).ConfigureAwait(false);
+            return await database.GetCosmosDBSqlContainerAsync(properties.Id, cancellationToken).ConfigureAwait(false);
         }
 
-        private static Task<Azure.Response<CosmosDBAccountResource>> GetCosmosDbResourceAsync(ResourceIdentifier cosmosDbAccountResourceId, TokenCredential credential)
+        private static Task<Azure.Response<CosmosDBAccountResource>> GetCosmosDbResourceAsync(
+            ResourceIdentifier cosmosDbAccountResourceId,
+            TokenCredential credential,
+            CancellationToken cancellationToken)
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             var arm = new ArmClient(credential);
             CosmosDBAccountResource cosmosDb = arm.GetCosmosDBAccountResource(cosmosDbAccountResourceId);
 
-            return cosmosDb.GetAsync();
+            return cosmosDb.GetAsync(cancellationToken);
         }
 
-        private static Task CleanContainerOnSetupAsync(Container container, TemporaryNoSqlContainerOptions options, ILogger logger)
+        private static Task CleanContainerOnSetupAsync(Container container, TemporaryNoSqlContainerOptions options, ILogger logger, CancellationToken cancellationToken)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             if (options.OnSetup.Items is OnSetupNoSqlContainer.LeaveExisted)
             {
                 return Task.CompletedTask;
@@ -603,10 +785,11 @@ namespace Arcus.Testing
 
             if (options.OnSetup.Items is OnSetupNoSqlContainer.CleanIfExisted)
             {
-                return ForEachItemAsync(container, async (id, partitionKey, _) =>
+                return ForEachItemAsync(container, async (id, partitionKey, _, token) =>
                 {
+                    token.ThrowIfCancellationRequested();
                     logger.LogSetupDeleteItem(id, partitionKey, container.Database.Id, container.Id);
-                    using ResponseMessage response = await container.DeleteItemStreamAsync(id, partitionKey).ConfigureAwait(false);
+                    using ResponseMessage response = await container.DeleteItemStreamAsync(id, partitionKey, cancellationToken: token).ConfigureAwait(false);
 
                     if (!response.IsSuccessStatusCode && response.StatusCode != HttpStatusCode.NotFound)
                     {
@@ -614,17 +797,19 @@ namespace Arcus.Testing
                             $"[Test:Setup] Failed to delete NoSQL item '{id}' {partitionKey} in Azure Cosmos DB for NoSQL container '{container.Database.Id}/{container.Id}' " +
                             $"since the delete operation responded with a failure: {(int) response.StatusCode} {response.StatusCode}: {response.ErrorMessage}");
                     }
-                });
+
+                }, cancellationToken);
             }
 
             if (options.OnSetup.Items is OnSetupNoSqlContainer.CleanIfMatched)
             {
-                return ForEachItemAsync(container, async (id, partitionKey, doc) =>
+                return ForEachItemAsync(container, async (id, partitionKey, doc, token) =>
                 {
+                    token.ThrowIfCancellationRequested();
                     if (options.OnSetup.IsMatched(id, partitionKey, doc, container.Database.Client))
                     {
                         logger.LogSetupDeleteMatchedItem(id, partitionKey, container.Database.Id, container.Id);
-                        using ResponseMessage response = await container.DeleteItemStreamAsync(id, partitionKey).ConfigureAwait(false);
+                        using ResponseMessage response = await container.DeleteItemStreamAsync(id, partitionKey, cancellationToken: token).ConfigureAwait(false);
 
                         if (!response.IsSuccessStatusCode && response.StatusCode != HttpStatusCode.NotFound)
                         {
@@ -633,7 +818,8 @@ namespace Arcus.Testing
                                 $"since the delete operation responded with a failure: {(int) response.StatusCode} {response.StatusCode}: {response.ErrorMessage}");
                         }
                     }
-                });
+
+                }, cancellationToken);
             }
 
             return Task.CompletedTask;
@@ -645,11 +831,8 @@ namespace Arcus.Testing
         /// <typeparam name="T">The custom NoSQL model.</typeparam>
         /// <param name="item">The item to create in the NoSQL container.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="item"/> is <c>null</c>.</exception>
-        [Obsolete("Will be removed in v3, please use the " + nameof(UpsertItemAsync) + "instead that provides exactly the same functionality", DiagnosticId = ObsoleteDefaults.DiagnosticId)]
-        public Task AddItemAsync<T>(T item)
-        {
-            return UpsertItemAsync(item);
-        }
+        [Obsolete("Will be removed in v3.0, please use the " + nameof(UpsertItemAsync) + "instead that provides exactly the same functionality", DiagnosticId = ObsoleteDefaults.DiagnosticId)]
+        public Task AddItemAsync<T>(T item) => UpsertItemAsync(item);
 
         /// <summary>
         /// Adds a new or replaces an existing NoSQL item in the Azure Cosmos DB for NoSQL container (a.k.a. UPSERT).
@@ -661,11 +844,27 @@ namespace Arcus.Testing
         /// <param name="item">The item to create in the Azure Cosmos DB for NoSQL container.</param>
         /// <exception cref="ObjectDisposedException">Thrown when the test fixture was already teared down.</exception>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="item"/> is <c>null</c>.</exception>
-        public async Task UpsertItemAsync<TItem>(TItem item)
+        [Obsolete("Will be removed in v3.0, please use the " + nameof(UpsertItemAsync) + " overload instead with cancellation token support")]
+        public Task UpsertItemAsync<TItem>(TItem item) => UpsertItemAsync(item, CancellationToken.None);
+
+        /// <summary>
+        /// Adds a new or replaces an existing NoSQL item in the Azure Cosmos DB for NoSQL container (a.k.a. UPSERT).
+        /// </summary>
+        /// <remarks>
+        ///     ⚡ Any items upserted via this call will always be deleted (if new) or reverted (if existing)
+        ///     when the <see cref="TemporaryNoSqlContainer"/> is disposed.
+        /// </remarks>
+        /// <param name="item">The item to create in the Azure Cosmos DB for NoSQL container.</param>
+        /// <param name="cancellationToken">The optional token to propagate notifications that the operation should be cancelled.</param>
+        /// <exception cref="ObjectDisposedException">Thrown when the test fixture was already teared down.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="item"/> is <c>null</c>.</exception>
+        public async Task UpsertItemAsync<TItem>(TItem item, CancellationToken cancellationToken)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             ObjectDisposedException.ThrowIf(_disposables.IsDisposed, this);
             ArgumentNullException.ThrowIfNull(item);
-            _items.Add(await TemporaryNoSqlItem.UpsertItemAsync(_containerClient, item, _logger).ConfigureAwait(false));
+
+            _items.Add(await TemporaryNoSqlItem.UpsertItemAsync(_containerClient, item, _logger, cancellationToken).ConfigureAwait(false));
         }
 
         /// <summary>
@@ -709,7 +908,7 @@ namespace Arcus.Testing
                 return;
             }
 
-            await ForEachItemAsync((id, partitionKey, doc) =>
+            await ForEachItemAsync((id, partitionKey, doc, _) =>
             {
                 disposables.Add(AsyncDisposable.Create(async () =>
                 {
@@ -733,7 +932,7 @@ namespace Arcus.Testing
 
                 return Task.CompletedTask;
 
-            }).ConfigureAwait(false);
+            }, CancellationToken.None).ConfigureAwait(false);
         }
 
         private async Task DeleteItemAsync(string id, PartitionKey partitionKey)
@@ -748,26 +947,30 @@ namespace Arcus.Testing
             }
         }
 
-        private Task ForEachItemAsync(Func<string, PartitionKey, JsonObject, Task> deleteItemAsync)
+        private Task ForEachItemAsync(Func<string, PartitionKey, JsonObject, CancellationToken, Task> deleteItemAsync, CancellationToken cancellationToken)
         {
-            return ForEachItemAsync(_containerClient, deleteItemAsync);
+            return ForEachItemAsync(_containerClient, deleteItemAsync, cancellationToken);
         }
 
-        private static async Task ForEachItemAsync(Container container, Func<string, PartitionKey, JsonObject, Task> deleteItemAsync)
+        private static async Task ForEachItemAsync(
+            Container container,
+            Func<string, PartitionKey, JsonObject, CancellationToken, Task> deleteItemAsync,
+            CancellationToken cancellationToken)
         {
-            ContainerResponse resp = await container.ReadContainerAsync().ConfigureAwait(false);
+            cancellationToken.ThrowIfCancellationRequested();
+            ContainerResponse resp = await container.ReadContainerAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
             ContainerProperties properties = resp.Resource;
 
             using FeedIterator iterator = container.GetItemQueryStreamIterator();
             while (iterator.HasMoreResults)
             {
-                using ResponseMessage message = await iterator.ReadNextAsync().ConfigureAwait(false);
+                using ResponseMessage message = await iterator.ReadNextAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
                 if (!message.IsSuccessStatusCode)
                 {
                     continue;
                 }
 
-                JsonNode json = await JsonNode.ParseAsync(message.Content, DeserializeOptions).ConfigureAwait(false);
+                JsonNode json = await JsonNode.ParseAsync(message.Content, DeserializeOptions, cancellationToken: cancellationToken).ConfigureAwait(false);
 
                 if (json is not JsonObject root
                     || !root.TryGetPropertyValue("Documents", out JsonNode docs)
@@ -785,7 +988,7 @@ namespace Arcus.Testing
                     }
 
                     PartitionKey partitionKey = ExtractPartitionKeyFromItem(doc, properties);
-                    await deleteItemAsync(id, partitionKey, doc).ConfigureAwait(false);
+                    await deleteItemAsync(id, partitionKey, doc, cancellationToken).ConfigureAwait(false);
                 }
             }
         }

--- a/src/Arcus.Testing.Storage.Cosmos/TemporaryNoSqlContainer.cs
+++ b/src/Arcus.Testing.Storage.Cosmos/TemporaryNoSqlContainer.cs
@@ -189,7 +189,7 @@ namespace Arcus.Testing
 
         /// <summary>
         /// (default for cleaning items) Configures the <see cref="TemporaryNoSqlContainer"/> to only delete or revert the NoSQL items
-        /// in an Azure Cosmos DB for NoSQL container upon disposal if the item was upserted by the test fixture (using <see cref="TemporaryNoSqlContainer.UpsertItemAsync{TItem}"/>).
+        /// in an Azure Cosmos DB for NoSQL container upon disposal if the item was upserted by the test fixture (using <see cref="TemporaryNoSqlContainer.UpsertItemAsync{TItem}(TItem,CancellationToken)"/>).
         /// </summary>
         public OnTeardownNoSqlContainerOptions CleanUpsertedItems()
         {

--- a/src/Arcus.Testing.Storage.Cosmos/TemporaryNoSqlItem.cs
+++ b/src/Arcus.Testing.Storage.Cosmos/TemporaryNoSqlItem.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Net;
 using System.Text.Json;
 using System.Text.Json.Nodes;
+using System.Threading;
 using System.Threading.Tasks;
 using Azure;
 using Microsoft.Azure.Cosmos;
@@ -81,8 +82,26 @@ namespace Arcus.Testing
         /// <param name="item">The item to temporary create in the NoSQL container.</param>
         /// <param name="logger">The logger instance to write diagnostic information during the lifetime of the test fixture.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="container"/> is <c>null</c>.</exception>
-        public static async Task<TemporaryNoSqlItem> UpsertItemAsync<TItem>(Container container, TItem item, ILogger logger)
+        [Obsolete("Will be removed in v3.0, please use the " + nameof(UpsertItemAsync) + " overload with cancellation token support", DiagnosticId = ObsoleteDefaults.DiagnosticId)]
+        public static Task<TemporaryNoSqlItem> UpsertItemAsync<TItem>(Container container, TItem item, ILogger logger)
         {
+            return UpsertItemAsync(container, item, logger, CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Creates a new or replaces an existing NoSQL item in an Azure Cosmos DB for NoSQL container.
+        /// </summary>
+        /// <remarks>
+        ///     ⚡ Item will be deleted (if new) or reverted (if existing) when the <see cref="TemporaryNoSqlItem"/> is disposed.
+        /// </remarks>
+        /// <param name="container">The NoSQL container where a temporary item should be created.</param>
+        /// <param name="item">The item to temporary create in the NoSQL container.</param>
+        /// <param name="logger">The logger instance to write diagnostic information during the lifetime of the test fixture.</param>
+        /// <param name="cancellationToken">The optional token to propagate notifications that the operation should be cancelled.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="container"/> is <c>null</c>.</exception>
+        public static async Task<TemporaryNoSqlItem> UpsertItemAsync<TItem>(Container container, TItem item, ILogger logger, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
             ArgumentNullException.ThrowIfNull(container);
             logger ??= NullLogger.Instance;
             Type itemType = typeof(TItem);
@@ -90,17 +109,17 @@ namespace Arcus.Testing
             JsonNode json = JsonSerializer.SerializeToNode(item, SerializeToNodeOptions);
             string itemId = ExtractIdFromItem(json, itemType);
 
-            ContainerResponse resp = await container.ReadContainerAsync().ConfigureAwait(false);
+            ContainerResponse resp = await container.ReadContainerAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
             PartitionKey partitionKey = ExtractPartitionKeyFromItem(json, resp.Resource);
 
             try
             {
-                Stream originalItemStream = await ReplaceExistingItemOnSetupAsync(container, itemType, itemId, partitionKey, item, logger).ConfigureAwait(false);
+                Stream originalItemStream = await ReplaceExistingItemOnSetupAsync(container, itemType, itemId, partitionKey, item, logger, cancellationToken).ConfigureAwait(false);
                 return new TemporaryNoSqlItem(container, itemId, partitionKey, itemType, createdByUs: false, originalItemStream, logger);
             }
             catch (CosmosException exception) when (exception.StatusCode is HttpStatusCode.NotFound)
             {
-                await InsertNewItemOnSetupAsync(container, itemType, itemId, item, logger).ConfigureAwait(false);
+                await InsertNewItemOnSetupAsync(container, itemType, itemId, item, logger, cancellationToken).ConfigureAwait(false);
                 return new TemporaryNoSqlItem(container, itemId, partitionKey, itemType, createdByUs: true, originalItemStream: null, logger);
             }
         }
@@ -111,10 +130,13 @@ namespace Arcus.Testing
             string itemId,
             PartitionKey partitionKey,
             TItem item,
-            ILogger logger)
+            ILogger logger,
+            CancellationToken cancellationToken)
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             logger.LogBeforeSetupReplaceItem(itemType.Name, itemId, container.Database.Id, container.Id);
-            ItemResponse<TItem> response = await container.ReadItemAsync<TItem>(itemId, partitionKey).ConfigureAwait(false);
+            ItemResponse<TItem> response = await container.ReadItemAsync<TItem>(itemId, partitionKey, cancellationToken: cancellationToken).ConfigureAwait(false);
 
             CosmosSerializer serializer = container.Database.Client.ClientOptions.Serializer;
             if (serializer is null)
@@ -127,15 +149,17 @@ namespace Arcus.Testing
             var originalItemStream = serializer.ToStream(original);
 
             logger.LogSetupReplaceItem(itemType.Name, itemId, container.Database.Id, container.Id);
-            await container.ReplaceItemAsync(item, itemId, partitionKey).ConfigureAwait(false);
+            await container.ReplaceItemAsync(item, itemId, partitionKey, cancellationToken: cancellationToken).ConfigureAwait(false);
 
             return originalItemStream;
         }
 
-        private static async Task InsertNewItemOnSetupAsync<TItem>(Container container, Type itemType, string itemId, TItem item, ILogger logger)
+        private static async Task InsertNewItemOnSetupAsync<TItem>(Container container, Type itemType, string itemId, TItem item, ILogger logger, CancellationToken cancellationToken)
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             logger.LogSetupInsertNewItem(itemType.Name, itemId, container.Database.Id, container.Id);
-            ItemResponse<TItem> response = await container.CreateItemAsync(item).ConfigureAwait(false);
+            ItemResponse<TItem> response = await container.CreateItemAsync(item, cancellationToken: cancellationToken).ConfigureAwait(false);
 
             if (response.StatusCode != HttpStatusCode.Created)
             {

--- a/src/Arcus.Testing.Tests.Integration/Storage/Fixture/MongoDbTestContext.cs
+++ b/src/Arcus.Testing.Tests.Integration/Storage/Fixture/MongoDbTestContext.cs
@@ -114,8 +114,9 @@ namespace Arcus.Testing.Tests.Integration.Storage.Fixture
             _logger.LogTrace("[Test] create MongoDb collection '{CollectionName}' outside the fixture's scope", collectionName);
 
             await WhenMongoDbAvailableAsync(
-                () => Database.CreateCollectionAsync(collectionName, cancellationToken: _cancellationToken),
-                $"[Test] cannot create MongoDb collection '{collectionName}' outside the fixture's scope, due to a high-rate failure");
+                cancellationToken => Database.CreateCollectionAsync(collectionName, cancellationToken: cancellationToken),
+                $"[Test] cannot create MongoDb collection '{collectionName}' outside the fixture's scope, due to a high-rate failure",
+                _cancellationToken);
 
             return collectionName;
         }
@@ -125,14 +126,18 @@ namespace Arcus.Testing.Tests.Integration.Storage.Fixture
         /// </summary>
         /// <param name="mongoDbOperationAsync">The operation to run against a MongoDb database.</param>
         /// <param name="errorMessage">The custom user message that describes the <paramref name="mongoDbOperationAsync"/>.</param>
-        internal static async Task WhenMongoDbAvailableAsync(Func<CancellationToken, Task> mongoDbOperationAsync, string errorMessage)
+        /// <param name="cancellationToken">The optional token to propagate notifications that the operation should be cancelled.</param>
+        internal static async Task WhenMongoDbAvailableAsync(
+            Func<CancellationToken, Task> mongoDbOperationAsync,
+            string errorMessage,
+            CancellationToken cancellationToken)
         {
-            await WhenMongoDbAvailableAsync(async cancellationToken =>
+            await WhenMongoDbAvailableAsync(async token =>
             {
-                await mongoDbOperationAsync(cancellationToken);
+                await mongoDbOperationAsync(token);
                 return 0;
 
-            }, errorMessage);
+            }, errorMessage, cancellationToken);
         }
 
         /// <summary>
@@ -140,9 +145,14 @@ namespace Arcus.Testing.Tests.Integration.Storage.Fixture
         /// </summary>
         /// <param name="mongoDbOperationAsync">The operation to run against a MongoDb database.</param>
         /// <param name="errorMessage">The custom user message that describes the <paramref name="mongoDbOperationAsync"/>.</param>
-        internal static async Task<TResult> WhenMongoDbAvailableAsync<TResult>(Func<CancellationToken, Task<TResult>> mongoDbOperationAsync, string errorMessage)
+        /// <param name="cancellationToken">The optional token to propagate notifications that the operation should be cancelled.</param>
+        internal static async Task<TResult> WhenMongoDbAvailableAsync<TResult>(
+            Func<CancellationToken, Task<TResult>> mongoDbOperationAsync,
+            string errorMessage,
+            CancellationToken cancellationToken)
         {
-            return await Poll.Target<TResult, MongoCommandException>(() => mongoDbOperationAsync(TestContext.Current.CancellationToken))
+            cancellationToken.ThrowIfCancellationRequested();
+            return await Poll.Target<TResult, MongoCommandException>(() => mongoDbOperationAsync(cancellationToken))
                              .When(ex => ex.Message.Contains("high rate") || ex.ErrorMessage.Contains("high rate"))
                              .Every(TimeSpan.FromMilliseconds(500))
                              .FailWith(errorMessage);

--- a/src/Arcus.Testing.Tests.Integration/Storage/Fixture/MongoDbTestContext.cs
+++ b/src/Arcus.Testing.Tests.Integration/Storage/Fixture/MongoDbTestContext.cs
@@ -4,6 +4,7 @@ using System.Collections.ObjectModel;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text.Json;
+using System.Threading;
 using System.Threading.Tasks;
 using Arcus.Testing.Tests.Integration.Configuration;
 using Azure.Core;
@@ -24,6 +25,7 @@ namespace Arcus.Testing.Tests.Integration.Storage.Fixture
     {
         private readonly Collection<string> _collectionNames = new();
         private readonly ILogger _logger;
+        private readonly CancellationToken _cancellationToken;
 
         private static readonly Faker Bogus = new();
         private static readonly HttpClient HttpClient = new();
@@ -33,9 +35,11 @@ namespace Arcus.Testing.Tests.Integration.Storage.Fixture
         /// </summary>
         private MongoDbTestContext(
             IMongoDatabase database,
-            ILogger logger)
+            ILogger logger,
+            CancellationToken cancellationToken)
         {
             _logger = logger;
+            _cancellationToken = cancellationToken;
             Database = database;
         }
 
@@ -49,17 +53,17 @@ namespace Arcus.Testing.Tests.Integration.Storage.Fixture
         /// </summary>
         public static async Task<MongoDbTestContext> GivenAsync(TestConfig config, ILogger logger)
         {
-            MongoClient mongoDbClient = await AuthenticateMongoDbClientAsync(config);
+            MongoClient mongoDbClient = await AuthenticateMongoDbClientAsync(config, TestContext.Current.CancellationToken);
             IMongoDatabase database = mongoDbClient.GetDatabase(config["Arcus:Cosmos:MongoDb:DatabaseName"]);
 
-            return new MongoDbTestContext(database, logger);
+            return new MongoDbTestContext(database, logger, TestContext.Current.CancellationToken);
         }
 
-        private static async Task<MongoClient> AuthenticateMongoDbClientAsync(TestConfig config)
+        private static async Task<MongoClient> AuthenticateMongoDbClientAsync(TestConfig config, CancellationToken cancellationToken)
         {
             const string scope = "https://management.azure.com/.default";
             var tokenProvider = new DefaultAzureCredential();
-            AccessToken accessToken = await tokenProvider.GetTokenAsync(new TokenRequestContext(scopes: new[] { scope }));
+            AccessToken accessToken = await tokenProvider.GetTokenAsync(new TokenRequestContext(scopes: new[] { scope }), cancellationToken);
 
             AzureEnvironment env = config.GetAzureEnvironment();
             string subscriptionId = env.SubscriptionId;
@@ -71,8 +75,8 @@ namespace Arcus.Testing.Tests.Integration.Storage.Fixture
             using var request = new HttpRequestMessage(HttpMethod.Post, listConnectionStringUrl);
             request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken.Token);
 
-            using HttpResponseMessage response = await HttpClient.SendAsync(request);
-            string responseBody = await response.Content.ReadAsStringAsync();
+            using HttpResponseMessage response = await HttpClient.SendAsync(request, cancellationToken);
+            string responseBody = await response.Content.ReadAsStringAsync(cancellationToken);
             var connectionStringDic = JsonSerializer.Deserialize<Dictionary<string, List<Dictionary<string, string>>>>(responseBody);
 
             Assert.NotNull(connectionStringDic);
@@ -104,11 +108,13 @@ namespace Arcus.Testing.Tests.Integration.Storage.Fixture
         /// </summary>
         public async Task<string> WhenCollectionNameAvailableAsync()
         {
+            _cancellationToken.ThrowIfCancellationRequested();
+
             string collectionName = WhenCollectionNameUnavailable();
             _logger.LogTrace("[Test] create MongoDb collection '{CollectionName}' outside the fixture's scope", collectionName);
 
             await WhenMongoDbAvailableAsync(
-                () => Database.CreateCollectionAsync(collectionName),
+                () => Database.CreateCollectionAsync(collectionName, cancellationToken: _cancellationToken),
                 $"[Test] cannot create MongoDb collection '{collectionName}' outside the fixture's scope, due to a high-rate failure");
 
             return collectionName;
@@ -119,11 +125,11 @@ namespace Arcus.Testing.Tests.Integration.Storage.Fixture
         /// </summary>
         /// <param name="mongoDbOperationAsync">The operation to run against a MongoDb database.</param>
         /// <param name="errorMessage">The custom user message that describes the <paramref name="mongoDbOperationAsync"/>.</param>
-        internal static async Task WhenMongoDbAvailableAsync(Func<Task> mongoDbOperationAsync, string errorMessage)
+        internal static async Task WhenMongoDbAvailableAsync(Func<CancellationToken, Task> mongoDbOperationAsync, string errorMessage)
         {
-            await WhenMongoDbAvailableAsync(async () =>
+            await WhenMongoDbAvailableAsync(async cancellationToken =>
             {
-                await mongoDbOperationAsync();
+                await mongoDbOperationAsync(cancellationToken);
                 return 0;
 
             }, errorMessage);
@@ -134,9 +140,9 @@ namespace Arcus.Testing.Tests.Integration.Storage.Fixture
         /// </summary>
         /// <param name="mongoDbOperationAsync">The operation to run against a MongoDb database.</param>
         /// <param name="errorMessage">The custom user message that describes the <paramref name="mongoDbOperationAsync"/>.</param>
-        internal static async Task<TResult> WhenMongoDbAvailableAsync<TResult>(Func<Task<TResult>> mongoDbOperationAsync, string errorMessage)
+        internal static async Task<TResult> WhenMongoDbAvailableAsync<TResult>(Func<CancellationToken, Task<TResult>> mongoDbOperationAsync, string errorMessage)
         {
-            return await Poll.Target<TResult, MongoCommandException>(mongoDbOperationAsync)
+            return await Poll.Target<TResult, MongoCommandException>(() => mongoDbOperationAsync(TestContext.Current.CancellationToken))
                              .When(ex => ex.Message.Contains("high rate") || ex.ErrorMessage.Contains("high rate"))
                              .Every(TimeSpan.FromMilliseconds(500))
                              .FailWith(errorMessage);
@@ -148,7 +154,7 @@ namespace Arcus.Testing.Tests.Integration.Storage.Fixture
         public async Task WhenCollectionDeletedAsync(string collectionName)
         {
             _logger.LogTrace("[Test] delete MongoDb collection '{CollectionName}' outside test fixture's scope", collectionName);
-            await Database.DropCollectionAsync(collectionName);
+            await Database.DropCollectionAsync(collectionName, _cancellationToken);
         }
 
         /// <summary>
@@ -156,6 +162,7 @@ namespace Arcus.Testing.Tests.Integration.Storage.Fixture
         /// </summary>
         public async Task<BsonValue> WhenDocumentAvailableAsync<T>(string collectionName, T document)
         {
+            _cancellationToken.ThrowIfCancellationRequested();
             IMongoCollection<BsonDocument> collection = Database.GetCollection<BsonDocument>(collectionName);
 
             var bson = document.ToBsonDocument();
@@ -168,7 +175,7 @@ namespace Arcus.Testing.Tests.Integration.Storage.Fixture
             bson[elementName] = id;
 
             _logger.LogTrace("[Test] add '{DocType}' item '{DocId}' to MongoDb collection '{CollectionName}'", typeof(T).Name, id, collectionName);
-            await collection.InsertOneAsync(bson);
+            await collection.InsertOneAsync(bson, cancellationToken: _cancellationToken);
 
             return id;
         }
@@ -178,12 +185,13 @@ namespace Arcus.Testing.Tests.Integration.Storage.Fixture
         /// </summary>
         public async Task WhenDocumentDeletedAsync<T>(string collectionName, BsonValue id)
         {
+            _cancellationToken.ThrowIfCancellationRequested();
             _logger.LogTrace("[Test] delete MongoDb document '{DocId}' in collection '{CollectionName}' outside test fixture's scope", id, collectionName);
 
             IMongoCollection<T> collection = Database.GetCollection<T>(collectionName);
             FilterDefinition<T> filter = CreateIdFilter<T>(id);
 
-            await collection.DeleteOneAsync(filter);
+            await collection.DeleteOneAsync(filter, _cancellationToken);
         }
 
         /// <summary>
@@ -191,6 +199,7 @@ namespace Arcus.Testing.Tests.Integration.Storage.Fixture
         /// </summary>
         public async Task ShouldStoreCollectionAsync(string collectionName)
         {
+            _cancellationToken.ThrowIfCancellationRequested();
             Assert.True(
                 await StoresCollectionNameAsync(collectionName),
                 $"temporary mongo db collection '{collectionName}' should be available");
@@ -201,6 +210,7 @@ namespace Arcus.Testing.Tests.Integration.Storage.Fixture
         /// </summary>
         public async Task ShouldNotStoreCollectionAsync(string collectionName)
         {
+            _cancellationToken.ThrowIfCancellationRequested();
             Assert.False(
                 await StoresCollectionNameAsync(collectionName),
                 $"temporary mongo db collection '{collectionName}' should not be available");
@@ -208,12 +218,13 @@ namespace Arcus.Testing.Tests.Integration.Storage.Fixture
 
         private async Task<bool> StoresCollectionNameAsync(string collectionName)
         {
+            _cancellationToken.ThrowIfCancellationRequested();
             var options = new ListCollectionNamesOptions
             {
                 Filter = Builders<BsonDocument>.Filter.Eq("name", collectionName)
             };
-            using IAsyncCursor<string> collectionNames = await Database.ListCollectionNamesAsync(options);
-            return await collectionNames.AnyAsync();
+            using IAsyncCursor<string> collectionNames = await Database.ListCollectionNamesAsync(options, _cancellationToken);
+            return await collectionNames.AnyAsync(_cancellationToken);
         }
 
         /// <summary>
@@ -221,10 +232,11 @@ namespace Arcus.Testing.Tests.Integration.Storage.Fixture
         /// </summary>
         public async Task ShouldStoreDocumentAsync<T>(string collectionName, BsonValue id, Action<T> assertion = null)
         {
+            _cancellationToken.ThrowIfCancellationRequested();
             IMongoCollection<T> collection = Database.GetCollection<T>(collectionName);
             FilterDefinition<T> filter = CreateIdFilter<T>(id);
 
-            List<T> matchingDocs = await collection.Find(filter).ToListAsync();
+            List<T> matchingDocs = await collection.Find(filter).ToListAsync(_cancellationToken);
             Assert.Single(matchingDocs);
 
             assertion?.Invoke(matchingDocs[0]);
@@ -235,10 +247,11 @@ namespace Arcus.Testing.Tests.Integration.Storage.Fixture
         /// </summary>
         public async Task ShouldNotStoreDocumentAsync<T>(string collectionName, BsonValue id)
         {
+            _cancellationToken.ThrowIfCancellationRequested();
             IMongoCollection<T> collection = Database.GetCollection<T>(collectionName);
             FilterDefinition<T> filter = CreateIdFilter<T>(id);
 
-            List<T> matchingDocs = await collection.Find(filter).ToListAsync();
+            List<T> matchingDocs = await collection.Find(filter).ToListAsync(_cancellationToken);
             Assert.Empty(matchingDocs);
         }
 
@@ -263,7 +276,7 @@ namespace Arcus.Testing.Tests.Integration.Storage.Fixture
             {
                 disposables.Add(AsyncDisposable.Create(async () =>
                 {
-                    await Database.DropCollectionAsync(collectionName);
+                    await Database.DropCollectionAsync(collectionName, CancellationToken.None);
                 }));
             }
         }

--- a/src/Arcus.Testing.Tests.Integration/Storage/Fixture/NoSqlTestContext.cs
+++ b/src/Arcus.Testing.Tests.Integration/Storage/Fixture/NoSqlTestContext.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.ObjectModel;
 using System.Net;
+using System.Threading;
 using System.Threading.Tasks;
 using Azure;
 using Azure.Identity;
@@ -34,18 +35,21 @@ namespace Arcus.Testing.Tests.Integration.Storage.Fixture
         private readonly CosmosDbConfig _config;
         private readonly CosmosClient _client;
         private readonly Collection<string> _containerNames = new();
+        private readonly CancellationToken _cancellationToken;
         private readonly ILogger _logger;
 
         private NoSqlTestContext(
             CosmosClient client,
             Database database,
             CosmosDbConfig config,
-            ILogger logger)
+            ILogger logger,
+            CancellationToken cancellationToken)
         {
             _config = config;
             _client = client;
-            Database = database;
             _logger = logger;
+            _cancellationToken = cancellationToken;
+            Database = database;
         }
 
         /// <summary>
@@ -63,7 +67,7 @@ namespace Arcus.Testing.Tests.Integration.Storage.Fixture
             var client = new CosmosClient(noSql.AccountEndpoint.ToString(), new DefaultAzureCredential());
             Database database = client.GetDatabase(noSql.DatabaseName);
 
-            return new NoSqlTestContext(client, database, noSql, logger);
+            return new NoSqlTestContext(client, database, noSql, logger, TestContext.Current.CancellationToken);
         }
 
         /// <summary>
@@ -82,21 +86,23 @@ namespace Arcus.Testing.Tests.Integration.Storage.Fixture
         /// </summary>
         public async Task<string> WhenContainerNameAvailableAsync(string partitionKeyPath = "/pk")
         {
+            _cancellationToken.ThrowIfCancellationRequested();
+
             string containerName = WhenContainerNameUnavailable();
             _logger.LogTrace("[Test] create NoSql container '{ContainerName}' outside the fixture's scope", containerName);
 
             var arm = new ArmClient(new DefaultAzureCredential());
             CosmosDBAccountResource cosmosDb = arm.GetCosmosDBAccountResource(_config.AccountResourceId);
-            CosmosDBSqlDatabaseResource database = await cosmosDb.GetCosmosDBSqlDatabaseAsync(_config.DatabaseName);
+            CosmosDBSqlDatabaseResource database = await cosmosDb.GetCosmosDBSqlDatabaseAsync(_config.DatabaseName, _cancellationToken);
 
-            CosmosDBAccountResource resource = await cosmosDb.GetAsync();
+            CosmosDBAccountResource resource = await cosmosDb.GetAsync(_cancellationToken);
             var newContainer = new CosmosDBSqlContainerResourceInfo(containerName)
             {
                 PartitionKey = new CosmosDBContainerPartitionKey { Paths = { partitionKeyPath } }
             };
             var request = new CosmosDBSqlContainerCreateOrUpdateContent(resource.Data.Location, newContainer);
             await database.GetCosmosDBSqlContainers()
-                          .CreateOrUpdateAsync(WaitUntil.Completed, containerName, request);
+                          .CreateOrUpdateAsync(WaitUntil.Completed, containerName, request, _cancellationToken);
 
             return containerName;
         }
@@ -110,10 +116,10 @@ namespace Arcus.Testing.Tests.Integration.Storage.Fixture
 
             var arm = new ArmClient(new DefaultAzureCredential());
             CosmosDBAccountResource cosmosDb = arm.GetCosmosDBAccountResource(_config.AccountResourceId);
-            CosmosDBSqlDatabaseResource database = await cosmosDb.GetCosmosDBSqlDatabaseAsync(_config.DatabaseName);
+            CosmosDBSqlDatabaseResource database = await cosmosDb.GetCosmosDBSqlDatabaseAsync(_config.DatabaseName, _cancellationToken);
 
-            CosmosDBSqlContainerResource container = await database.GetCosmosDBSqlContainerAsync(containerName);
-            await container.DeleteAsync(WaitUntil.Completed);
+            CosmosDBSqlContainerResource container = await database.GetCosmosDBSqlContainerAsync(containerName, _cancellationToken);
+            await container.DeleteAsync(WaitUntil.Completed, _cancellationToken);
         }
 
         /// <summary>
@@ -121,11 +127,12 @@ namespace Arcus.Testing.Tests.Integration.Storage.Fixture
         /// </summary>
         public async Task<T> WhenItemAvailableAsync<T>(string containerName, T item) where T : INoSqlItem
         {
+            _cancellationToken.ThrowIfCancellationRequested();
             _logger.LogTrace("[Test] add '{ItemType}' item '{ItemId}' to NoSql container '{ContainerName}'", typeof(T).Name, item.GetId(), containerName);
 
             Container container = Database.GetContainer(containerName);
             await using var stream = _client.ClientOptions.Serializer.ToStream(item);
-            await container.CreateItemStreamAsync(stream, item.GetPartitionKey());
+            await container.CreateItemStreamAsync(stream, item.GetPartitionKey(), cancellationToken: _cancellationToken);
 
             return item;
         }
@@ -135,10 +142,11 @@ namespace Arcus.Testing.Tests.Integration.Storage.Fixture
         /// </summary>
         public async Task WhenItemDeletedAsync<T>(string containerName, T item) where T : INoSqlItem
         {
+            _cancellationToken.ThrowIfCancellationRequested();
             _logger.LogTrace("[Test] delete NoSql item '{ItemId}' in container '{ContainerName}' outside test fixture's scope", item.GetId(), containerName);
 
             Container container = Database.GetContainer(containerName);
-            await container.DeleteItemAsync<T>(item.GetId(), item.GetPartitionKey());
+            await container.DeleteItemAsync<T>(item.GetId(), item.GetPartitionKey(), cancellationToken: _cancellationToken);
         }
 
         /// <summary>
@@ -147,7 +155,7 @@ namespace Arcus.Testing.Tests.Integration.Storage.Fixture
         public async Task ShouldStoreContainerAsync(string containerId)
         {
             Container cont = Database.GetContainer(containerId);
-            ContainerProperties properties = await cont.ReadContainerAsync();
+            ContainerProperties properties = await cont.ReadContainerAsync(cancellationToken: _cancellationToken);
             Assert.NotNull(properties);
         }
 
@@ -157,7 +165,7 @@ namespace Arcus.Testing.Tests.Integration.Storage.Fixture
         public async Task ShouldNotStoreContainerAsync(string containerId)
         {
             Container cont = Database.GetContainer(containerId);
-            var exception = await Assert.ThrowsAnyAsync<CosmosException>(() => cont.ReadContainerAsync());
+            var exception = await Assert.ThrowsAnyAsync<CosmosException>(() => cont.ReadContainerAsync(cancellationToken: _cancellationToken));
             Assert.Equal(HttpStatusCode.NotFound, exception.StatusCode);
         }
 
@@ -166,10 +174,11 @@ namespace Arcus.Testing.Tests.Integration.Storage.Fixture
         /// </summary>
         public async Task ShouldStoreItemAsync<T>(string containerName, T expected, Action<T> assertion = null) where T : INoSqlItem
         {
+            _cancellationToken.ThrowIfCancellationRequested();
             Container container = Database.GetContainer(containerName);
             await Poll.UntilAvailableAsync(async () =>
             {
-                ItemResponse<T> response = await container.ReadItemAsync<T>(expected.GetId(), expected.GetPartitionKey());
+                ItemResponse<T> response = await container.ReadItemAsync<T>(expected.GetId(), expected.GetPartitionKey(), cancellationToken: _cancellationToken);
                 Assert.Equal(HttpStatusCode.OK, response.StatusCode);
                 assertion?.Invoke(response.Resource);
             });
@@ -180,10 +189,11 @@ namespace Arcus.Testing.Tests.Integration.Storage.Fixture
         /// </summary>
         public async Task ShouldNotStoreItemAsync<T>(string containerName, T expected) where T : INoSqlItem
         {
+            _cancellationToken.ThrowIfCancellationRequested();
             Container container = Database.GetContainer(containerName);
             await Poll.UntilAvailableAsync(async () =>
             {
-                using ResponseMessage response = await container.ReadItemStreamAsync(expected.GetId(), expected.GetPartitionKey());
+                using ResponseMessage response = await container.ReadItemStreamAsync(expected.GetId(), expected.GetPartitionKey(), cancellationToken: _cancellationToken);
                 Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
             });
         }
@@ -200,15 +210,15 @@ namespace Arcus.Testing.Tests.Integration.Storage.Fixture
             {
                 var arm = new ArmClient(new DefaultAzureCredential());
                 CosmosDBAccountResource cosmosDb = arm.GetCosmosDBAccountResource(_config.AccountResourceId);
-                CosmosDBSqlDatabaseResource database = await cosmosDb.GetCosmosDBSqlDatabaseAsync(_config.DatabaseName);
+                CosmosDBSqlDatabaseResource database = await cosmosDb.GetCosmosDBSqlDatabaseAsync(_config.DatabaseName, cancellationToken: CancellationToken.None);
 
                 foreach (var containerName in _containerNames)
                 {
                     try
                     {
                         _logger.LogTrace("[Test] delete NoSql container '{ContainerName}'", containerName);
-                        CosmosDBSqlContainerResource container = await database.GetCosmosDBSqlContainerAsync(containerName);
-                        await container.DeleteAsync(WaitUntil.Started);
+                        CosmosDBSqlContainerResource container = await database.GetCosmosDBSqlContainerAsync(containerName, cancellationToken: CancellationToken.None);
+                        await container.DeleteAsync(WaitUntil.Started, cancellationToken: CancellationToken.None);
                     }
                     catch (CosmosException exception) when (exception.StatusCode is HttpStatusCode.NotFound)
                     {

--- a/src/Arcus.Testing.Tests.Integration/Storage/TemporaryMongoDbCollectionTests.cs
+++ b/src/Arcus.Testing.Tests.Integration/Storage/TemporaryMongoDbCollectionTests.cs
@@ -246,7 +246,8 @@ namespace Arcus.Testing.Tests.Integration.Storage
                 Assert.Equal(collectionName, collection.Name);
                 return collection;
 
-            }, $"Cannot create temporary MongoDb fixture collection '{collectionName}', due to a high-rate failure");
+            }, $"Cannot create temporary MongoDb fixture collection '{collectionName}', due to a high-rate failure",
+                TestContext.Current.CancellationToken);
         }
 
         private async Task<MongoDbTestContext> GivenCosmosMongoDbAsync()

--- a/src/Arcus.Testing.Tests.Integration/Storage/TemporaryMongoDbCollectionTests.cs
+++ b/src/Arcus.Testing.Tests.Integration/Storage/TemporaryMongoDbCollectionTests.cs
@@ -49,9 +49,7 @@ namespace Arcus.Testing.Tests.Integration.Storage
 
             TemporaryMongoDbCollection collection = await WhenTempCollectionCreatedAsync(collectionName, context);
             Shipment createdByUs = CreateShipment();
-#pragma warning disable CS0618 // Type or member is obsolete: currently still testing deprecated functionality.
-            await collection.AddDocumentAsync(createdByUs);
-#pragma warning restore CS0618 // Type or member is obsolete
+            await collection.UpsertDocumentAsync(createdByUs, TestContext.Current.CancellationToken);
 
             await context.ShouldStoreCollectionAsync(collectionName);
             await context.ShouldStoreDocumentAsync<Shipment>(collectionName, existingId);
@@ -187,9 +185,7 @@ namespace Arcus.Testing.Tests.Integration.Storage
                 options.OnSetup.CleanMatchingDocuments((Shipment s) => s.BoatName == matchedOnSetup.BoatName);
             });
             collection.OnTeardown.CleanAllDocuments();
-#pragma warning disable CS0618 // Type or member is obsolete: currently still testing deprecated functionality.
-            await collection.AddDocumentAsync(createdByUs);
-#pragma warning restore CS0618 // Type or member is obsolete
+            await collection.UpsertDocumentAsync(createdByUs, TestContext.Current.CancellationToken);
 
             await context.ShouldNotStoreDocumentAsync<Shipment>(collectionName, matchedOnSetupId);
             await context.ShouldStoreDocumentAsync<Shipment>(collectionName, unmatchedOnSetupId);
@@ -237,14 +233,14 @@ namespace Arcus.Testing.Tests.Integration.Storage
 
         private async Task<TemporaryMongoDbCollection> WhenTempCollectionCreatedAsync(string collectionName, MongoDbTestContext context, Action<TemporaryMongoDbCollectionOptions> configureOptions = null)
         {
-            return await MongoDbTestContext.WhenMongoDbAvailableAsync(async () =>
+            return await MongoDbTestContext.WhenMongoDbAvailableAsync(async cancellationToken =>
             {
                 var collection = (Bogus.Random.Bool(), configureOptions is null) switch
                 {
-                    (false, false) => await TemporaryMongoDbCollection.CreateIfNotExistsAsync(MongoDb.AccountResourceId, MongoDb.DatabaseName, collectionName, Logger, configureOptions),
-                    (false, true) => await TemporaryMongoDbCollection.CreateIfNotExistsAsync(MongoDb.AccountResourceId, MongoDb.DatabaseName, collectionName, Logger),
-                    (true, false) => await TemporaryMongoDbCollection.CreateIfNotExistsAsync(context.Database, collectionName, Logger, configureOptions),
-                    (true, true) => await TemporaryMongoDbCollection.CreateIfNotExistsAsync(context.Database, collectionName, Logger)
+                    (false, false) => await TemporaryMongoDbCollection.CreateIfNotExistsAsync(MongoDb.AccountResourceId, MongoDb.DatabaseName, collectionName, Logger, configureOptions, cancellationToken),
+                    (false, true) => await TemporaryMongoDbCollection.CreateIfNotExistsAsync(MongoDb.AccountResourceId, MongoDb.DatabaseName, collectionName, Logger, cancellationToken),
+                    (true, false) => await TemporaryMongoDbCollection.CreateIfNotExistsAsync(context.Database, collectionName, Logger, configureOptions, cancellationToken),
+                    (true, true) => await TemporaryMongoDbCollection.CreateIfNotExistsAsync(context.Database, collectionName, Logger, cancellationToken)
                 };
 
                 Assert.Equal(collectionName, collection.Name);

--- a/src/Arcus.Testing.Tests.Integration/Storage/TemporaryMongoDbDocumentTests.cs
+++ b/src/Arcus.Testing.Tests.Integration/Storage/TemporaryMongoDbDocumentTests.cs
@@ -66,14 +66,13 @@ namespace Arcus.Testing.Tests.Integration.Storage
         private async Task<TemporaryMongoDbDocument> WhenTempDocumentCreatedAsync<TDoc>(string collectionName, TDoc doc)
             where TDoc : class
         {
-#pragma warning disable CS0618 // Type or member is obsolete: currently still testing deprecated functionality.
-            return await TemporaryMongoDbDocument.InsertIfNotExistsAsync(
+            return await TemporaryMongoDbDocument.UpsertDocumentAsync(
                 MongoDb.AccountResourceId,
                 MongoDb.DatabaseName,
                 collectionName,
                 doc,
-                Logger);
-#pragma warning restore CS0618 // Type or member is obsolete
+                Logger,
+                TestContext.Current.CancellationToken);
         }
 
         public class Product

--- a/src/Arcus.Testing.Tests.Integration/Storage/TemporaryNoSqlContainerTests.cs
+++ b/src/Arcus.Testing.Tests.Integration/Storage/TemporaryNoSqlContainerTests.cs
@@ -202,8 +202,8 @@ namespace Arcus.Testing.Tests.Integration.Storage
         {
             var container =
                 configureOptions is null
-                    ? await TemporaryNoSqlContainer.CreateIfNotExistsAsync(NoSql.AccountResourceId, NoSql.DatabaseName, containerName, PartitionKeyPaths.Single(), Logger)
-                    : await TemporaryNoSqlContainer.CreateIfNotExistsAsync(NoSql.AccountResourceId, NoSql.DatabaseName, containerName, PartitionKeyPaths.Single(), Logger, configureOptions);
+                    ? await TemporaryNoSqlContainer.CreateIfNotExistsAsync(NoSql.AccountResourceId, NoSql.DatabaseName, containerName, PartitionKeyPaths.Single(), Logger, TestContext.Current.CancellationToken)
+                    : await TemporaryNoSqlContainer.CreateIfNotExistsAsync(NoSql.AccountResourceId, NoSql.DatabaseName, containerName, PartitionKeyPaths.Single(), Logger, configureOptions, TestContext.Current.CancellationToken);
 
             Assert.Equal(NoSql.DatabaseName, container.Client.Database.Id);
             Assert.Equal(containerName, container.Name);
@@ -214,9 +214,7 @@ namespace Arcus.Testing.Tests.Integration.Storage
         private static async Task<Ship> AddItemAsync(TemporaryNoSqlContainer container)
         {
             Ship item = CreateShip("own");
-#pragma warning disable CS0618 // Type or member is obsolete: currently still testing deprecated functionality.
-            await container.AddItemAsync(item);
-#pragma warning restore CS0618 // Type or member is obsolete
+            await container.UpsertItemAsync(item, TestContext.Current.CancellationToken);
 
             return item;
         }

--- a/src/Arcus.Testing.Tests.Integration/Storage/TemporaryNoSqlItemTests.cs
+++ b/src/Arcus.Testing.Tests.Integration/Storage/TemporaryNoSqlItemTests.cs
@@ -212,13 +212,10 @@ namespace Arcus.Testing.Tests.Integration.Storage
             where T : INoSqlItem
         {
             container ??= context.Database.GetContainer(containerName);
-#pragma warning disable CS0618 // Type or member is obsolete: currently still testing deprecated functionality.
-            var temp = await TemporaryNoSqlItem.InsertIfNotExistsAsync(container, item, Logger);
-#pragma warning restore CS0618 // Type or member is obsolete
+            var temp = await TemporaryNoSqlItem.UpsertItemAsync(container, item, Logger, TestContext.Current.CancellationToken);
 
             Assert.Equal(item.GetId(), temp.Id);
             Assert.Equal(item.GetPartitionKey(), temp.PartitionKey);
-
             return temp;
         }
     }


### PR DESCRIPTION
Add cancellation token support for the Cosmos DB test fixtures.



Relates to #507

