### PR TITLE
chore(deps): higher up the logging abstractions dependency in data factory test fixtures

### DIFF
--- a/src/Arcus.Testing.Integration.DataFactory/Arcus.Testing.Integration.DataFactory.csproj
+++ b/src/Arcus.Testing.Integration.DataFactory/Arcus.Testing.Integration.DataFactory.csproj
@@ -31,7 +31,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="[1.*,2.0.0)" />
     <PackageReference Include="Azure.ResourceManager.DataFactory" Version="[1.*,2.0.0)" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="[8.*,11.0.0)" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="[10.*,11.0.0)" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The newest Azure.Identity package requires a higher logging abstractions package.